### PR TITLE
Add link to documentation when not provided

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,52 +4,52 @@
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/s3\/2006-03-01\/api-2.json",
             "methods": {
                 "PutObject": {
-                    "generated": "2020-02-02T22:22:02+00:00",
+                    "generated": "2020-02-03T13:12:35+01:00",
                     "separate-result-trait": false
                 },
                 "CreateBucket": {
-                    "generated": "2020-02-02T22:22:02+00:00",
+                    "generated": "2020-02-03T13:12:35+01:00",
                     "separate-result-trait": false
                 },
                 "DeleteObject": {
-                    "generated": "2020-02-02T22:22:02+00:00",
+                    "generated": "2020-02-03T13:12:35+01:00",
                     "separate-result-trait": false
                 },
                 "HeadObject": {
-                    "generated": "2020-02-02T22:22:02+00:00",
+                    "generated": "2020-02-03T13:12:35+01:00",
                     "separate-result-trait": false
                 },
                 "CopyObject": {
-                    "generated": "2020-02-02T22:22:02+00:00",
+                    "generated": "2020-02-03T13:12:35+01:00",
                     "separate-result-trait": false
                 },
                 "GetObject": {
-                    "generated": "2020-02-02T22:22:02+00:00",
+                    "generated": "2020-02-03T13:12:35+01:00",
                     "separate-result-trait": false
                 },
                 "PutObjectAcl": {
-                    "generated": "2020-02-02T22:22:02+00:00",
+                    "generated": "2020-02-03T13:12:35+01:00",
                     "separate-result-trait": false
                 },
                 "GetObjectAcl": {
-                    "generated": "2020-02-02T22:22:02+00:00",
+                    "generated": "2020-02-03T13:12:35+01:00",
                     "separate-result-trait": false
                 },
                 "ListObjects": {
-                    "generated": "2020-02-02T22:22:02+00:00",
+                    "generated": "2020-02-03T13:12:35+01:00",
                     "separate-result-trait": false
                 }
             }
         },
         "Ses": {
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sesv2\/2019-09-27\/api-2.json",
-            "methods": {}
+            "methods": []
         },
         "Sqs": {
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sqs\/2012-11-05\/api-2.json",
             "methods": {
                 "SendMessage": {
-                    "generated": "2020-02-02T22:22:06+00:00",
+                    "generated": "2020-02-03T13:12:36+01:00",
                     "separate-result-trait": false
                 }
             }
@@ -59,11 +59,11 @@
             "namespace": "AsyncAws\\Core\\Sts",
             "methods": {
                 "GetCallerIdentity": {
-                    "generated": "2020-02-02T22:22:08+00:00",
+                    "generated": "2020-02-03T13:12:36+01:00",
                     "separate-result-trait": false
                 },
                 "AssumeRole": {
-                    "generated": "2020-02-02T22:22:08+00:00",
+                    "generated": "2020-02-03T13:12:36+01:00",
                     "separate-result-trait": false
                 }
             }

--- a/src/CodeGenerator/Generator/ApiGenerator.php
+++ b/src/CodeGenerator/Generator/ApiGenerator.php
@@ -49,7 +49,7 @@ class ApiGenerator
         $inputShape = $definition->getShape($operation['input']['shape']) ?? [];
 
         $inputClassName = $operation['input']['shape'];
-        $this->generateInputClass($service, $definition->getApiVersion(), $operationName, $baseNamespace . '\\Input', $inputClassName, true);
+        $this->generateInputClass($service, $apiVersion = $definition->getApiVersion(), $operationName, $baseNamespace . '\\Input', $inputClassName, true);
 
         $namespace = ClassFactory::fromExistingClass(\sprintf('%s\\%sClient', $baseNamespace, $service));
         $safeClassName = $this->safeClassName($inputClassName);
@@ -66,7 +66,7 @@ class ApiGenerator
             $class->getMethod('getServiceCode')
                 ->setBody("return '$prefix';");
         }
-        if (null !== $version = $definition->getSignatureVersion()) {
+        if (null !== $signatureVersion = $definition->getSignatureVersion()) {
             if (!$class->hasMethod('getSignatureVersion')) {
                 $class->addMethod('getSignatureVersion')
                     ->setReturnType('string')
@@ -74,13 +74,15 @@ class ApiGenerator
                 ;
             }
             $class->getMethod('getSignatureVersion')
-                ->setBody("return '$version';");
+                ->setBody("return '$signatureVersion';");
         }
 
         $class->removeMethod(\lcfirst($operation['name']));
         $method = $class->addMethod(\lcfirst($operation['name']));
         if (isset($operation['documentationUrl'])) {
             $method->addComment('@see ' . $operation['documentationUrl']);
+        } elseif (null !== $prefix) {
+            $method->addComment('@see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-' . $prefix . '-' . $apiVersion . '.html#' . \strtolower($operation['name']));
         }
 
         $method->addComment('@param array{');

--- a/src/Core/Sts/StsClient.php
+++ b/src/Core/Sts/StsClient.php
@@ -11,6 +11,8 @@ use AsyncAws\Core\Sts\Result\GetCallerIdentityResponse;
 class StsClient extends AbstractApi
 {
     /**
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-sts-2011-06-15.html#assumerole
+     *
      * @param array{
      *   RoleArn: string,
      *   RoleSessionName: string,
@@ -40,6 +42,8 @@ class StsClient extends AbstractApi
     }
 
     /**
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-sts-2011-06-15.html#getcalleridentity
+     *
      * @param array{
      * }|GetCallerIdentityRequest $input
      */

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -18,6 +18,8 @@ class SqsClient extends AbstractApi
     }
 
     /**
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-sqs-2012-11-05.html#sendmessage
+     *
      * @param array{
      *   QueueUrl: string,
      *   MessageBody: string,


### PR DESCRIPTION
This PR adds a link to the official documentation when the API.json does not provides the documentation.

While S3 services uses the link (provided in apis.json) that point to the Api Documentation (not related to an languages/sdk, with RAW HTTP request/response example), this PR generate a link to the official php-sdk because, the path to the Official documentation is not guessable...

I've 2 issues with this PR
- Links in S3 and other services are not consistent
- displaying a link to the official PHP-SDK maybe confusing, if somebody copy/paste a sample from the documentation, they may face issue because the `async-aws` does not always expose the same contract...

This will fix #76