### PR TITLE
Validate request input

### DIFF
--- a/build/Generator/ApiGenerator.php
+++ b/build/Generator/ApiGenerator.php
@@ -235,7 +235,7 @@ foreach ([$requiredArray] as \$name) {
     }
 }
 PHP;
-        $class->addMethod('validate')->setPublic()->setReturnType('void')->setBody(empty($requiredArray) ? '' : $validateBody);
+        $class->addMethod('validate')->setPublic()->setReturnType('void')->setBody(empty($requiredProperties) ? '// There are no required properties' : $validateBody);
 
         $this->fileWriter->write($namespace);
     }

--- a/build/Generator/ApiGenerator.php
+++ b/build/Generator/ApiGenerator.php
@@ -163,6 +163,7 @@ PHP
         $constructor->addComment('} $input');
         $constructor->addParameter('input')->setType('array')->setDefaultValue([]);
         $constructorBody = '';
+        $requiredProperties = [];
 
         foreach ($members as $name => $data) {
             $parameterType = $members[$name]['shape'];
@@ -185,6 +186,7 @@ PHP
 
             $property = $class->addProperty($name)->setPrivate();
             if (\in_array($name, $shapes[$className]['required'] ?? [])) {
+                $requiredProperties[] = $name;
                 $property->addComment('@required');
             }
             $property->addComment('@var ' . $parameterType . ($nullable ? '|null' : ''));
@@ -213,6 +215,7 @@ PHP
         }
 
         $constructor->setBody($constructorBody);
+        $class->addConstant('REQUIRED_PARAMETERS', $requiredProperties)->setPublic();
         if ($root) {
             $this->inputClassRequestGetters($inputShape, $class, $operationName);
         }
