### PR TITLE
Remove dupplicate php-cs-fixer in CI test

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -68,9 +68,6 @@ jobs:
       run: |
         ./generate --all
 
-    - name: Fix cs
-      uses: docker://oskarstark/php-cs-fixer-ga
-
     - name: Assert up-to-date
       run: |
         if [ -n "$(git status src --porcelain)" ]; then


### PR DESCRIPTION
The php-cs-fixer is now embeded in generate command. No need to run it after﻿
