### PR TITLE
Handle pagination

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,6 +3,7 @@
         "S3": {
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/s3\/2006-03-01\/api-2.json",
             "documentation": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/s3\/2006-03-01\/docs-2.json",
+            "pagination": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/s3\/2006-03-01\/paginators-1.json",
             "methods": {
                 "PutObject": [],
                 "CreateBucket": [],
@@ -18,11 +19,13 @@
         "Ses": {
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sesv2\/2019-09-27\/api-2.json",
             "documentation": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sesv2\/2019-09-27\/docs-2.json",
+            "pagination": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sesv2\/2019-09-27\/paginators-1.json",
             "methods": []
         },
         "Sqs": {
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sqs\/2012-11-05\/api-2.json",
             "documentation": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sqs\/2012-11-05\/docs-2.json",
+            "pagination": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sqs\/2012-11-05\/paginators-1.json",
             "methods": {
                 "SendMessage": []
             }
@@ -30,6 +33,7 @@
         "Sts": {
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sts\/2011-06-15\/api-2.json",
             "documentation": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sts\/2011-06-15\/docs-2.json",
+            "pagination": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sts\/2011-06-15\/paginators-1.json",
             "namespace": "AsyncAws\\Core\\Sts",
             "methods": {
                 "GetCallerIdentity": [],

--- a/src/CodeGenerator/Command/GenerateCommand.php
+++ b/src/CodeGenerator/Command/GenerateCommand.php
@@ -83,6 +83,7 @@ class GenerateCommand extends Command
 
             $definitionArray = \json_decode(\file_get_contents($manifest['services'][$serviceName]['source']), true);
             $documentationArray = \json_decode(\file_get_contents($manifest['services'][$serviceName]['documentation']), true);
+            $paginationArray = \json_decode(\file_get_contents($manifest['services'][$serviceName]['pagination']), true);
             if (\count($serviceNames) > 1) {
                 $operationNames = $this->getOperationNames(null, true, $io, $definitionArray, $manifest['services'][$serviceName]);
             } else {
@@ -94,7 +95,7 @@ class GenerateCommand extends Command
 
             $progressOperation->start(\count($operationNames));
 
-            $definition = new ServiceDefinition($definitionArray, $documentationArray);
+            $definition = new ServiceDefinition($definitionArray, $documentationArray, $paginationArray);
             $baseNamespace = $manifest['services'][$serviceName]['namespace'] ?? \sprintf('AsyncAws\\%s', $serviceName);
             $resultNamespace = $baseNamespace . '\\Result';
 

--- a/src/CodeGenerator/Generator/ApiGenerator.php
+++ b/src/CodeGenerator/Generator/ApiGenerator.php
@@ -11,6 +11,7 @@ use AsyncAws\Core\StreamableBody;
 use AsyncAws\Core\XmlBuilder;
 use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Method;
+use Nette\PhpGenerator\Parameter;
 use Nette\PhpGenerator\PhpNamespace;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -200,8 +201,92 @@ class ApiGenerator
         }
 
         $this->resultClassAddProperties($baseNamespace, $root, $inputShape, $className, $class, $namespace);
+        // should be called After Properties injection
+        if ($operationName && null !== $pagination = $this->definition->getOperationPagination($operationName)) {
+            $this->generateOutputPagination($pagination, $className, $baseNamespace, $class);
+        }
 
         $this->fileWriter->write($namespace);
+    }
+
+    private function generateOutputPagination(array $pagination, string $className, string $baseNamespace, ClassType $class)
+    {
+        if (empty($pagination['result_key'])) {
+            throw new \RuntimeException('This is not implemented yet');
+        }
+
+        $class->addImplement(\IteratorAggregate::class);
+        $iteratorBody = '';
+        $iteratorTypes = [];
+        foreach ((array) $pagination['result_key'] as $resultKey) {
+            $iteratorBody .= strtr('yield from $this->PROPERTY_NAME;
+            ', [
+                'PROPERTY_NAME' => $resultKey,
+            ]);
+            $resultShapeName = $this->definition->getShape($className)['members'][$resultKey]['shape'];
+            $resultShape = $this->definition->getShape($resultShapeName);
+
+            if ('list' !== $resultShape['type']) {
+                throw new \RuntimeException('Cannot generate a pagination for a non-iterable result');
+            }
+
+            $listShape = $this->definition->getShape($resultShape['member']['shape']);
+            if ('structure' !== $listShape['type']) {
+                $iteratorTypes[] = $iteratorType = $this->toPhpType($listShape['type']);
+            } else {
+                $iteratorTypes[] = $iteratorType = $this->safeClassName($resultShape['member']['shape']);
+            }
+
+            $getter = 'get' . $resultKey;
+            if (!$class->hasMethod($getter)) {
+                throw new \RuntimeException(sprintf('Unable to find the method "%s" in "%s"', $getter, $className));
+            }
+            $getterBody = strtr('
+                $this->initialize();
+
+                if ($currentPageOnly) {
+                    return $this->PROPERTY_NAME;
+                }
+                while (true) {
+                    yield from $this->PROPERTY_NAME;
+
+                    // TODO load next results
+                    break;
+                }
+            ', [
+                'PROPERTY_NAME' => $resultKey,
+            ]);
+            $method = $class->getMethod($getter);
+            $method
+                ->setParameters([(new Parameter('currentPageOnly'))->setType('bool')->setDefaultValue(false)])
+                ->setReturnType('iterable')
+                ->setComment('@param bool $currentPageOnly When true, iterates over items of the current page. Otherwise also fetch items in the next pages.')
+                ->addComment("@return iterable<$iteratorType>")
+                ->setBody($getterBody);
+        }
+
+        $iteratorType = implode('|', $iteratorTypes);
+
+        $iteratorBody = strtr('
+            $this->initialize();
+
+            while (true) {
+                ITERATE_PROPERTIES_CODE
+
+                // TODO load next results
+                break;
+            }
+        ', [
+            'ITERATE_PROPERTIES_CODE' => $iteratorBody,
+        ]);
+
+        $class->removeMethod('getIterator');
+        $class->addMethod('getIterator')
+            ->setReturnType(\Traversable::class)
+            ->addComment('Iterates over ' . implode(' then ', (array) $pagination['result_key']))
+            ->addComment("@return \Traversable<$iteratorType>")
+            ->setBody($iteratorBody)
+        ;
     }
 
     /**
@@ -399,15 +484,21 @@ PHP;
         if (!\in_array($shape['type'], ['structure', 'list'])) {
             $type = $this->toPhpType($shape['type']);
 
+            if (null === $rootObjectName) {
+                return "\$this->xmlValueOrNull($prefix, '$type');\n";
+            }
+
             return "\$this->$rootObjectName = \$this->xmlValueOrNull(\$data->$rootObjectName, '$type');\n";
         }
 
         if ('list' === $shape['type']) {
             $childCall = $this->parseXmlResponse(null, $shape['member']['shape'], '$item');
 
+            $location = $shape['member']['locationName'] ?? $rootObjectName;
+
             return <<<PHP
 \$this->$rootObjectName = [];
-foreach ($prefix->$rootObjectName as \$item) {
+foreach ($prefix->{$location} as \$item) {
     \$this->{$rootObjectName}[] = $childCall;
 }
 
@@ -427,7 +518,7 @@ PHP;
             } elseif ('list' === $memberShape['type']) {
                 // TODO check for list type
                 // TODO we should do something similar like above, but here we are in the middle of defining an array.
-                throw new \RuntimeException('This si not implemented yet');
+                throw new \RuntimeException('This is not implemented yet');
             //$body .= sprintf('$this->%s = array_map(function($item) { return %s::create($item); }, $input["%s"] ?? []);' . "\n", $name, $this->safeClassName($memberShape['member']['shape']), $name);
             } else {
                 $type = $this->toPhpType($memberShape['type']);
@@ -679,7 +770,7 @@ PHP
                     $this->doGenerateResultClass($baseNamespace, $listItemShapeName);
                     $returnType = $this->safeClassName($listItemShapeName);
                 } else {
-                    $returnType = $type . '[]';
+                    $returnType = $type;
                 }
             } elseif ($data['streaming'] ?? false) {
                 $parameterType = StreamableBody::class;

--- a/src/CodeGenerator/Generator/ServiceDefinition.php
+++ b/src/CodeGenerator/Generator/ServiceDefinition.php
@@ -15,10 +15,13 @@ class ServiceDefinition
 
     private $documentation;
 
-    public function __construct(array $definition, array $documentation)
+    private $pagination;
+
+    public function __construct(array $definition, array $documentation, array $pagination)
     {
         $this->definition = $definition;
         $this->documentation = $documentation;
+        $this->pagination = $pagination;
     }
 
     public function getOperations(): array
@@ -34,6 +37,11 @@ class ServiceDefinition
     public function getOperationDocumentation(string $name): ?string
     {
         return $this->documentation['operations'][$name] ?? null;
+    }
+
+    public function getOperationPagination(string $name): ?array
+    {
+        return $this->pagination['pagination'][$name] ?? null;
     }
 
     public function getShapes(): array

--- a/src/Core/Result.php
+++ b/src/Core/Result.php
@@ -118,11 +118,10 @@ class Result
 
     final protected function xmlValueOrNull(\SimpleXMLElement $xml, string $type)
     {
-        if (0 === $xml->count()) {
+        $value = $xml->__toString();
+        if (empty($value) && 0 === $xml->count()) {
             return null;
         }
-
-        $value = $xml->__toString();
 
         // Return the correct type
         switch ($type) {

--- a/src/S3/Result/GetObjectAclOutput.php
+++ b/src/S3/Result/GetObjectAclOutput.php
@@ -56,7 +56,7 @@ class GetObjectAclOutput extends Result
             'ID' => $this->xmlValueOrNull($data->Owner->ID, 'string'),
         ]);
         $this->Grants = [];
-        foreach ($data->Grants as $item) {
+        foreach ($data->Grant as $item) {
             $this->Grants[] = new Grant([
                 'Grantee' => new Grantee([
                     'DisplayName' => $this->xmlValueOrNull($item->Grantee->DisplayName, 'string'),


### PR DESCRIPTION
This is the very first layer of pagination.

It provide an iterrator that iterate over the items in the current page. Calling API to fetch next page will be done in another PR.

For the user, when the operation returns a paginated response, the they receive an \IteratorAggregate result
usage:

```php
foreach ($sqsClient->ListQueues() as $queueUrl) {
  echo $queueUrl .PHP_EOL;
}

$list = $s3Client->ListObjects();
foreach ($list as $object) {
  echo $list->getName() . $object->getPrefix().$object->getKey() .PHP_EOL;
}
```

nb: Some operation returns the "merge" of 2 lists (see `S3::ListObjects`).
ListObjectsOutput contains:
- Contents: Objects[]
- CommonPrefixes: CommonPrefixes[]

When iterating, my implementation returns a new class `ObjectCommonPrefixes[]` which decorates the 2 Class..

WDYT?