@@ -369,6 +372,7 @@ PHP;
     {
         $body = <<<PHP
 \$input = $inputClassName::create(\$input); 
+\$this->validate(\$input);
 
 PHP;
 

--- a/build/manifest.json
+++ b/build/manifest.json
@@ -4,39 +4,39 @@
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/s3\/2006-03-01\/api-2.json",
             "methods": {
                 "PutObject": {
-                    "generated": "2020-02-01T14:56:12+00:00",
+                    "generated": "2020-02-01T15:25:59+00:00",
                     "generate-result-trait": false
                 },
                 "CreateBucket": {
-                    "generated": "2020-02-01T14:56:12+00:00",
+                    "generated": "2020-02-01T15:25:59+00:00",
                     "generate-result-trait": false
                 },
                 "DeleteObject": {
-                    "generated": "2020-02-01T14:56:12+00:00",
+                    "generated": "2020-02-01T15:25:59+00:00",
                     "generate-result-trait": false
                 },
                 "HeadObject": {
-                    "generated": "2020-02-01T14:56:12+00:00",
+                    "generated": "2020-02-01T15:25:59+00:00",
                     "generate-result-trait": false
                 },
                 "CopyObject": {
-                    "generated": "2020-02-01T14:56:12+00:00",
+                    "generated": "2020-02-01T15:25:59+00:00",
                     "generate-result-trait": false
                 },
                 "GetObject": {
-                    "generated": "2020-02-01T14:56:12+00:00",
+                    "generated": "2020-02-01T15:25:59+00:00",
                     "generate-result-trait": false
                 },
                 "PutObjectAcl": {
-                    "generated": "2020-02-01T14:56:12+00:00",
+                    "generated": "2020-02-01T15:25:59+00:00",
                     "generate-result-trait": false
                 },
                 "GetObjectAcl": {
-                    "generated": "2020-02-01T14:56:12+00:00",
+                    "generated": "2020-02-01T15:25:59+00:00",
                     "generate-result-trait": false
                 },
                 "ListObjects": {
-                    "generated": "2020-02-01T14:56:12+00:00",
+                    "generated": "2020-02-01T15:25:59+00:00",
                     "generate-result-trait": false
                 }
             }
@@ -48,7 +48,7 @@
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sqs\/2012-11-05\/api-2.json",
             "methods": {
                 "SendMessage": {
-                    "generated": "2020-02-01T14:55:38+00:00",
+                    "generated": "2020-02-01T15:25:56+00:00",
                     "generate-result-trait": true
                 }
             }

--- a/build/manifest.json
+++ b/build/manifest.json
@@ -4,39 +4,39 @@
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/s3\/2006-03-01\/api-2.json",
             "methods": {
                 "PutObject": {
-                    "generated": "2020-02-01T15:54:20+00:00",
+                    "generated": "2020-02-01T16:26:45+00:00",
                     "generate-result-trait": false
                 },
                 "CreateBucket": {
-                    "generated": "2020-02-01T15:54:20+00:00",
+                    "generated": "2020-02-01T16:26:45+00:00",
                     "generate-result-trait": false
                 },
                 "DeleteObject": {
-                    "generated": "2020-02-01T15:54:20+00:00",
+                    "generated": "2020-02-01T16:26:45+00:00",
                     "generate-result-trait": false
                 },
                 "HeadObject": {
-                    "generated": "2020-02-01T15:54:20+00:00",
+                    "generated": "2020-02-01T16:26:45+00:00",
                     "generate-result-trait": false
                 },
                 "CopyObject": {
-                    "generated": "2020-02-01T15:54:20+00:00",
+                    "generated": "2020-02-01T16:26:45+00:00",
                     "generate-result-trait": false
                 },
                 "GetObject": {
-                    "generated": "2020-02-01T15:54:20+00:00",
+                    "generated": "2020-02-01T16:26:45+00:00",
                     "generate-result-trait": false
                 },
                 "PutObjectAcl": {
-                    "generated": "2020-02-01T15:54:20+00:00",
+                    "generated": "2020-02-01T16:26:45+00:00",
                     "generate-result-trait": false
                 },
                 "GetObjectAcl": {
-                    "generated": "2020-02-01T15:54:20+00:00",
+                    "generated": "2020-02-01T16:26:46+00:00",
                     "generate-result-trait": false
                 },
                 "ListObjects": {
-                    "generated": "2020-02-01T15:54:20+00:00",
+                    "generated": "2020-02-01T16:26:46+00:00",
                     "generate-result-trait": false
                 }
             }
@@ -48,7 +48,7 @@
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sqs\/2012-11-05\/api-2.json",
             "methods": {
                 "SendMessage": {
-                    "generated": "2020-02-01T15:54:17+00:00",
+                    "generated": "2020-02-01T16:27:01+00:00",
                     "generate-result-trait": true
                 }
             }

--- a/build/manifest.json
+++ b/build/manifest.json
@@ -4,39 +4,39 @@
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/s3\/2006-03-01\/api-2.json",
             "methods": {
                 "PutObject": {
-                    "generated": "2020-02-01T15:49:11+00:00",
+                    "generated": "2020-02-01T15:54:20+00:00",
                     "generate-result-trait": false
                 },
                 "CreateBucket": {
-                    "generated": "2020-02-01T15:49:11+00:00",
+                    "generated": "2020-02-01T15:54:20+00:00",
                     "generate-result-trait": false
                 },
                 "DeleteObject": {
-                    "generated": "2020-02-01T15:49:11+00:00",
+                    "generated": "2020-02-01T15:54:20+00:00",
                     "generate-result-trait": false
                 },
                 "HeadObject": {
-                    "generated": "2020-02-01T15:49:11+00:00",
+                    "generated": "2020-02-01T15:54:20+00:00",
                     "generate-result-trait": false
                 },
                 "CopyObject": {
-                    "generated": "2020-02-01T15:49:11+00:00",
+                    "generated": "2020-02-01T15:54:20+00:00",
                     "generate-result-trait": false
                 },
                 "GetObject": {
-                    "generated": "2020-02-01T15:49:11+00:00",
+                    "generated": "2020-02-01T15:54:20+00:00",
                     "generate-result-trait": false
                 },
                 "PutObjectAcl": {
-                    "generated": "2020-02-01T15:49:11+00:00",
+                    "generated": "2020-02-01T15:54:20+00:00",
                     "generate-result-trait": false
                 },
                 "GetObjectAcl": {
-                    "generated": "2020-02-01T15:49:11+00:00",
+                    "generated": "2020-02-01T15:54:20+00:00",
                     "generate-result-trait": false
                 },
                 "ListObjects": {
-                    "generated": "2020-02-01T15:49:11+00:00",
+                    "generated": "2020-02-01T15:54:20+00:00",
                     "generate-result-trait": false
                 }
             }
@@ -48,7 +48,7 @@
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sqs\/2012-11-05\/api-2.json",
             "methods": {
                 "SendMessage": {
-                    "generated": "2020-02-01T15:48:59+00:00",
+                    "generated": "2020-02-01T15:54:17+00:00",
                     "generate-result-trait": true
                 }
             }

--- a/build/manifest.json
+++ b/build/manifest.json
@@ -4,39 +4,39 @@
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/s3\/2006-03-01\/api-2.json",
             "methods": {
                 "PutObject": {
-                    "generated": "2020-02-01T15:25:59+00:00",
+                    "generated": "2020-02-01T15:49:11+00:00",
                     "generate-result-trait": false
                 },
                 "CreateBucket": {
-                    "generated": "2020-02-01T15:25:59+00:00",
+                    "generated": "2020-02-01T15:49:11+00:00",
                     "generate-result-trait": false
                 },
                 "DeleteObject": {
-                    "generated": "2020-02-01T15:25:59+00:00",
+                    "generated": "2020-02-01T15:49:11+00:00",
                     "generate-result-trait": false
                 },
                 "HeadObject": {
-                    "generated": "2020-02-01T15:25:59+00:00",
+                    "generated": "2020-02-01T15:49:11+00:00",
                     "generate-result-trait": false
                 },
                 "CopyObject": {
-                    "generated": "2020-02-01T15:25:59+00:00",
+                    "generated": "2020-02-01T15:49:11+00:00",
                     "generate-result-trait": false
                 },
                 "GetObject": {
-                    "generated": "2020-02-01T15:25:59+00:00",
+                    "generated": "2020-02-01T15:49:11+00:00",
                     "generate-result-trait": false
                 },
                 "PutObjectAcl": {
-                    "generated": "2020-02-01T15:25:59+00:00",
+                    "generated": "2020-02-01T15:49:11+00:00",
                     "generate-result-trait": false
                 },
                 "GetObjectAcl": {
-                    "generated": "2020-02-01T15:25:59+00:00",
+                    "generated": "2020-02-01T15:49:11+00:00",
                     "generate-result-trait": false
                 },
                 "ListObjects": {
-                    "generated": "2020-02-01T15:25:59+00:00",
+                    "generated": "2020-02-01T15:49:11+00:00",
                     "generate-result-trait": false
                 }
             }
@@ -48,7 +48,7 @@
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sqs\/2012-11-05\/api-2.json",
             "methods": {
                 "SendMessage": {
-                    "generated": "2020-02-01T15:25:56+00:00",
+                    "generated": "2020-02-01T15:48:59+00:00",
                     "generate-result-trait": true
                 }
             }

--- a/src/Core/AbstractApi.php
+++ b/src/Core/AbstractApi.php
@@ -135,28 +135,4 @@ abstract class AbstractApi
 
         return $endpoint . (false === \strpos($endpoint, '?') ? '?' : '&') . http_build_query($query);
     }
-
-    final protected function validate($input)
-    {
-        $class = \get_class($input);
-        if (!\defined($class . '::REQUIRED_PARAMETERS')) {
-            // There is nothing we can do
-            return;
-        }
-        $requirements = \constant($class . '::REQUIRED_PARAMETERS');
-        if (!\is_array($requirements)) {
-            throw new InvalidArgument(sprintf('Constant "" must be an array.', $class . '::REQUIRED_PARAMETERS'));
-        }
-
-        foreach ($requirements as $name) {
-            $method = 'get' . $name;
-            if (null === $value = \call_user_func([$input, $method])) {
-                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, $class));
-            }
-
-            if (\is_object($value)) {
-                $this->validate($value);
-            }
-        }
-    }
 }

--- a/src/S3/Input/AccessControlPolicy.php
+++ b/src/S3/Input/AccessControlPolicy.php
@@ -2,8 +2,6 @@
 
 namespace AsyncAws\S3\Input;
 
