### PR TITLE
Call resolve on __destruct to ensure proper exception

### DIFF
--- a/src/Core/Result.php
+++ b/src/Core/Result.php
@@ -58,7 +58,7 @@ class Result
      */
     final public function resolve(?float $timeout = null): bool
     {
-        if (null === $this->response) {
+        if (!isset($this->response)) {
             return true;
         }
 
@@ -113,7 +113,7 @@ class Result
 
     final public function cancel(): void
     {
-        if (null === $this->response) {
+        if (!isset($this->response)) {
             return;
         }
 

--- a/src/Core/Sts/Result/AssumeRoleResponse.php
+++ b/src/Core/Sts/Result/AssumeRoleResponse.php
@@ -29,6 +29,14 @@ class AssumeRoleResponse extends Result
      */
     private $PackedPolicySize;
 
+    /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
     public function getAssumedRoleUser(): ?AssumedRoleUser
     {
         $this->initialize();

--- a/src/Core/Sts/Result/GetCallerIdentityResponse.php
+++ b/src/Core/Sts/Result/GetCallerIdentityResponse.php
@@ -27,6 +27,14 @@ class GetCallerIdentityResponse extends Result
      */
     private $Arn;
 
+    /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
     public function getAccount(): ?string
     {
         $this->initialize();

--- a/src/S3/Result/CopyObjectOutput.php
+++ b/src/S3/Result/CopyObjectOutput.php
@@ -59,6 +59,14 @@ class CopyObjectOutput extends Result
 
     private $RequestCharged;
 
+    /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
     public function getCopyObjectResult(): ?CopyObjectResult
     {
         $this->initialize();

--- a/src/S3/Result/CreateBucketOutput.php
+++ b/src/S3/Result/CreateBucketOutput.php
@@ -14,6 +14,14 @@ class CreateBucketOutput extends Result
      */
     private $Location;
 
+    /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
     public function getLocation(): ?string
     {
         $this->initialize();

--- a/src/S3/Result/DeleteObjectOutput.php
+++ b/src/S3/Result/DeleteObjectOutput.php
@@ -20,6 +20,14 @@ class DeleteObjectOutput extends Result
 
     private $RequestCharged;
 
+    /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
     public function getDeleteMarker(): ?bool
     {
         $this->initialize();

--- a/src/S3/Result/DeleteObjectsOutput.php
+++ b/src/S3/Result/DeleteObjectsOutput.php
@@ -22,6 +22,14 @@ class DeleteObjectsOutput extends Result
     private $Errors = [];
 
     /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
+    /**
      * @return DeletedObject[]
      */
     public function getDeleted(): array

--- a/src/S3/Result/GetObjectAclOutput.php
+++ b/src/S3/Result/GetObjectAclOutput.php
@@ -21,6 +21,14 @@ class GetObjectAclOutput extends Result
     private $RequestCharged;
 
     /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
+    /**
      * @return Grant[]
      */
     public function getGrants(): array

--- a/src/S3/Result/GetObjectOutput.php
+++ b/src/S3/Result/GetObjectOutput.php
@@ -175,6 +175,14 @@ class GetObjectOutput extends Result
      */
     private $ObjectLockLegalHoldStatus;
 
+    /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
     public function getAcceptRanges(): ?string
     {
         $this->initialize();

--- a/src/S3/Result/HeadObjectOutput.php
+++ b/src/S3/Result/HeadObjectOutput.php
@@ -168,6 +168,14 @@ class HeadObjectOutput extends Result
      */
     private $ObjectLockLegalHoldStatus;
 
+    /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
     public function getAcceptRanges(): ?string
     {
         $this->initialize();

--- a/src/S3/Result/ListObjectsV2Output.php
+++ b/src/S3/Result/ListObjectsV2Output.php
@@ -82,11 +82,16 @@ class ListObjectsV2Output extends Result implements \IteratorAggregate
      */
     private $prefetch = [];
 
+    /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
     public function __destruct()
     {
         while (!empty($this->prefetch)) {
             array_shift($this->prefetch)->cancel();
         }
+
+        $this->resolve();
     }
 
     /**

--- a/src/S3/Result/PutObjectAclOutput.php
+++ b/src/S3/Result/PutObjectAclOutput.php
@@ -10,6 +10,14 @@ class PutObjectAclOutput extends Result
 {
     private $RequestCharged;
 
+    /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
     public function getRequestCharged(): ?string
     {
         $this->initialize();

--- a/src/S3/Result/PutObjectOutput.php
+++ b/src/S3/Result/PutObjectOutput.php
@@ -58,6 +58,14 @@ class PutObjectOutput extends Result
 
     private $RequestCharged;
 
+    /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
     public function getETag(): ?string
     {
         $this->initialize();

--- a/src/Ses/Result/SendEmailResponse.php
+++ b/src/Ses/Result/SendEmailResponse.php
@@ -13,6 +13,14 @@ class SendEmailResponse extends Result
      */
     private $MessageId;
 
+    /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
     public function getMessageId(): ?string
     {
         $this->initialize();

--- a/src/Sqs/Result/CreateQueueResult.php
+++ b/src/Sqs/Result/CreateQueueResult.php
@@ -13,6 +13,14 @@ class CreateQueueResult extends Result
      */
     private $QueueUrl;
 
+    /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
     public function getQueueUrl(): ?string
     {
         $this->initialize();

--- a/src/Sqs/Result/GetQueueAttributesResult.php
+++ b/src/Sqs/Result/GetQueueAttributesResult.php
@@ -13,6 +13,14 @@ class GetQueueAttributesResult extends Result
      */
     private $Attributes = [];
 
+    /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
     public function getAttributes(): array
     {
         $this->initialize();

--- a/src/Sqs/Result/GetQueueUrlResult.php
+++ b/src/Sqs/Result/GetQueueUrlResult.php
@@ -13,6 +13,14 @@ class GetQueueUrlResult extends Result
      */
     private $QueueUrl;
 
+    /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
     public function getQueueUrl(): ?string
     {
         $this->initialize();

--- a/src/Sqs/Result/ListQueuesResult.php
+++ b/src/Sqs/Result/ListQueuesResult.php
@@ -14,6 +14,14 @@ class ListQueuesResult extends Result implements \IteratorAggregate
     private $QueueUrls = [];
 
     /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
+    /**
      * Iterates over QueueUrls.
      *
      * @return \Traversable<string>

--- a/src/Sqs/Result/ReceiveMessageResult.php
+++ b/src/Sqs/Result/ReceiveMessageResult.php
@@ -14,6 +14,14 @@ class ReceiveMessageResult extends Result
     private $Messages = [];
 
     /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
+    /**
      * @return Message[]
      */
     public function getMessages(): array

--- a/src/Sqs/Result/SendMessageResult.php
+++ b/src/Sqs/Result/SendMessageResult.php
@@ -45,6 +45,14 @@ class SendMessageResult extends Result
      */
     private $SequenceNumber;
 
+    /**
+     * Ensure current request is resolved and right exception is thrown.
+     */
+    public function __destruct()
+    {
+        $this->resolve();
+    }
+
     public function getMD5OfMessageAttributes(): ?string
     {
         $this->initialize();


### PR DESCRIPTION
When user don't wait for the request to be resolved, and the object is unset, the HttpClient (by dsign) finish the current request and throws exception if the request is unsucccesffull.

The issue, is, that the exception is not wrapped with our own exception. This PR called `resolve` on destruct to let the request finish and maybe thrown our exceptions

before
```
PHP Fatal error:  Uncaught Symfony\Component\HttpClient\Exception\ClientException: HTTP/1.1 400 Bad Request returned for "https://sqs.eu-west-1.amazonaws.com/". in /data/oss/test-aws/vendor/symfony/http-client/Response/ResponseTrait.php:284             
Stack trace:
#0 /data/oss/test-aws/vendor/symfony/http-client/Response/ResponseTrait.php(301): Symfony\Component\HttpClient\Response\CurlResponse->checkStatusCode()                                                                                                      
#1 /data/oss/test-aws/vendor/symfony/http-client/Response/CurlResponse.php(179): Symfony\Component\HttpClient\Response\CurlResponse->doDestruct()                                                                                                            
#2 /data/oss/test-aws/test.php(49): Symfony\Component\HttpClient\Response\CurlResponse->__destruct()
#3 {main}
  thrown in /data/oss/test-aws/vendor/symfony/http-client/Response/ResponseTrait.php on line 284
* Closing connection 0

```

after
```
PHP Fatal error:  Uncaught AsyncAws\Core\Exception\Http\ClientException: HTTP/1.1 400 Bad Request returned for "https://sqs.eu-west-1.amazonaws.com/".                                                                                                       

Code:    AWS.SimpleQueueService.NonExistentQueue
Message: The specified queue does not exist for this wsdl version.
Type:    Sender
Detail:
 in /data/oss/aws/src/Core/Result.php:80
Stack trace:
#0 /data/oss/aws/src/Sqs/Result/GetQueueUrlResult.php(21): AsyncAws\Core\Result->resolve()
#1 /data/oss/test-aws/test.php(49): AsyncAws\Sqs\Result\GetQueueUrlResult->__destruct()
#2 {main}
  thrown in /data/oss/aws/src/Core/Result.php on line 80

```