### PR TITLE
Add Basics SQS operations

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -28,7 +28,14 @@
             "pagination": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sqs\/2012-11-05\/paginators-1.json",
             "methods": {
                 "SendMessage": [],
-                "DeleteMessage": []
+                "DeleteMessage": [],
+                "ChangeMessageVisibility": [],
+                "CreateQueue": [],
+                "DeleteQueue": [],
+                "GetQueueUrl": [],
+                "GetQueueAttributes": [],
+                "ListQueues": [],
+                "PurgeQueue": []
             }
         },
         "Sts": {

--- a/src/Sqs/Input/ChangeMessageVisibilityRequest.php
+++ b/src/Sqs/Input/ChangeMessageVisibilityRequest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace AsyncAws\Sqs\Input;
+
+use AsyncAws\Core\Exception\InvalidArgument;
+
+class ChangeMessageVisibilityRequest
+{
+    /**
+     * The URL of the Amazon SQS queue whose message's visibility is changed.
+     *
+     * @required
+     *
+     * @var string|null
+     */
+    private $QueueUrl;
+
+    /**
+     * The receipt handle associated with the message whose visibility timeout is changed. This parameter is returned by the
+     * `ReceiveMessage` action.
+     *
+     * @required
+     *
+     * @var string|null
+     */
+    private $ReceiptHandle;
+
+    /**
+     * The new value for the message's visibility timeout (in seconds). Values values: `0` to `43200`. Maximum: 12 hours.
+     *
+     * @required
+     *
+     * @var int|null
+     */
+    private $VisibilityTimeout;
+
+    /**
+     * @param array{
+     *   QueueUrl: string,
+     *   ReceiptHandle: string,
+     *   VisibilityTimeout: int,
+     * } $input
+     */
+    public function __construct(array $input)
+    {
+        $this->QueueUrl = $input['QueueUrl'] ?? null;
+        $this->ReceiptHandle = $input['ReceiptHandle'] ?? null;
+        $this->VisibilityTimeout = $input['VisibilityTimeout'] ?? null;
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getQueueUrl(): ?string
+    {
+        return $this->QueueUrl;
+    }
+
+    public function getReceiptHandle(): ?string
+    {
+        return $this->ReceiptHandle;
+    }
+
+    public function getVisibilityTimeout(): ?int
+    {
+        return $this->VisibilityTimeout;
+    }
+
+    public function requestBody(): array
+    {
+        $payload = ['Action' => 'ChangeMessageVisibility', 'Version' => '2012-11-05'];
+        if (null !== $this->QueueUrl) {
+            $payload['QueueUrl'] = $this->QueueUrl;
+        }
+        if (null !== $this->ReceiptHandle) {
+            $payload['ReceiptHandle'] = $this->ReceiptHandle;
+        }
+        if (null !== $this->VisibilityTimeout) {
+            $payload['VisibilityTimeout'] = $this->VisibilityTimeout;
+        }
+
+        return $payload;
+    }
+
+    public function requestHeaders(): array
+    {
+        $headers = [];
+
+        return $headers;
+    }
+
+    public function requestQuery(): array
+    {
+        $query = [];
+
+        return $query;
+    }
+
+    public function requestUri(): string
+    {
+        return '/';
+    }
+
+    public function setQueueUrl(?string $value): self
+    {
+        $this->QueueUrl = $value;
+
+        return $this;
+    }
+
+    public function setReceiptHandle(?string $value): self
+    {
+        $this->ReceiptHandle = $value;
+
+        return $this;
+    }
+
+    public function setVisibilityTimeout(?int $value): self
+    {
+        $this->VisibilityTimeout = $value;
+
+        return $this;
+    }
+
+    public function validate(): void
+    {
+        foreach (['QueueUrl', 'ReceiptHandle', 'VisibilityTimeout'] as $name) {
+            if (null === $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+        }
+    }
+}

--- a/src/Sqs/Input/CreateQueueRequest.php
+++ b/src/Sqs/Input/CreateQueueRequest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace AsyncAws\Sqs\Input;
+
+use AsyncAws\Core\Exception\InvalidArgument;
+
+class CreateQueueRequest
+{
+    /**
+     * The name of the new queue. The following limits apply to this name:.
+     *
+     * @required
+     *
+     * @var string|null
+     */
+    private $QueueName;
+
+    /**
+     * A map of attributes with their corresponding values.
+     *
+     * @var array|null
+     */
+    private $Attributes;
+
+    /**
+     * Add cost allocation tags to the specified Amazon SQS queue. For an overview, see Tagging Your Amazon SQS Queues in
+     * the *Amazon Simple Queue Service Developer Guide*.
+     *
+     * @see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-queue-tags.html
+     *
+     * @var array|null
+     */
+    private $tags;
+
+    /**
+     * @param array{
+     *   QueueName: string,
+     *   Attributes?: array,
+     *   tags?: array,
+     * } $input
+     */
+    public function __construct(array $input)
+    {
+        $this->QueueName = $input['QueueName'] ?? null;
+        $this->Attributes = $input['Attributes'] ?? null;
+        $this->tags = $input['tags'] ?? null;
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getAttributes(): ?array
+    {
+        return $this->Attributes;
+    }
+
+    public function getQueueName(): ?string
+    {
+        return $this->QueueName;
+    }
+
+    public function gettags(): ?array
+    {
+        return $this->tags;
+    }
+
+    public function requestBody(): array
+    {
+        $payload = ['Action' => 'CreateQueue', 'Version' => '2012-11-05'];
+        if (null !== $this->QueueName) {
+            $payload['QueueName'] = $this->QueueName;
+        }
+        if (null !== $this->Attributes) {
+            $payload['Attribute'] = $this->Attributes;
+        }
+        if (null !== $this->tags) {
+            $payload['Tag'] = $this->tags;
+        }
+
+        return $payload;
+    }
+
+    public function requestHeaders(): array
+    {
+        $headers = [];
+
+        return $headers;
+    }
+
+    public function requestQuery(): array
+    {
+        $query = [];
+
+        return $query;
+    }
+
+    public function requestUri(): string
+    {
+        return '/';
+    }
+
+    public function setAttributes(?array $value): self
+    {
+        $this->Attributes = $value;
+
+        return $this;
+    }
+
+    public function setQueueName(?string $value): self
+    {
+        $this->QueueName = $value;
+
+        return $this;
+    }
+
+    public function settags(?array $value): self
+    {
+        $this->tags = $value;
+
+        return $this;
+    }
+
+    public function validate(): void
+    {
+        foreach (['QueueName'] as $name) {
+            if (null === $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+        }
+    }
+}

--- a/src/Sqs/Input/DeleteQueueRequest.php
+++ b/src/Sqs/Input/DeleteQueueRequest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace AsyncAws\Sqs\Input;
+
+use AsyncAws\Core\Exception\InvalidArgument;
+
+class DeleteQueueRequest
+{
+    /**
+     * The URL of the Amazon SQS queue to delete.
+     *
+     * @required
+     *
+     * @var string|null
+     */
+    private $QueueUrl;
+
+    /**
+     * @param array{
+     *   QueueUrl: string,
+     * } $input
+     */
+    public function __construct(array $input)
+    {
+        $this->QueueUrl = $input['QueueUrl'] ?? null;
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getQueueUrl(): ?string
+    {
+        return $this->QueueUrl;
+    }
+
+    public function requestBody(): array
+    {
+        $payload = ['Action' => 'DeleteQueue', 'Version' => '2012-11-05'];
+        if (null !== $this->QueueUrl) {
+            $payload['QueueUrl'] = $this->QueueUrl;
+        }
+
+        return $payload;
+    }
+
+    public function requestHeaders(): array
+    {
+        $headers = [];
+
+        return $headers;
+    }
+
+    public function requestQuery(): array
+    {
+        $query = [];
+
+        return $query;
+    }
+
+    public function requestUri(): string
+    {
+        return '/';
+    }
+
+    public function setQueueUrl(?string $value): self
+    {
+        $this->QueueUrl = $value;
+
+        return $this;
+    }
+
+    public function validate(): void
+    {
+        foreach (['QueueUrl'] as $name) {
+            if (null === $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+        }
+    }
+}

--- a/src/Sqs/Input/GetQueueAttributesRequest.php
+++ b/src/Sqs/Input/GetQueueAttributesRequest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace AsyncAws\Sqs\Input;
+
+use AsyncAws\Core\Exception\InvalidArgument;
+
+class GetQueueAttributesRequest
+{
+    /**
+     * The URL of the Amazon SQS queue whose attribute information is retrieved.
+     *
+     * @required
+     *
+     * @var string|null
+     */
+    private $QueueUrl;
+
+    /**
+     * A list of attributes for which to retrieve information.
+     *
+     * @var string[]
+     */
+    private $AttributeNames;
+
+    /**
+     * @param array{
+     *   QueueUrl: string,
+     *   AttributeNames?: string[],
+     * } $input
+     */
+    public function __construct(array $input)
+    {
+        $this->QueueUrl = $input['QueueUrl'] ?? null;
+        $this->AttributeNames = $input['AttributeNames'] ?? [];
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getAttributeNames(): array
+    {
+        return $this->AttributeNames;
+    }
+
+    public function getQueueUrl(): ?string
+    {
+        return $this->QueueUrl;
+    }
+
+    public function requestBody(): array
+    {
+        $payload = ['Action' => 'GetQueueAttributes', 'Version' => '2012-11-05'];
+        if (null !== $this->QueueUrl) {
+            $payload['QueueUrl'] = $this->QueueUrl;
+        }
+        if (null !== $this->AttributeNames) {
+            $payload['AttributeNames'] = $this->AttributeNames;
+        }
+
+        return $payload;
+    }
+
+    public function requestHeaders(): array
+    {
+        $headers = [];
+
+        return $headers;
+    }
+
+    public function requestQuery(): array
+    {
+        $query = [];
+
+        return $query;
+    }
+
+    public function requestUri(): string
+    {
+        return '/';
+    }
+
+    public function setAttributeNames(array $value): self
+    {
+        $this->AttributeNames = $value;
+
+        return $this;
+    }
+
+    public function setQueueUrl(?string $value): self
+    {
+        $this->QueueUrl = $value;
+
+        return $this;
+    }
+
+    public function validate(): void
+    {
+        foreach (['QueueUrl'] as $name) {
+            if (null === $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+        }
+    }
+}

--- a/src/Sqs/Input/GetQueueUrlRequest.php
+++ b/src/Sqs/Input/GetQueueUrlRequest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace AsyncAws\Sqs\Input;
+
+use AsyncAws\Core\Exception\InvalidArgument;
+
+class GetQueueUrlRequest
+{
+    /**
+     * The name of the queue whose URL must be fetched. Maximum 80 characters. Valid values: alphanumeric characters,
+     * hyphens (`-`), and underscores (`_`).
+     *
+     * @required
+     *
+     * @var string|null
+     */
+    private $QueueName;
+
+    /**
+     * The AWS account ID of the account that created the queue.
+     *
+     * @var string|null
+     */
+    private $QueueOwnerAWSAccountId;
+
+    /**
+     * @param array{
+     *   QueueName: string,
+     *   QueueOwnerAWSAccountId?: string,
+     * } $input
+     */
+    public function __construct(array $input)
+    {
+        $this->QueueName = $input['QueueName'] ?? null;
+        $this->QueueOwnerAWSAccountId = $input['QueueOwnerAWSAccountId'] ?? null;
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getQueueName(): ?string
+    {
+        return $this->QueueName;
+    }
+
+    public function getQueueOwnerAWSAccountId(): ?string
+    {
+        return $this->QueueOwnerAWSAccountId;
+    }
+
+    public function requestBody(): array
+    {
+        $payload = ['Action' => 'GetQueueUrl', 'Version' => '2012-11-05'];
+        if (null !== $this->QueueName) {
+            $payload['QueueName'] = $this->QueueName;
+        }
+        if (null !== $this->QueueOwnerAWSAccountId) {
+            $payload['QueueOwnerAWSAccountId'] = $this->QueueOwnerAWSAccountId;
+        }
+
+        return $payload;
+    }
+
+    public function requestHeaders(): array
+    {
+        $headers = [];
+
+        return $headers;
+    }
+
+    public function requestQuery(): array
+    {
+        $query = [];
+
+        return $query;
+    }
+
+    public function requestUri(): string
+    {
+        return '/';
+    }
+
+    public function setQueueName(?string $value): self
+    {
+        $this->QueueName = $value;
+
+        return $this;
+    }
+
+    public function setQueueOwnerAWSAccountId(?string $value): self
+    {
+        $this->QueueOwnerAWSAccountId = $value;
+
+        return $this;
+    }
+
+    public function validate(): void
+    {
+        foreach (['QueueName'] as $name) {
+            if (null === $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+        }
+    }
+}

--- a/src/Sqs/Input/ListQueuesRequest.php
+++ b/src/Sqs/Input/ListQueuesRequest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace AsyncAws\Sqs\Input;
+
+class ListQueuesRequest
+{
+    /**
+     * A string to use for filtering the list results. Only those queues whose name begins with the specified string are
+     * returned.
+     *
+     * @var string|null
+     */
+    private $QueueNamePrefix;
+
+    /**
+     * @param array{
+     *   QueueNamePrefix?: string,
+     * } $input
+     */
+    public function __construct(array $input = [])
+    {
+        $this->QueueNamePrefix = $input['QueueNamePrefix'] ?? null;
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getQueueNamePrefix(): ?string
+    {
+        return $this->QueueNamePrefix;
+    }
+
+    public function requestBody(): array
+    {
+        $payload = ['Action' => 'ListQueues', 'Version' => '2012-11-05'];
+        if (null !== $this->QueueNamePrefix) {
+            $payload['QueueNamePrefix'] = $this->QueueNamePrefix;
+        }
+
+        return $payload;
+    }
+
+    public function requestHeaders(): array
+    {
+        $headers = [];
+
+        return $headers;
+    }
+
+    public function requestQuery(): array
+    {
+        $query = [];
+
+        return $query;
+    }
+
+    public function requestUri(): string
+    {
+        return '/';
+    }
+
+    public function setQueueNamePrefix(?string $value): self
+    {
+        $this->QueueNamePrefix = $value;
+
+        return $this;
+    }
+
+    public function validate(): void
+    {
+        // There are no required properties
+    }
+}

--- a/src/Sqs/Input/PurgeQueueRequest.php
+++ b/src/Sqs/Input/PurgeQueueRequest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace AsyncAws\Sqs\Input;
+
+use AsyncAws\Core\Exception\InvalidArgument;
+
+class PurgeQueueRequest
+{
+    /**
+     * The URL of the queue from which the `PurgeQueue` action deletes messages.
+     *
+     * @required
+     *
+     * @var string|null
+     */
+    private $QueueUrl;
+
+    /**
+     * @param array{
+     *   QueueUrl: string,
+     * } $input
+     */
+    public function __construct(array $input)
+    {
+        $this->QueueUrl = $input['QueueUrl'] ?? null;
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getQueueUrl(): ?string
+    {
+        return $this->QueueUrl;
+    }
+
+    public function requestBody(): array
+    {
+        $payload = ['Action' => 'PurgeQueue', 'Version' => '2012-11-05'];
+        if (null !== $this->QueueUrl) {
+            $payload['QueueUrl'] = $this->QueueUrl;
+        }
+
+        return $payload;
+    }
+
+    public function requestHeaders(): array
+    {
+        $headers = [];
+
+        return $headers;
+    }
+
+    public function requestQuery(): array
+    {
+        $query = [];
+
+        return $query;
+    }
+
+    public function requestUri(): string
+    {
+        return '/';
+    }
+
+    public function setQueueUrl(?string $value): self
+    {
+        $this->QueueUrl = $value;
+
+        return $this;
+    }
+
+    public function validate(): void
+    {
+        foreach (['QueueUrl'] as $name) {
+            if (null === $this->$name) {
+                throw new InvalidArgument(sprintf('Missing parameter "%s" when validating the "%s". The value cannot be null.', $name, __CLASS__));
+            }
+        }
+    }
+}

--- a/src/Sqs/Result/CreateQueueResult.php
+++ b/src/Sqs/Result/CreateQueueResult.php
@@ -6,10 +6,10 @@ use AsyncAws\Core\Result;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
-class GetQueueUrlResult extends Result
+class CreateQueueResult extends Result
 {
     /**
-     * The URL of the queue.
+     * The URL of the created Amazon SQS queue.
      */
     private $QueueUrl;
 
@@ -23,7 +23,7 @@ class GetQueueUrlResult extends Result
     protected function populateResult(ResponseInterface $response, ?HttpClientInterface $httpClient): void
     {
         $data = new \SimpleXMLElement($response->getContent(false));
-        $data = $data->GetQueueUrlResult;
+        $data = $data->CreateQueueResult;
 
         $this->QueueUrl = $this->xmlValueOrNull($data->QueueUrl, 'string');
     }

--- a/src/Sqs/Result/GetQueueAttributesResult.php
+++ b/src/Sqs/Result/GetQueueAttributesResult.php
@@ -6,25 +6,25 @@ use AsyncAws\Core\Result;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
-class GetQueueUrlResult extends Result
+class GetQueueAttributesResult extends Result
 {
     /**
-     * The URL of the queue.
+     * A map of attributes to their respective values.
      */
-    private $QueueUrl;
+    private $Attributes;
 
-    public function getQueueUrl(): ?string
+    public function getAttributes(): array
     {
         $this->initialize();
 
-        return $this->QueueUrl;
+        return $this->Attributes;
     }
 
     protected function populateResult(ResponseInterface $response, ?HttpClientInterface $httpClient): void
     {
         $data = new \SimpleXMLElement($response->getContent(false));
-        $data = $data->GetQueueUrlResult;
+        $data = $data->GetQueueAttributesResult;
 
-        $this->QueueUrl = $this->xmlValueOrNull($data->QueueUrl, 'string');
+        $this->Attributes = $this->xmlValueOrNull($data->Attributes, 'array');
     }
 }

--- a/src/Sqs/Result/ListQueuesResult.php
+++ b/src/Sqs/Result/ListQueuesResult.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace AsyncAws\Sqs\Result;
+
+use AsyncAws\Core\Result;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class ListQueuesResult extends Result implements \IteratorAggregate
+{
+    /**
+     * A list of queue URLs, up to 1,000 entries.
+     */
+    private $QueueUrls = [];
+
+    /**
+     * Iterates over QueueUrls.
+     *
+     * @return \Traversable<string>
+     */
+    public function getIterator(): \Traversable
+    {
+        $this->initialize();
+
+        while (true) {
+            yield from $this->QueueUrls;
+
+            // TODO load next results
+            break;
+        }
+    }
+
+    /**
+     * @param bool $currentPageOnly When true, iterates over items of the current page. Otherwise also fetch items in the next pages.
+     *
+     * @return iterable<string>
+     */
+    public function getQueueUrls(bool $currentPageOnly = false): iterable
+    {
+        $this->initialize();
+
+        if ($currentPageOnly) {
+            return $this->QueueUrls;
+        }
+        while (true) {
+            yield from $this->QueueUrls;
+
+            // TODO load next results
+            break;
+        }
+    }
+
+    protected function populateResult(ResponseInterface $response, ?HttpClientInterface $httpClient): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        $data = $data->ListQueuesResult;
+
+        $this->QueueUrls = [];
+        foreach ($data->QueueUrl as $item) {
+            $this->QueueUrls[] = $this->xmlValueOrNull($item, 'string');
+        }
+    }
+}

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -4,12 +4,79 @@ namespace AsyncAws\Sqs;
 
 use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\Result;
+use AsyncAws\Sqs\Input\ChangeMessageVisibilityRequest;
+use AsyncAws\Sqs\Input\CreateQueueRequest;
 use AsyncAws\Sqs\Input\DeleteMessageRequest;
+use AsyncAws\Sqs\Input\DeleteQueueRequest;
+use AsyncAws\Sqs\Input\GetQueueAttributesRequest;
+use AsyncAws\Sqs\Input\GetQueueUrlRequest;
+use AsyncAws\Sqs\Input\ListQueuesRequest;
+use AsyncAws\Sqs\Input\PurgeQueueRequest;
 use AsyncAws\Sqs\Input\SendMessageRequest;
+use AsyncAws\Sqs\Result\CreateQueueResult;
+use AsyncAws\Sqs\Result\GetQueueAttributesResult;
+use AsyncAws\Sqs\Result\GetQueueUrlResult;
+use AsyncAws\Sqs\Result\ListQueuesResult;
 use AsyncAws\Sqs\Result\SendMessageResult;
 
 class SqsClient extends AbstractApi
 {
+    /**
+     * Changes the visibility timeout of a specified message in a queue to a new value. The default visibility timeout for a
+     * message is 30 seconds. The minimum is 0 seconds. The maximum is 12 hours. For more information, see Visibility
+     * Timeout in the *Amazon Simple Queue Service Developer Guide*.
+     *
+     * @see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-visibility-timeout.html
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-sqs-2012-11-05.html#changemessagevisibility
+     *
+     * @param array{
+     *   QueueUrl: string,
+     *   ReceiptHandle: string,
+     *   VisibilityTimeout: int,
+     * }|ChangeMessageVisibilityRequest $input
+     */
+    public function changeMessageVisibility($input): Result
+    {
+        $input = ChangeMessageVisibilityRequest::create($input);
+        $input->validate();
+
+        $response = $this->getResponse(
+            'POST',
+            $input->requestBody(),
+            $input->requestHeaders(),
+            $this->getEndpoint($input->requestUri(), $input->requestQuery())
+        );
+
+        return new Result($response);
+    }
+
+    /**
+     * Creates a new standard or FIFO queue. You can pass one or more attributes in the request. Keep the following caveats
+     * in mind:.
+     *
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-sqs-2012-11-05.html#createqueue
+     *
+     * @param array{
+     *   QueueName: string,
+     *   Attributes?: array,
+     *   tags?: array,
+     * }|CreateQueueRequest $input
+     */
+    public function createQueue($input): CreateQueueResult
+    {
+        $input = CreateQueueRequest::create($input);
+        $input->validate();
+
+        $response = $this->getResponse(
+            'POST',
+            $input->requestBody(),
+            $input->requestHeaders(),
+            $this->getEndpoint($input->requestUri(), $input->requestQuery())
+        );
+
+        return new CreateQueueResult($response);
+    }
+
     /**
      * Deletes the specified message from the specified queue. To select the message to delete, use the `ReceiptHandle` of
      * the message (*not* the `MessageId` which you receive when you send the message). Amazon SQS can delete a message from
@@ -26,6 +93,130 @@ class SqsClient extends AbstractApi
     public function deleteMessage($input): Result
     {
         $input = DeleteMessageRequest::create($input);
+        $input->validate();
+
+        $response = $this->getResponse(
+            'POST',
+            $input->requestBody(),
+            $input->requestHeaders(),
+            $this->getEndpoint($input->requestUri(), $input->requestQuery())
+        );
+
+        return new Result($response);
+    }
+
+    /**
+     * Deletes the queue specified by the `QueueUrl`, regardless of the queue's contents. If the specified queue doesn't
+     * exist, Amazon SQS returns a successful response.
+     *
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-sqs-2012-11-05.html#deletequeue
+     *
+     * @param array{
+     *   QueueUrl: string,
+     * }|DeleteQueueRequest $input
+     */
+    public function deleteQueue($input): Result
+    {
+        $input = DeleteQueueRequest::create($input);
+        $input->validate();
+
+        $response = $this->getResponse(
+            'POST',
+            $input->requestBody(),
+            $input->requestHeaders(),
+            $this->getEndpoint($input->requestUri(), $input->requestQuery())
+        );
+
+        return new Result($response);
+    }
+
+    /**
+     * Gets attributes for the specified queue.
+     *
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-sqs-2012-11-05.html#getqueueattributes
+     *
+     * @param array{
+     *   QueueUrl: string,
+     *   AttributeNames?: string[],
+     * }|GetQueueAttributesRequest $input
+     */
+    public function getQueueAttributes($input): GetQueueAttributesResult
+    {
+        $input = GetQueueAttributesRequest::create($input);
+        $input->validate();
+
+        $response = $this->getResponse(
+            'POST',
+            $input->requestBody(),
+            $input->requestHeaders(),
+            $this->getEndpoint($input->requestUri(), $input->requestQuery())
+        );
+
+        return new GetQueueAttributesResult($response);
+    }
+
+    /**
+     * Returns the URL of an existing Amazon SQS queue.
+     *
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-sqs-2012-11-05.html#getqueueurl
+     *
+     * @param array{
+     *   QueueName: string,
+     *   QueueOwnerAWSAccountId?: string,
+     * }|GetQueueUrlRequest $input
+     */
+    public function getQueueUrl($input): GetQueueUrlResult
+    {
+        $input = GetQueueUrlRequest::create($input);
+        $input->validate();
+
+        $response = $this->getResponse(
+            'POST',
+            $input->requestBody(),
+            $input->requestHeaders(),
+            $this->getEndpoint($input->requestUri(), $input->requestQuery())
+        );
+
+        return new GetQueueUrlResult($response);
+    }
+
+    /**
+     * Returns a list of your queues. The maximum number of queues that can be returned is 1,000. If you specify a value for
+     * the optional `QueueNamePrefix` parameter, only queues with a name that begins with the specified value are returned.
+     *
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-sqs-2012-11-05.html#listqueues
+     *
+     * @param array{
+     *   QueueNamePrefix?: string,
+     * }|ListQueuesRequest $input
+     */
+    public function listQueues($input = []): ListQueuesResult
+    {
+        $input = ListQueuesRequest::create($input);
+        $input->validate();
+
+        $response = $this->getResponse(
+            'POST',
+            $input->requestBody(),
+            $input->requestHeaders(),
+            $this->getEndpoint($input->requestUri(), $input->requestQuery())
+        );
+
+        return new ListQueuesResult($response);
+    }
+
+    /**
+     * Deletes the messages in a queue specified by the `QueueURL` parameter.
+     *
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-sqs-2012-11-05.html#purgequeue
+     *
+     * @param array{
+     *   QueueUrl: string,
+     * }|PurgeQueueRequest $input
+     */
+    public function purgeQueue($input): Result
+    {
+        $input = PurgeQueueRequest::create($input);
         $input->validate();
 
         $response = $this->getResponse(


### PR DESCRIPTION
Most of those operation are needed for a client like `symfony/messenger`
* SendMessage
* DeleteMessage
* ChangeMessageVisibility
* GetQueueUrl
* GetQueueAttributes
* CreateQueue

I also added those methods that could be usefull for testing or managing the broker
* DeleteQueue
* ListQueues
* PurgeQueue

Missing operation (ApiGeneartor fails to generate it... PR in progress)
* ReceiveMessage 