-use AsyncAws\Core\Exception\InvalidArgument;
-
 class AccessControlPolicy
 {
     /**
@@ -61,14 +59,6 @@ class AccessControlPolicy
 
     public function validate(): void
     {
-        foreach ([''] as $name) {
-            if (null === $value = $this->$name) {
-                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
-            }
-
-            if (\is_object($value) && method_exists($value, 'validate')) {
-                $value->validate();
-            }
-        }
+        // There are no required properties
     }
 }

--- a/src/S3/Input/AccessControlPolicy.php
+++ b/src/S3/Input/AccessControlPolicy.php
@@ -4,6 +4,8 @@ namespace AsyncAws\S3\Input;
 
 class AccessControlPolicy
 {
+    public const REQUIRED_PARAMETERS = [];
+
     /**
      * @var Grant[]
      */

--- a/src/S3/Input/AccessControlPolicy.php
+++ b/src/S3/Input/AccessControlPolicy.php
@@ -2,10 +2,10 @@
 
 namespace AsyncAws\S3\Input;
 
+use AsyncAws\Core\Exception\InvalidArgument;
+
 class AccessControlPolicy
 {
-    public const REQUIRED_PARAMETERS = [];
-
     /**
      * @var Grant[]
      */
@@ -57,5 +57,18 @@ class AccessControlPolicy
         $this->Owner = $value;
 
         return $this;
+    }
+
+    public function validate(): void
+    {
+        foreach ([''] as $name) {
+            if (null === $value = $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+
+            if (\is_object($value) && method_exists($value, 'validate')) {
+                $value->validate();
+            }
+        }
     }
 }

--- a/src/S3/Input/AccessControlPolicy.php
+++ b/src/S3/Input/AccessControlPolicy.php
@@ -59,6 +59,11 @@ class AccessControlPolicy
 
     public function validate(): void
     {
-        // There are no required properties
+        foreach ($this->Grants as $item) {
+            $item->validate();
+        }
+        if ($this->Owner) {
+            $this->Owner->validate();
+        }
     }
 }

