### PR TITLE
Remove trait if it isn't needed

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,40 +4,40 @@
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/s3\/2006-03-01\/api-2.json",
             "methods": {
                 "PutObject": {
-                    "generated": "2020-02-02T21:05:15+00:00",
+                    "generated": "2020-02-02T21:21:06+00:00",
                     "separate-result-trait": true
                 },
                 "CreateBucket": {
-                    "generated": "2020-02-02T21:05:15+00:00",
+                    "generated": "2020-02-02T21:21:06+00:00",
                     "separate-result-trait": true
                 },
                 "DeleteObject": {
-                    "generated": "2020-02-02T21:05:15+00:00",
+                    "generated": "2020-02-02T21:21:06+00:00",
                     "separate-result-trait": true
                 },
                 "HeadObject": {
-                    "generated": "2020-02-02T21:05:15+00:00",
+                    "generated": "2020-02-02T21:21:06+00:00",
                     "separate-result-trait": true
                 },
                 "CopyObject": {
-                    "generated": "2020-02-02T21:05:15+00:00",
+                    "generated": "2020-02-02T21:21:06+00:00",
                     "separate-result-trait": true
                 },
                 "GetObject": {
-                    "generated": "2020-02-02T21:05:15+00:00",
+                    "generated": "2020-02-02T21:21:06+00:00",
                     "separate-result-trait": true
                 },
                 "PutObjectAcl": {
-                    "generated": "2020-02-02T21:05:15+00:00",
+                    "generated": "2020-02-02T21:21:06+00:00",
                     "separate-result-trait": true
                 },
                 "GetObjectAcl": {
-                    "generated": "2020-02-02T21:05:15+00:00",
+                    "generated": "2020-02-02T21:21:06+00:00",
                     "separate-result-trait": true
                 },
                 "ListObjects": {
-                    "generated": "2020-02-02T21:05:15+00:00",
-                    "separate-result-trait": true
+                    "generated": "2020-02-02T21:21:06+00:00",
+                    "separate-result-trait": false
                 }
             }
         },

--- a/manifest.json
+++ b/manifest.json
@@ -4,39 +4,39 @@
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/s3\/2006-03-01\/api-2.json",
             "methods": {
                 "PutObject": {
-                    "generated": "2020-02-02T20:51:53+00:00",
+                    "generated": "2020-02-02T21:05:15+00:00",
                     "separate-result-trait": true
                 },
                 "CreateBucket": {
-                    "generated": "2020-02-02T20:51:53+00:00",
+                    "generated": "2020-02-02T21:05:15+00:00",
                     "separate-result-trait": true
                 },
                 "DeleteObject": {
-                    "generated": "2020-02-02T20:51:53+00:00",
+                    "generated": "2020-02-02T21:05:15+00:00",
                     "separate-result-trait": true
                 },
                 "HeadObject": {
-                    "generated": "2020-02-02T20:51:53+00:00",
+                    "generated": "2020-02-02T21:05:15+00:00",
                     "separate-result-trait": true
                 },
                 "CopyObject": {
-                    "generated": "2020-02-02T20:51:53+00:00",
+                    "generated": "2020-02-02T21:05:15+00:00",
                     "separate-result-trait": true
                 },
                 "GetObject": {
-                    "generated": "2020-02-02T20:51:53+00:00",
+                    "generated": "2020-02-02T21:05:15+00:00",
                     "separate-result-trait": true
                 },
                 "PutObjectAcl": {
-                    "generated": "2020-02-02T20:51:53+00:00",
+                    "generated": "2020-02-02T21:05:15+00:00",
                     "separate-result-trait": true
                 },
                 "GetObjectAcl": {
-                    "generated": "2020-02-02T20:51:53+00:00",
+                    "generated": "2020-02-02T21:05:15+00:00",
                     "separate-result-trait": true
                 },
                 "ListObjects": {
-                    "generated": "2020-02-02T20:51:53+00:00",
+                    "generated": "2020-02-02T21:05:15+00:00",
                     "separate-result-trait": true
                 }
             }

--- a/manifest.json
+++ b/manifest.json
@@ -37,7 +37,7 @@
                 },
                 "ListObjects": {
                     "generated": "2020-02-02T21:21:06+00:00",
-                    "separate-result-trait": false
+                    "separate-result-trait": true
                 }
             }
         },

