### PR TITLE
Adding failing tests for S3Client::DeleteObjects

### DIFF
--- a/src/S3/Tests/Integration/S3ClientTest.php
+++ b/src/S3/Tests/Integration/S3ClientTest.php
@@ -110,4 +110,18 @@ class S3ClientTest extends TestCase
         self::assertContains('list/prefix-1/', $prefixes);
         self::assertContains('list/content-2', $files);
     }
+
+    public function testDeleteObjects()
+    {
+        $s3 = $this->getClient();
+        $bucket = 'foo';
+
+        $result = $s3->deleteObjects([
+            'Bucket' => $bucket,
+            'Delete' => ['Objects' => [['Key' => 'foo/bar.txt'], ['Key' => 'foo/bix/xx.txt']]],
+        ]);
+
+        $info = $result->info();
+        self::assertEquals(204, $info['status']);
+    }
 }


### PR DESCRIPTION
This is related to #121 (I think). It is an authentication issue. 