### PR TITLE
Embed php-cs-fixer with the generate command

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
         "symfony/service-contracts": "^1.0 || ^2.0"
     },
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^2.16",
         "nette/php-generator": "^3.3",
         "nette/utils": "^3.0",
         "symfony/console": "^5.0",

--- a/src/CodeGenerator/composer.json
+++ b/src/CodeGenerator/composer.json
@@ -8,6 +8,7 @@
         "ext-SimpleXML": "*",
         "ext-hash": "*",
         "ext-json": "*",
+        "friendsofphp/php-cs-fixer": "^2.16",
         "nette/php-generator": "^3.3",
         "nette/utils": "^3.0",
         "symfony/console": "^5.0",


### PR DESCRIPTION
For now, it uses the `.php_cs` file located alongside the `manifest.json` but we could use a different file