--- a/manifest.json
+++ b/manifest.json
@@ -4,40 +4,40 @@
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/s3\/2006-03-01\/api-2.json",
             "methods": {
                 "PutObject": {
-                    "generated": "2020-02-02T20:14:52+00:00",
-                    "generate-result-trait": true
+                    "generated": "2020-02-02T20:51:53+00:00",
+                    "separate-result-trait": true
                 },
                 "CreateBucket": {
-                    "generated": "2020-02-02T20:14:52+00:00",
-                    "generate-result-trait": true
+                    "generated": "2020-02-02T20:51:53+00:00",
+                    "separate-result-trait": true
                 },
                 "DeleteObject": {
-                    "generated": "2020-02-02T20:14:52+00:00",
-                    "generate-result-trait": true
+                    "generated": "2020-02-02T20:51:53+00:00",
+                    "separate-result-trait": true
                 },
                 "HeadObject": {
-                    "generated": "2020-02-02T20:14:52+00:00",
-                    "generate-result-trait": true
+                    "generated": "2020-02-02T20:51:53+00:00",
+                    "separate-result-trait": true
                 },
                 "CopyObject": {
-                    "generated": "2020-02-02T20:14:52+00:00",
-                    "generate-result-trait": true
+                    "generated": "2020-02-02T20:51:53+00:00",
+                    "separate-result-trait": true
                 },
                 "GetObject": {
-                    "generated": "2020-02-02T20:14:52+00:00",
-                    "generate-result-trait": true
+                    "generated": "2020-02-02T20:51:53+00:00",
+                    "separate-result-trait": true
                 },
                 "PutObjectAcl": {
-                    "generated": "2020-02-02T20:14:52+00:00",
-                    "generate-result-trait": true
+                    "generated": "2020-02-02T20:51:53+00:00",
+                    "separate-result-trait": true
                 },
                 "GetObjectAcl": {
-                    "generated": "2020-02-02T20:14:52+00:00",
-                    "generate-result-trait": true
+                    "generated": "2020-02-02T20:51:53+00:00",
+                    "separate-result-trait": true
                 },
                 "ListObjects": {
-                    "generated": "2020-02-02T20:14:52+00:00",
-                    "generate-result-trait": true
+                    "generated": "2020-02-02T20:51:53+00:00",
+                    "separate-result-trait": true
                 }
             }
         },
@@ -48,8 +48,8 @@
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sqs\/2012-11-05\/api-2.json",
             "methods": {
                 "SendMessage": {
-                    "generated": "2020-02-02T20:15:19+00:00",
-                    "generate-result-trait": true
+                    "generated": "2020-02-02T18:04:01+00:00",
+                    "separate-result-trait": true
                 }
             }
         },
@@ -58,12 +58,12 @@
             "namespace": "AsyncAws\\Core\\Sts",
             "methods": {
                 "GetCallerIdentity": {
-                    "generated": "2020-02-02T20:15:50+00:00",
-                    "generate-result-trait": true
+                    "generated": "2020-02-02T18:15:53+00:00",
+                    "separate-result-trait": true
                 },
                 "AssumeRole": {
-                    "generated": "2020-02-02T20:15:50+00:00",
-                    "generate-result-trait": true
+                    "generated": "2020-02-02T18:15:53+00:00",
+                    "separate-result-trait": false
                 }
             }
         }

--- a/src/CodeGenerator/Command/CreateCommand.php
+++ b/src/CodeGenerator/Command/CreateCommand.php
@@ -80,8 +80,8 @@ class CreateCommand extends Command
         $resultClassName = $operation['output']['shape'];
         $resultNamespace = $baseNamespace . '\\Result';
 
-        $this->generator->generateOperation($definition, $service, $baseNamespace, $operationName);
-        $this->generator->generateResultClass($definition, $resultNamespace, $resultClassName, true, true);
+        $this->generator->generateOperation($definition, $operationName, $service, $baseNamespace);
+        $this->generator->generateResultClass($definition, $operationName, $resultNamespace, $resultClassName, true, true);
         $this->generator->generateOutputTrait($definition, $operationName, $resultNamespace, $resultClassName);
 
         // Update manifest file

--- a/src/CodeGenerator/Command/CreateCommand.php
+++ b/src/CodeGenerator/Command/CreateCommand.php
@@ -81,7 +81,7 @@ class CreateCommand extends Command
         $resultNamespace = $baseNamespace . '\\Result';
 
         $this->generator->generateOperation($definition, $service, $baseNamespace, $operationName);
-        $this->generator->generateResultClass($definition, $service, $resultNamespace, $resultClassName, true);
+        $this->generator->generateResultClass($definition, $resultNamespace, $resultClassName, true, true);
         $this->generator->generateOutputTrait($definition, $operationName, $resultNamespace, $resultClassName);
 
         // Update manifest file

--- a/src/CodeGenerator/Command/CreateCommand.php
+++ b/src/CodeGenerator/Command/CreateCommand.php
@@ -86,7 +86,7 @@ class CreateCommand extends Command
 
         // Update manifest file
         $manifest['services'][$service]['methods'][$operationName]['generated'] = \date('c');
