### PR TITLE
Fix credentials use with custom endpoint

### DIFF
--- a/src/Core/AbstractApi.php
+++ b/src/Core/AbstractApi.php
@@ -67,11 +67,18 @@ abstract class AbstractApi
         $this->httpClient = $httpClient ?? HttpClient::create();
         $this->logger = $logger ?? new NullLogger();
         $this->configuration = $configuration;
-        $this->credentialProvider = $credentialProvider ?? new CacheProvider(new ChainProvider([
-            new ConfigurationProvider(),
-            new IniFileProvider($this->logger),
-            new InstanceProvider($this->httpClient, $this->logger),
-        ]));
+        if ($configuration->isDefault(Configuration::OPTION_ENDPOINT)) {
+            $this->credentialProvider = $credentialProvider ?? new CacheProvider(new ChainProvider([
+                new ConfigurationProvider(),
+                new IniFileProvider($this->logger),
+                new InstanceProvider($this->httpClient, $this->logger),
+            ]));
+        } else {
+            $this->credentialProvider = $credentialProvider ?? new CacheProvider(new ChainProvider([
+                new ConfigurationProvider(),
+                new IniFileProvider($this->logger),
+            ]));
+        }
     }
 
     /**

--- a/src/Core/Configuration.php
+++ b/src/Core/Configuration.php
@@ -97,4 +97,13 @@ class Configuration
 
         return isset($this->data[$name]);
     }
+
+    public function isDefault(string $name): bool
+    {
+        if (!isset(self::AVAILABLE_OPTIONS[$name])) {
+            throw new InvalidArgument(\sprintf('Invalid option "%s" passed to "%s::%s". ', $name, __CLASS__, __METHOD__));
+        }
+
+        return isset($this->data[$name], self::DEFAULT_OPTIONS[$name]) && $this->data[$name] === self::DEFAULT_OPTIONS[$name];
+    }
 }

--- a/src/Core/Credentials/CacheProvider.php
+++ b/src/Core/Credentials/CacheProvider.php
@@ -31,7 +31,7 @@ class CacheProvider implements CredentialProvider, ResetInterface
     public function getCredentials(Configuration $configuration): ?Credentials
     {
         $key = \spl_object_hash($configuration);
-        if (!isset($this->cache[$key]) || (null !== $this->cache[$key] && $this->cache[$key]->isExpired())) {
+        if (!\array_key_exists($key, $this->cache) || (null !== $this->cache[$key] && $this->cache[$key]->isExpired())) {
             $this->cache[$key] = $this->decorated->getCredentials($configuration);
         }
 

--- a/src/Core/Credentials/ChainProvider.php
+++ b/src/Core/Credentials/ChainProvider.php
@@ -20,7 +20,7 @@ class ChainProvider implements CredentialProvider, ResetInterface
     private $providers;
 
     /**
-     * @var CredentialProvider[]
+     * @var (CredentialProvider|null)[]
      */
     private $lastSuccessfulProvider = [];
 
@@ -35,8 +35,12 @@ class ChainProvider implements CredentialProvider, ResetInterface
     public function getCredentials(Configuration $configuration): ?Credentials
     {
         $key = \spl_object_hash($configuration);
-        if (isset($this->lastSuccessfulProvider[$key])) {
-            return $this->lastSuccessfulProvider[$key]->getCredentials($configuration);
+        if (\array_key_exists($key, $this->lastSuccessfulProvider)) {
+            if (null === $provider = $this->lastSuccessfulProvider[$key]) {
+                return null;
+            }
+
+            return $provider->getCredentials($configuration);
         }
 
         foreach ($this->providers as $provider) {
@@ -46,6 +50,8 @@ class ChainProvider implements CredentialProvider, ResetInterface
                 return $credentials;
             }
         }
+
+        $this->lastSuccessfulProvider[$key] = null;
 
         return null;
     }


### PR DESCRIPTION
This PR fixes 2 things:
- caching "null" credentials to avoid calling providers again and again
- do not use InstanceProvider (AWS specific) when using a custom endpoint

This PR fixes slow tests on CI (because no credentials in config nor .ini file, it always try to call "AWS API" to get instance's credentials) 