--- a/src/S3/Input/CopyObjectRequest.php
+++ b/src/S3/Input/CopyObjectRequest.php
@@ -4,6 +4,8 @@ namespace AsyncAws\S3\Input;
 
 class CopyObjectRequest
 {
+    public const REQUIRED_PARAMETERS = ['Bucket', 'CopySource', 'Key'];
+
     /**
      * @var string|null
      */

--- a/src/S3/Input/CopyObjectRequest.php
+++ b/src/S3/Input/CopyObjectRequest.php
@@ -2,10 +2,10 @@
 
 namespace AsyncAws\S3\Input;
 
+use AsyncAws\Core\Exception\InvalidArgument;
+
 class CopyObjectRequest
 {
-    public const REQUIRED_PARAMETERS = ['Bucket', 'CopySource', 'Key'];
-
     /**
      * @var string|null
      */
@@ -860,5 +860,18 @@ class CopyObjectRequest
         $uri['Key'] = $this->Key ?? '';
 
         return "/{$uri['Bucket']}/{$uri['Key']}";
+    }
+
+    public function validate(): void
+    {
+        foreach (['Bucket', 'CopySource', 'Key'] as $name) {
+            if (null === $value = $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+
+            if (\is_object($value) && method_exists($value, 'validate')) {
+                $value->validate();
+            }
+        }
     }
 }

--- a/src/S3/Input/CopyObjectRequest.php
+++ b/src/S3/Input/CopyObjectRequest.php
@@ -865,12 +865,8 @@ class CopyObjectRequest
     public function validate(): void
     {
         foreach (['Bucket', 'CopySource', 'Key'] as $name) {
-            if (null === $value = $this->$name) {
+            if (null === $this->$name) {
                 throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
-            }
-
-            if (\is_object($value) && method_exists($value, 'validate')) {
-                $value->validate();
             }
         }
     }

--- a/src/S3/Input/CreateBucketConfiguration.php
+++ b/src/S3/Input/CreateBucketConfiguration.php
@@ -4,6 +4,8 @@ namespace AsyncAws\S3\Input;
 
 class CreateBucketConfiguration
 {
+    public const REQUIRED_PARAMETERS = [];
+
     /**
      * @var string|null
      */

--- a/src/S3/Input/CreateBucketConfiguration.php
+++ b/src/S3/Input/CreateBucketConfiguration.php
@@ -2,10 +2,10 @@
 
 namespace AsyncAws\S3\Input;
 
+use AsyncAws\Core\Exception\InvalidArgument;
+
 class CreateBucketConfiguration
 {
-    public const REQUIRED_PARAMETERS = [];
-
     /**
      * @var string|null
      */
@@ -36,5 +36,18 @@ class CreateBucketConfiguration
         $this->LocationConstraint = $value;
 
         return $this;
+    }
+
+    public function validate(): void
+    {
+        foreach ([''] as $name) {
+            if (null === $value = $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+
+            if (\is_object($value) && method_exists($value, 'validate')) {
+                $value->validate();
+            }
+        }
     }
 }

--- a/src/S3/Input/CreateBucketConfiguration.php
+++ b/src/S3/Input/CreateBucketConfiguration.php
@@ -2,8 +2,6 @@
 
 namespace AsyncAws\S3\Input;
 
-use AsyncAws\Core\Exception\InvalidArgument;
-
 class CreateBucketConfiguration
 {
     /**
@@ -40,14 +38,6 @@ class CreateBucketConfiguration
 
     public function validate(): void
     {
-        foreach ([''] as $name) {
-            if (null === $value = $this->$name) {
-                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
-            }
-
-            if (\is_object($value) && method_exists($value, 'validate')) {
-                $value->validate();
-            }
-        }
+        // There are no required properties
     }
 }

--- a/src/S3/Input/CreateBucketRequest.php
+++ b/src/S3/Input/CreateBucketRequest.php
@@ -2,10 +2,10 @@
 
 namespace AsyncAws\S3\Input;
 
+use AsyncAws\Core\Exception\InvalidArgument;
+
 class CreateBucketRequest
 {
-    public const REQUIRED_PARAMETERS = ['Bucket'];
-
     /**
      * @var string|null
      */
@@ -245,5 +245,18 @@ class CreateBucketRequest
         $uri['Bucket'] = $this->Bucket ?? '';
 
         return "/{$uri['Bucket']}";
+    }
+
+    public function validate(): void
+    {
+        foreach (['Bucket'] as $name) {
+            if (null === $value = $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+
+            if (\is_object($value) && method_exists($value, 'validate')) {
+                $value->validate();
+            }
+        }
     }
 }

--- a/src/S3/Input/CreateBucketRequest.php
+++ b/src/S3/Input/CreateBucketRequest.php
@@ -250,13 +250,12 @@ class CreateBucketRequest
     public function validate(): void
     {
         foreach (['Bucket'] as $name) {
-            if (null === $value = $this->$name) {
+            if (null === $this->$name) {
                 throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
             }
-
-            if (\is_object($value) && method_exists($value, 'validate')) {
-                $value->validate();
-            }
+        }
+        if ($this->CreateBucketConfiguration) {
+            $this->CreateBucketConfiguration->validate();
         }
     }
 }

--- a/src/S3/Input/CreateBucketRequest.php
+++ b/src/S3/Input/CreateBucketRequest.php
@@ -4,6 +4,8 @@ namespace AsyncAws\S3\Input;
 
 class CreateBucketRequest
 {
+    public const REQUIRED_PARAMETERS = ['Bucket'];
+
     /**
      * @var string|null
      */

--- a/src/S3/Input/DeleteObjectRequest.php
+++ b/src/S3/Input/DeleteObjectRequest.php
@@ -184,12 +184,8 @@ class DeleteObjectRequest
     public function validate(): void
     {
         foreach (['Bucket', 'Key'] as $name) {
-            if (null === $value = $this->$name) {
+            if (null === $this->$name) {
                 throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
-            }
-
-            if (\is_object($value) && method_exists($value, 'validate')) {
-                $value->validate();
             }
         }
     }

--- a/src/S3/Input/DeleteObjectRequest.php
+++ b/src/S3/Input/DeleteObjectRequest.php
@@ -4,6 +4,8 @@ namespace AsyncAws\S3\Input;
 
 class DeleteObjectRequest
 {
+    public const REQUIRED_PARAMETERS = ['Bucket', 'Key'];
+
     /**
      * @required
      *

--- a/src/S3/Input/DeleteObjectRequest.php
+++ b/src/S3/Input/DeleteObjectRequest.php
@@ -2,10 +2,10 @@
 
 namespace AsyncAws\S3\Input;
 
+use AsyncAws\Core\Exception\InvalidArgument;
+
 class DeleteObjectRequest
 {
-    public const REQUIRED_PARAMETERS = ['Bucket', 'Key'];
-
     /**
      * @required
      *
@@ -179,5 +179,18 @@ class DeleteObjectRequest
         $uri['Key'] = $this->Key ?? '';
 
         return "/{$uri['Bucket']}/{$uri['Key']}";
+    }
+
+    public function validate(): void
+    {
+        foreach (['Bucket', 'Key'] as $name) {
+            if (null === $value = $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+
+            if (\is_object($value) && method_exists($value, 'validate')) {
+                $value->validate();
+            }
+        }
     }
 }

--- a/src/S3/Input/GetObjectAclRequest.php
+++ b/src/S3/Input/GetObjectAclRequest.php
@@ -4,6 +4,8 @@ namespace AsyncAws\S3\Input;
 
 class GetObjectAclRequest
 {
+    public const REQUIRED_PARAMETERS = ['Bucket', 'Key'];
+
     /**
      * @required
      *

--- a/src/S3/Input/GetObjectAclRequest.php
+++ b/src/S3/Input/GetObjectAclRequest.php
@@ -2,10 +2,10 @@
 
 namespace AsyncAws\S3\Input;
 
+use AsyncAws\Core\Exception\InvalidArgument;
+
 class GetObjectAclRequest
 {
-    public const REQUIRED_PARAMETERS = ['Bucket', 'Key'];
-
     /**
      * @required
      *
@@ -135,5 +135,18 @@ class GetObjectAclRequest
         $uri['Key'] = $this->Key ?? '';
 
         return "/{$uri['Bucket']}/{$uri['Key']}?acl";
+    }
+
+    public function validate(): void
+    {
+        foreach (['Bucket', 'Key'] as $name) {
+            if (null === $value = $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+
+            if (\is_object($value) && method_exists($value, 'validate')) {
+                $value->validate();
+            }
+        }
     }
 }

--- a/src/S3/Input/GetObjectAclRequest.php
+++ b/src/S3/Input/GetObjectAclRequest.php
@@ -140,12 +140,8 @@ class GetObjectAclRequest
     public function validate(): void
     {
         foreach (['Bucket', 'Key'] as $name) {
-            if (null === $value = $this->$name) {
+            if (null === $this->$name) {
                 throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
-            }
-
-            if (\is_object($value) && method_exists($value, 'validate')) {
-                $value->validate();
             }
         }
     }

--- a/src/S3/Input/GetObjectRequest.php
+++ b/src/S3/Input/GetObjectRequest.php
@@ -4,6 +4,8 @@ namespace AsyncAws\S3\Input;
 
 class GetObjectRequest
 {
+    public const REQUIRED_PARAMETERS = ['Bucket', 'Key'];
+
     /**
      * @required
      *

--- a/src/S3/Input/GetObjectRequest.php
+++ b/src/S3/Input/GetObjectRequest.php
@@ -470,12 +470,8 @@ class GetObjectRequest
     public function validate(): void
     {
         foreach (['Bucket', 'Key'] as $name) {
-            if (null === $value = $this->$name) {
+            if (null === $this->$name) {
                 throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
-            }
-
-            if (\is_object($value) && method_exists($value, 'validate')) {
-                $value->validate();
             }
         }
     }

--- a/src/S3/Input/GetObjectRequest.php
+++ b/src/S3/Input/GetObjectRequest.php
@@ -2,10 +2,10 @@
 
 namespace AsyncAws\S3\Input;
 
+use AsyncAws\Core\Exception\InvalidArgument;
+
 class GetObjectRequest
 {
-    public const REQUIRED_PARAMETERS = ['Bucket', 'Key'];
-
     /**
      * @required
      *
@@ -465,5 +465,18 @@ class GetObjectRequest
         $uri['Key'] = $this->Key ?? '';
 
         return "/{$uri['Bucket']}/{$uri['Key']}";
+    }
+
+    public function validate(): void
+    {
+        foreach (['Bucket', 'Key'] as $name) {
+            if (null === $value = $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+
+            if (\is_object($value) && method_exists($value, 'validate')) {
+                $value->validate();
+            }
+        }
     }
 }

--- a/src/S3/Input/Grant.php
+++ b/src/S3/Input/Grant.php
@@ -2,10 +2,10 @@
 
 namespace AsyncAws\S3\Input;
 
+use AsyncAws\Core\Exception\InvalidArgument;
+
 class Grant
 {
-    public const REQUIRED_PARAMETERS = [];
-
     /**
      * @var Grantee|null
      */
@@ -55,5 +55,18 @@ class Grant
         $this->Permission = $value;
 
         return $this;
+    }
+
+    public function validate(): void
+    {
+        foreach ([''] as $name) {
+            if (null === $value = $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+
+            if (\is_object($value) && method_exists($value, 'validate')) {
+                $value->validate();
+            }
+        }
     }
 }

--- a/src/S3/Input/Grant.php
+++ b/src/S3/Input/Grant.php
@@ -2,8 +2,6 @@
 
 namespace AsyncAws\S3\Input;
 
-use AsyncAws\Core\Exception\InvalidArgument;
-
 class Grant
 {
     /**
@@ -59,14 +57,6 @@ class Grant
 
     public function validate(): void
     {
-        foreach ([''] as $name) {
-            if (null === $value = $this->$name) {
-                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
-            }
-
-            if (\is_object($value) && method_exists($value, 'validate')) {
-                $value->validate();
-            }
-        }
+        // There are no required properties
     }
 }

--- a/src/S3/Input/Grant.php
+++ b/src/S3/Input/Grant.php
@@ -4,6 +4,8 @@ namespace AsyncAws\S3\Input;
 
 class Grant
 {
+    public const REQUIRED_PARAMETERS = [];
+
     /**
      * @var Grantee|null
      */

--- a/src/S3/Input/Grant.php
+++ b/src/S3/Input/Grant.php
@@ -57,6 +57,8 @@ class Grant
 
     public function validate(): void
     {
-        // There are no required properties
+        if ($this->Grantee) {
+            $this->Grantee->validate();
+        }
     }
 }

--- a/src/S3/Input/Grantee.php
+++ b/src/S3/Input/Grantee.php
@@ -2,10 +2,10 @@
 
 namespace AsyncAws\S3\Input;
 
+use AsyncAws\Core\Exception\InvalidArgument;
+
 class Grantee
 {
-    public const REQUIRED_PARAMETERS = ['Type'];
-
     /**
      * @var string|null
      */
@@ -114,5 +114,18 @@ class Grantee
         $this->URI = $value;
 
         return $this;
+    }
+
+    public function validate(): void
+    {
+        foreach (['Type'] as $name) {
+            if (null === $value = $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+
+            if (\is_object($value) && method_exists($value, 'validate')) {
+                $value->validate();
+            }
+        }
     }
 }

--- a/src/S3/Input/Grantee.php
+++ b/src/S3/Input/Grantee.php
@@ -119,12 +119,8 @@ class Grantee
     public function validate(): void
     {
         foreach (['Type'] as $name) {
-            if (null === $value = $this->$name) {
+            if (null === $this->$name) {
                 throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
-            }
-
-            if (\is_object($value) && method_exists($value, 'validate')) {
-                $value->validate();
             }
         }
     }

--- a/src/S3/Input/Grantee.php
+++ b/src/S3/Input/Grantee.php
@@ -4,6 +4,8 @@ namespace AsyncAws\S3\Input;
 
 class Grantee
 {
+    public const REQUIRED_PARAMETERS = ['Type'];
+
     /**
      * @var string|null
      */

--- a/src/S3/Input/HeadObjectRequest.php
+++ b/src/S3/Input/HeadObjectRequest.php
@@ -338,12 +338,8 @@ class HeadObjectRequest
     public function validate(): void
     {
         foreach (['Bucket', 'Key'] as $name) {
-            if (null === $value = $this->$name) {
+            if (null === $this->$name) {
                 throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
-            }
-
-            if (\is_object($value) && method_exists($value, 'validate')) {
-                $value->validate();
             }
         }
     }

--- a/src/S3/Input/HeadObjectRequest.php
+++ b/src/S3/Input/HeadObjectRequest.php
@@ -4,6 +4,8 @@ namespace AsyncAws\S3\Input;
 
 class HeadObjectRequest
 {
+    public const REQUIRED_PARAMETERS = ['Bucket', 'Key'];
+
     /**
      * @required
      *

--- a/src/S3/Input/HeadObjectRequest.php
+++ b/src/S3/Input/HeadObjectRequest.php
@@ -2,10 +2,10 @@
 
 namespace AsyncAws\S3\Input;
 
+use AsyncAws\Core\Exception\InvalidArgument;
+
 class HeadObjectRequest
 {
-    public const REQUIRED_PARAMETERS = ['Bucket', 'Key'];
-
     /**
      * @required
      *
@@ -333,5 +333,18 @@ class HeadObjectRequest
         $uri['Key'] = $this->Key ?? '';
 
         return "/{$uri['Bucket']}/{$uri['Key']}";
+    }
+
+    public function validate(): void
+    {
+        foreach (['Bucket', 'Key'] as $name) {
+            if (null === $value = $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+
+            if (\is_object($value) && method_exists($value, 'validate')) {
+                $value->validate();
+            }
+        }
     }
 }

--- a/src/S3/Input/ListObjectsRequest.php
+++ b/src/S3/Input/ListObjectsRequest.php
@@ -2,10 +2,10 @@
 
 namespace AsyncAws\S3\Input;
 
+use AsyncAws\Core\Exception\InvalidArgument;
+
 class ListObjectsRequest
 {
-    public const REQUIRED_PARAMETERS = ['Bucket'];
-
     /**
      * @required
      *
@@ -201,5 +201,18 @@ class ListObjectsRequest
         $uri['Bucket'] = $this->Bucket ?? '';
 
         return "/{$uri['Bucket']}";
+    }
+
+    public function validate(): void
+    {
+        foreach (['Bucket'] as $name) {
+            if (null === $value = $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+
+            if (\is_object($value) && method_exists($value, 'validate')) {
+                $value->validate();
+            }
+        }
     }
 }

--- a/src/S3/Input/ListObjectsRequest.php
+++ b/src/S3/Input/ListObjectsRequest.php
@@ -4,6 +4,8 @@ namespace AsyncAws\S3\Input;
 
 class ListObjectsRequest
 {
+    public const REQUIRED_PARAMETERS = ['Bucket'];
+
     /**
      * @required
      *

--- a/src/S3/Input/ListObjectsRequest.php
+++ b/src/S3/Input/ListObjectsRequest.php
@@ -206,12 +206,8 @@ class ListObjectsRequest
     public function validate(): void
     {
         foreach (['Bucket'] as $name) {
-            if (null === $value = $this->$name) {
+            if (null === $this->$name) {
                 throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
-            }
-
-            if (\is_object($value) && method_exists($value, 'validate')) {
-                $value->validate();
             }
         }
     }

--- a/src/S3/Input/Owner.php
+++ b/src/S3/Input/Owner.php
@@ -4,6 +4,8 @@ namespace AsyncAws\S3\Input;
 
 class Owner
 {
+    public const REQUIRED_PARAMETERS = [];
+
     /**
      * @var string|null
      */

--- a/src/S3/Input/Owner.php
+++ b/src/S3/Input/Owner.php
@@ -2,8 +2,6 @@
 
 namespace AsyncAws\S3\Input;
 
-use AsyncAws\Core\Exception\InvalidArgument;
-
 class Owner
 {
     /**
@@ -59,14 +57,6 @@ class Owner
 
     public function validate(): void
     {
-        foreach ([''] as $name) {
-            if (null === $value = $this->$name) {
-                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
-            }
-
-            if (\is_object($value) && method_exists($value, 'validate')) {
-                $value->validate();
-            }
-        }
+        // There are no required properties
     }
 }

--- a/src/S3/Input/Owner.php
+++ b/src/S3/Input/Owner.php
@@ -2,10 +2,10 @@
 
 namespace AsyncAws\S3\Input;
 
+use AsyncAws\Core\Exception\InvalidArgument;
+
 class Owner
 {
-    public const REQUIRED_PARAMETERS = [];
-
     /**
      * @var string|null
      */
@@ -55,5 +55,18 @@ class Owner
         $this->ID = $value;
 
         return $this;
+    }
+
+    public function validate(): void
+    {
+        foreach ([''] as $name) {
+            if (null === $value = $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+
+            if (\is_object($value) && method_exists($value, 'validate')) {
+                $value->validate();
+            }
+        }
     }
 }

--- a/src/S3/Input/PutObjectAclRequest.php
+++ b/src/S3/Input/PutObjectAclRequest.php
@@ -2,10 +2,10 @@
 
 namespace AsyncAws\S3\Input;
 
+use AsyncAws\Core\Exception\InvalidArgument;
+
 class PutObjectAclRequest
 {
-    public const REQUIRED_PARAMETERS = ['Bucket', 'Key'];
-
     /**
      * @var string|null
      */
@@ -311,5 +311,18 @@ class PutObjectAclRequest
         $uri['Key'] = $this->Key ?? '';
 
         return "/{$uri['Bucket']}/{$uri['Key']}?acl";
+    }
+
+    public function validate(): void
+    {
+        foreach (['Bucket', 'Key'] as $name) {
+            if (null === $value = $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+
+            if (\is_object($value) && method_exists($value, 'validate')) {
+                $value->validate();
+            }
+        }
     }
 }

--- a/src/S3/Input/PutObjectAclRequest.php
+++ b/src/S3/Input/PutObjectAclRequest.php
@@ -316,13 +316,12 @@ class PutObjectAclRequest
     public function validate(): void
     {
         foreach (['Bucket', 'Key'] as $name) {
-            if (null === $value = $this->$name) {
+            if (null === $this->$name) {
                 throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
             }
-
-            if (\is_object($value) && method_exists($value, 'validate')) {
-                $value->validate();
-            }
+        }
+        if ($this->AccessControlPolicy) {
+            $this->AccessControlPolicy->validate();
         }
     }
 }

--- a/src/S3/Input/PutObjectAclRequest.php
+++ b/src/S3/Input/PutObjectAclRequest.php
@@ -4,6 +4,8 @@ namespace AsyncAws\S3\Input;
 
 class PutObjectAclRequest
 {
+    public const REQUIRED_PARAMETERS = ['Bucket', 'Key'];
+
     /**
      * @var string|null
      */

--- a/src/S3/Input/PutObjectRequest.php
+++ b/src/S3/Input/PutObjectRequest.php
@@ -709,12 +709,8 @@ class PutObjectRequest
     public function validate(): void
     {
         foreach (['Bucket', 'Key'] as $name) {
-            if (null === $value = $this->$name) {
+            if (null === $this->$name) {
                 throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
-            }
-
-            if (\is_object($value) && method_exists($value, 'validate')) {
-                $value->validate();
             }
         }
     }

--- a/src/S3/Input/PutObjectRequest.php
+++ b/src/S3/Input/PutObjectRequest.php
@@ -4,6 +4,8 @@ namespace AsyncAws\S3\Input;
 
 class PutObjectRequest
 {
+    public const REQUIRED_PARAMETERS = ['Bucket', 'Key'];
+
     /**
      * @var string|null
      */

--- a/src/S3/Input/PutObjectRequest.php
+++ b/src/S3/Input/PutObjectRequest.php
@@ -2,10 +2,10 @@
 
 namespace AsyncAws\S3\Input;
 
+use AsyncAws\Core\Exception\InvalidArgument;
+
 class PutObjectRequest
 {
-    public const REQUIRED_PARAMETERS = ['Bucket', 'Key'];
-
     /**
      * @var string|null
      */
@@ -704,5 +704,18 @@ class PutObjectRequest
         $uri['Key'] = $this->Key ?? '';
 
         return "/{$uri['Bucket']}/{$uri['Key']}";
+    }
+
+    public function validate(): void
+    {
+        foreach (['Bucket', 'Key'] as $name) {
+            if (null === $value = $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+
+            if (\is_object($value) && method_exists($value, 'validate')) {
+                $value->validate();
+            }
+        }
     }
 }

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -74,6 +74,7 @@ class S3Client extends AbstractApi
     public function putObject($input): PutObjectOutput
     {
         $input = PutObjectRequest::create($input);
+        $this->validate($input);
         $payload = $input->getBody() ?? "";
         $response = $this->getResponse(
             'PUT',
@@ -103,6 +104,7 @@ class S3Client extends AbstractApi
     public function createBucket($input): CreateBucketOutput
     {
         $input = CreateBucketRequest::create($input);
+        $this->validate($input);
         $xmlConfig = ["CreateBucketConfiguration" => ["type" => 'structure',"members" => ["LocationConstraint" => ["shape" => 'BucketLocationConstraint']]],"BucketLocationConstraint" => ["type" => 'string'],"_root" => ["type" => 'CreateBucketConfiguration',"xmlName" => 'CreateBucketConfiguration',"uri" => 'http://s3.amazonaws.com/doc/2006-03-01/']];
         $payload = (new XmlBuilder($input->getCreateBucketConfiguration() ?? [], $xmlConfig))->getXml();
 
@@ -131,6 +133,7 @@ class S3Client extends AbstractApi
     public function deleteObject($input): DeleteObjectOutput
     {
         $input = DeleteObjectRequest::create($input);
+        $this->validate($input);
 
         $response = $this->getResponse(
             'DELETE',
@@ -164,6 +167,7 @@ class S3Client extends AbstractApi
     public function headObject($input): HeadObjectOutput
     {
         $input = HeadObjectRequest::create($input);
+        $this->validate($input);
 
         $response = $this->getResponse(
             'HEAD',
@@ -221,6 +225,7 @@ class S3Client extends AbstractApi
     public function copyObject($input): CopyObjectOutput
     {
         $input = CopyObjectRequest::create($input);
+        $this->validate($input);
 
         $response = $this->getResponse(
             'PUT',
@@ -260,6 +265,7 @@ class S3Client extends AbstractApi
     public function getObject($input): GetObjectOutput
     {
         $input = GetObjectRequest::create($input);
+        $this->validate($input);
 
         $response = $this->getResponse(
             'GET',
@@ -292,6 +298,7 @@ class S3Client extends AbstractApi
     public function putObjectAcl($input): PutObjectAclOutput
     {
         $input = PutObjectAclRequest::create($input);
+        $this->validate($input);
         $xmlConfig = ["AccessControlPolicy" => ["type" => 'structure',"members" => ["Grants" => ["shape" => 'Grants',"locationName" => 'AccessControlList'],"Owner" => ["shape" => 'Owner']]],"Grants" => ["type" => 'list',"member" => ["shape" => 'Grant',"locationName" => 'Grant']],"Grant" => ["type" => 'structure',"members" => ["Grantee" => ["shape" => 'Grantee'],"Permission" => ["shape" => 'Permission']]],"Grantee" => ["type" => 'structure',"required" => [0 => 'Type'],"members" => ["DisplayName" => ["shape" => 'DisplayName'],"EmailAddress" => ["shape" => 'EmailAddress'],"ID" => ["shape" => 'ID'],"Type" => ["shape" => 'Type',"locationName" => 'xsi:type',"xmlAttribute" => '1'],"URI" => ["shape" => 'URI']],"xmlNamespace" => ["prefix" => 'xsi',"uri" => 'http://www.w3.org/2001/XMLSchema-instance']],"DisplayName" => ["type" => 'string'],"EmailAddress" => ["type" => 'string'],"ID" => ["type" => 'string'],"Type" => ["type" => 'string'],"URI" => ["type" => 'string'],"Permission" => ["type" => 'string'],"Owner" => ["type" => 'structure',"members" => ["DisplayName" => ["shape" => 'DisplayName'],"ID" => ["shape" => 'ID']]],"_root" => ["type" => 'AccessControlPolicy',"xmlName" => 'AccessControlPolicy',"uri" => 'http://s3.amazonaws.com/doc/2006-03-01/']];
         $payload = (new XmlBuilder($input->getAccessControlPolicy() ?? [], $xmlConfig))->getXml();
 
@@ -318,6 +325,7 @@ class S3Client extends AbstractApi
     public function getObjectAcl($input): GetObjectAclOutput
     {
         $input = GetObjectAclRequest::create($input);
+        $this->validate($input);
 
         $response = $this->getResponse(
             'GET',
@@ -345,6 +353,7 @@ class S3Client extends AbstractApi
     public function listObjects($input): ListObjectsOutput
     {
         $input = ListObjectsRequest::create($input);
+        $this->validate($input);
 
         $response = $this->getResponse(
             'GET',

--- a/src/S3/S3Client.php
+++ b/src/S3/S3Client.php
@@ -74,7 +74,7 @@ class S3Client extends AbstractApi
     public function putObject($input): PutObjectOutput
     {
         $input = PutObjectRequest::create($input);
-        $this->validate($input);
+        $input->validate();
         $payload = $input->getBody() ?? "";
         $response = $this->getResponse(
             'PUT',
@@ -104,7 +104,7 @@ class S3Client extends AbstractApi
     public function createBucket($input): CreateBucketOutput
     {
         $input = CreateBucketRequest::create($input);
-        $this->validate($input);
+        $input->validate();
         $xmlConfig = ["CreateBucketConfiguration" => ["type" => 'structure',"members" => ["LocationConstraint" => ["shape" => 'BucketLocationConstraint']]],"BucketLocationConstraint" => ["type" => 'string'],"_root" => ["type" => 'CreateBucketConfiguration',"xmlName" => 'CreateBucketConfiguration',"uri" => 'http://s3.amazonaws.com/doc/2006-03-01/']];
         $payload = (new XmlBuilder($input->getCreateBucketConfiguration() ?? [], $xmlConfig))->getXml();
 
@@ -133,7 +133,7 @@ class S3Client extends AbstractApi
     public function deleteObject($input): DeleteObjectOutput
     {
         $input = DeleteObjectRequest::create($input);
-        $this->validate($input);
+        $input->validate();
 
         $response = $this->getResponse(
             'DELETE',
@@ -167,7 +167,7 @@ class S3Client extends AbstractApi
     public function headObject($input): HeadObjectOutput
     {
         $input = HeadObjectRequest::create($input);
-        $this->validate($input);
+        $input->validate();
 
         $response = $this->getResponse(
             'HEAD',
@@ -225,7 +225,7 @@ class S3Client extends AbstractApi
     public function copyObject($input): CopyObjectOutput
     {
         $input = CopyObjectRequest::create($input);
-        $this->validate($input);
+        $input->validate();
 
         $response = $this->getResponse(
             'PUT',
@@ -265,7 +265,7 @@ class S3Client extends AbstractApi
     public function getObject($input): GetObjectOutput
     {
         $input = GetObjectRequest::create($input);
-        $this->validate($input);
+        $input->validate();
 
         $response = $this->getResponse(
             'GET',
@@ -298,7 +298,7 @@ class S3Client extends AbstractApi
     public function putObjectAcl($input): PutObjectAclOutput
     {
         $input = PutObjectAclRequest::create($input);
-        $this->validate($input);
+        $input->validate();
         $xmlConfig = ["AccessControlPolicy" => ["type" => 'structure',"members" => ["Grants" => ["shape" => 'Grants',"locationName" => 'AccessControlList'],"Owner" => ["shape" => 'Owner']]],"Grants" => ["type" => 'list',"member" => ["shape" => 'Grant',"locationName" => 'Grant']],"Grant" => ["type" => 'structure',"members" => ["Grantee" => ["shape" => 'Grantee'],"Permission" => ["shape" => 'Permission']]],"Grantee" => ["type" => 'structure',"required" => [0 => 'Type'],"members" => ["DisplayName" => ["shape" => 'DisplayName'],"EmailAddress" => ["shape" => 'EmailAddress'],"ID" => ["shape" => 'ID'],"Type" => ["shape" => 'Type',"locationName" => 'xsi:type',"xmlAttribute" => '1'],"URI" => ["shape" => 'URI']],"xmlNamespace" => ["prefix" => 'xsi',"uri" => 'http://www.w3.org/2001/XMLSchema-instance']],"DisplayName" => ["type" => 'string'],"EmailAddress" => ["type" => 'string'],"ID" => ["type" => 'string'],"Type" => ["type" => 'string'],"URI" => ["type" => 'string'],"Permission" => ["type" => 'string'],"Owner" => ["type" => 'structure',"members" => ["DisplayName" => ["shape" => 'DisplayName'],"ID" => ["shape" => 'ID']]],"_root" => ["type" => 'AccessControlPolicy',"xmlName" => 'AccessControlPolicy',"uri" => 'http://s3.amazonaws.com/doc/2006-03-01/']];
         $payload = (new XmlBuilder($input->getAccessControlPolicy() ?? [], $xmlConfig))->getXml();
 
@@ -325,7 +325,7 @@ class S3Client extends AbstractApi
     public function getObjectAcl($input): GetObjectAclOutput
     {
         $input = GetObjectAclRequest::create($input);
-        $this->validate($input);
+        $input->validate();
 
         $response = $this->getResponse(
             'GET',
@@ -353,7 +353,7 @@ class S3Client extends AbstractApi
     public function listObjects($input): ListObjectsOutput
     {
         $input = ListObjectsRequest::create($input);
-        $this->validate($input);
+        $input->validate();
 
         $response = $this->getResponse(
             'GET',

--- a/src/Sqs/Input/SendMessageRequest.php
+++ b/src/Sqs/Input/SendMessageRequest.php
@@ -4,6 +4,8 @@ namespace AsyncAws\Sqs\Input;
 
 class SendMessageRequest
 {
+    public const REQUIRED_PARAMETERS = ['QueueUrl', 'MessageBody'];
+
     /**
      * @required
      *

--- a/src/Sqs/Input/SendMessageRequest.php
+++ b/src/Sqs/Input/SendMessageRequest.php
@@ -2,10 +2,10 @@
 
 namespace AsyncAws\Sqs\Input;
 
+use AsyncAws\Core\Exception\InvalidArgument;
+
 class SendMessageRequest
 {
-    public const REQUIRED_PARAMETERS = ['QueueUrl', 'MessageBody'];
-
     /**
      * @required
      *
@@ -201,5 +201,18 @@ class SendMessageRequest
     public function requestUri(): string
     {
         return "/";
+    }
+
+    public function validate(): void
+    {
+        foreach (['QueueUrl', 'MessageBody'] as $name) {
+            if (null === $value = $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+
+            if (\is_object($value) && method_exists($value, 'validate')) {
+                $value->validate();
+            }
+        }
     }
 }

--- a/src/Sqs/Input/SendMessageRequest.php
+++ b/src/Sqs/Input/SendMessageRequest.php
@@ -206,12 +206,8 @@ class SendMessageRequest
     public function validate(): void
     {
         foreach (['QueueUrl', 'MessageBody'] as $name) {
-            if (null === $value = $this->$name) {
+            if (null === $this->$name) {
                 throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
-            }
-
-            if (\is_object($value) && method_exists($value, 'validate')) {
-                $value->validate();
             }
         }
     }

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -41,7 +41,7 @@ class SqsClient extends AbstractApi
     public function sendMessage($input): SendMessageResult
     {
         $input = SendMessageRequest::create($input);
-        $this->validate($input);
+        $input->validate();
 
         $response = $this->getResponse(
             'POST',

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -41,6 +41,7 @@ class SqsClient extends AbstractApi
     public function sendMessage($input): SendMessageResult
     {
         $input = SendMessageRequest::create($input);
+        $this->validate($input);
 
         $response = $this->getResponse(
             'POST',


### PR DESCRIPTION
This will fix #26. 

There is an issue with this. 

If you do a `PutObjectAclRequest` we validate all required parameters (['Bucket', 'Key']). But you could pass an `AccessControlPolicy` which have a list of `Grant`. Each `Grant` has a `Grantee` which has one required parameter ('$Type'). We never validate `$Type` since `AccessControlPolicy` is not required. 

This is a minor thing but I think it should be documented. 