-        $manifest['services'][$service]['methods'][$operationName]['generate-result-trait'] = false;
+        $manifest['services'][$service]['methods'][$operationName]['separate-result-trait'] = false;
         \file_put_contents($this->manifestFile, \json_encode($manifest, \JSON_PRETTY_PRINT));
 
         return 0;

--- a/src/CodeGenerator/Command/RegenerateCommand.php
+++ b/src/CodeGenerator/Command/RegenerateCommand.php
@@ -78,16 +78,8 @@ class RegenerateCommand extends Command
                 $this->generator->generateOperation($definition, $service, $baseNamespace, $operationName);
             }
 
-            if ($operationConfig['separate-result-trait']) {
-                $this->generator->generateOutputTrait($definition, $operationName, $resultNamespace, $resultClassName);
-            }
-
             if ($operationConfig['generate-result']) {
-                $this->generator->generateResultClass($definition, $service, $resultNamespace, $resultClassName, true);
-            }
-
-            if ($operationConfig['separate-result-trait']) {
-                $this->mergeTrait($resultNamespace . '\\' . $resultClassName);
+                $this->generator->generateResultClass($definition, $resultNamespace, $resultClassName, true, $operationConfig['separate-result-trait']);
             }
 
             // Update manifest file

--- a/src/CodeGenerator/Command/RegenerateCommand.php
+++ b/src/CodeGenerator/Command/RegenerateCommand.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace AsyncAws\CodeGenerator\Command;
 
 use AsyncAws\CodeGenerator\Generator\ApiGenerator;
-use AsyncAws\CodeGenerator\Generator\ClassFactory;
 use AsyncAws\CodeGenerator\Generator\ServiceDefinition;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -75,11 +74,11 @@ class RegenerateCommand extends Command
             $resultClassName = $operation['output']['shape'];
 
             if ($operationConfig['generate-method']) {
-                $this->generator->generateOperation($definition, $service, $baseNamespace, $operationName);
+                $this->generator->generateOperation($definition, $operationName, $service, $baseNamespace);
             }
 
             if ($operationConfig['generate-result']) {
-                $this->generator->generateResultClass($definition, $resultNamespace, $resultClassName, true, $operationConfig['separate-result-trait']);
+                $this->generator->generateResultClass($definition, $operationName, $resultNamespace, $resultClassName, true, $operationConfig['separate-result-trait']);
             }
 
             // Update manifest file
@@ -139,14 +138,5 @@ class RegenerateCommand extends Command
             $default,
             $manifest['services'][$service]['methods'][$operationName]
         );
-    }
-
-    private function mergeTrait(string $outputClass)
-    {
-        $classNs = ClassFactory::fromExistingClass($outputClass);
-        $fileWriter = $this->generator->getFileWriter();
-        $fileWriter->write($classNs);
-        usleep(100);
-        $fileWriter->delete($outputClass . 'Trait');
     }
 }

--- a/src/CodeGenerator/FileWriter.php
+++ b/src/CodeGenerator/FileWriter.php
@@ -47,4 +47,15 @@ class FileWriter
         $filename = \sprintf('%s/%s.php', $directory, $className);
         \file_put_contents($filename, "<?php\n\n" . $this->printer->printNamespace($namespace));
     }
+
+    /**
+     * Delete a class from disk.
+     */
+    public function delete(string $class): void
+    {
+        // Remove AsyncAws\
+        $class = substr($class, 9);
+        $file = \sprintf('%s/%s.php', $this->srcDirectory, str_replace('\\', '/', $class));
+        unlink($file);
+    }
 }

--- a/src/CodeGenerator/FileWriter.php
+++ b/src/CodeGenerator/FileWriter.php
@@ -56,6 +56,8 @@ class FileWriter
         // Remove AsyncAws\
         $class = substr($class, 9);
         $file = \sprintf('%s/%s.php', $this->srcDirectory, str_replace('\\', '/', $class));
-        unlink($file);
+        if (is_file($file)) {
+            unlink($file);
+        }
     }
 }

--- a/src/CodeGenerator/Generator/ApiGenerator.php
+++ b/src/CodeGenerator/Generator/ApiGenerator.php
@@ -39,6 +39,11 @@ class ApiGenerator
         $this->fileWriter = new FileWriter($srcDirectory);
     }
 
+    public function getFileWriter(): FileWriter
+    {
+        return $this->fileWriter;
+    }
+
     /**
      * Update the API client with a new function call.
      */


### PR DESCRIPTION
Im moving around a lot of code in ApiGenerator. But the end result is that we only have a Trait if `"separate-result-trait": true` in the manifest file. The trait is only generated on "create". Never again. 