### PR TITLE
Implement waiters - async

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -91,6 +91,23 @@ foreach($result as $file) {
 }
 ```
 
+## Waiter
+
+Similar to Official AWS PHP SDK, Async-Aws provides waiters to let you wait
+until an long operation finished.
+
+```php
+// create a queue Async and don't wait for the response.
+$sqsClient->createQueue(['QueueName' => 'fooBar']);
+
+$waiter = $sqsClient->queueExists(['QueueName' => 'fooBar']);
+echo $waiter->isSuccess(); // false
+$waiter->wait();
+echo $waiter->isSuccess(); // true
+```
+
+[more information about waiters and hasers...](./docs/waiter.md)
+
 ## Organization
 
 | Repository | Namespace | Package name |

--- a/docs/waiter.md
+++ b/docs/waiter.md
@@ -1,0 +1,43 @@
+# Waiter and Haser
+
+Similar to Official AWS PHP SDK, Async-Aws provides waiters to let you wait
+until an long operation finished.
+
+To ease the development, the above code is wrapped in a helper called "waiter".
+
+```php
+// create a queue Async and don't wait for the response.
+$sqsClient->createQueue(['QueueName' => 'fooBar']);
+
+$waiter = $sqsClient->queueExists(['QueueName' => 'fooBar']);
+
+echo $waiter->isSuccess(); // false
+
+$waiter->wait();
+
+echo $waiter->isSuccess(); // true
+```
+
+A waiter provides methods that let you check the status of the operation.
+* `isSuccess()` returns true when operation is successful
+* `isFailure()` returns true when operation failed
+* `isPending()` returns true when the state of the operation is not yet determinate
+* `getState()` returns the state of the operation either `sucess`, `failure` or `pending`
+* `wait($timeout, $delay)` waits until the state of the operation is determinate.
+
+As usual, Async-Aws is async and not blocking by default:
+
+```php
+$waiter = $sqsClient->queueExists(['QueueName' => 'fooBar']);
+while(true) {
+    if ($waiter->wait(0)) {
+        // When method `wait` returns true, the state is resolved.
+        break;
+    }
+
+    // perform business logic
+    sleep(1);
+}
+
+echo $waiter->isSuccess();
+```

--- a/manifest.json
+++ b/manifest.json
@@ -4,6 +4,7 @@
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/s3\/2006-03-01\/api-2.json",
             "documentation": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/s3\/2006-03-01\/docs-2.json",
             "pagination": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/s3\/2006-03-01\/paginators-1.json",
+            "waiter": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/s3\/2006-03-01\/waiters-2.json",
             "methods": {
                 "PutObject": [],
                 "CreateBucket": [],
@@ -29,6 +30,7 @@
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sqs\/2012-11-05\/api-2.json",
             "documentation": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sqs\/2012-11-05\/docs-2.json",
             "pagination": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sqs\/2012-11-05\/paginators-1.json",
+            "waiter": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/3.133.6\/src\/data\/sqs\/2012-11-05\/waiters-2.json",
             "methods": {
                 "SendMessage": [],
                 "DeleteMessage": [],
@@ -39,7 +41,8 @@
                 "GetQueueAttributes": [],
                 "ListQueues": [],
                 "PurgeQueue": [],
-                "ReceiveMessage": []
+                "ReceiveMessage": [],
+                "QueueExists": []
             }
         },
         "Sts": {

--- a/src/CodeGenerator/Definition/ErrorWaiterAcceptor.php
+++ b/src/CodeGenerator/Definition/ErrorWaiterAcceptor.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\CodeGenerator\Definition;
+
+class ErrorWaiterAcceptor extends WaiterAcceptor
+{
+    public function getError(): ExceptionShape
+    {
+        return ($this->shapeLocator)($this->data['expected']);
+    }
+}

--- a/src/CodeGenerator/Definition/ExceptionShape.php
+++ b/src/CodeGenerator/Definition/ExceptionShape.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\CodeGenerator\Definition;
+
+class ExceptionShape extends Shape
+{
+    public function getCode(): ?string
+    {
+        return $this->data['error']['code'] ?? null;
+    }
+
+    public function getStatusCode(): ?int
+    {
+        return $this->data['error']['httpStatusCode'] ?? null;
+    }
+}

--- a/src/CodeGenerator/Definition/Operation.php
+++ b/src/CodeGenerator/Definition/Operation.php
@@ -12,6 +12,11 @@ class Operation
     private $data;
 
     /**
+     * @var ServiceDefinition
+     */
+    private $service;
+
+    /**
      * @var ?Pagination
      */
     private $pagination;
@@ -25,10 +30,11 @@ class Operation
     {
     }
 
-    public static function create(array $data, ?Pagination $pagination, \Closure $shapeLocator): self
+    public static function create(array $data, ServiceDefinition $service, ?Pagination $pagination, \Closure $shapeLocator): self
     {
         $operation = new self();
         $operation->data = $data;
+        $operation->service = $service;
         $operation->pagination = $pagination;
         $operation->shapeLocator = $shapeLocator;
 
@@ -38,6 +44,11 @@ class Operation
     public function getName(): string
     {
         return $this->data['name'];
+    }
+
+    public function getService(): ServiceDefinition
+    {
+        return $this->service;
     }
 
     public function getDocumentation(): ?string

--- a/src/CodeGenerator/Definition/Shape.php
+++ b/src/CodeGenerator/Definition/Shape.php
@@ -34,7 +34,7 @@ class Shape
     {
         switch ($data['type']) {
             case 'structure':
-                $shape = new StructureShape();
+                $shape = ($data['exception'] ?? false) ? new ExceptionShape() : new StructureShape();
 
                 break;
             case 'list':

--- a/src/CodeGenerator/Definition/Waiter.php
+++ b/src/CodeGenerator/Definition/Waiter.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\CodeGenerator\Definition;
+
+class Waiter
+{
+    /**
+     * @var array
+     */
+    private $data;
+
+    /**
+     * @var \Closure
+     */
+    private $operationLocator;
+
+    /**
+     * @var \Closure
+     */
+    private $shapeLocator;
+
+    public function __construct(array $data, \Closure $operationLocator, \Closure $shapeLocator)
+    {
+        $this->data = $data;
+        $this->operationLocator = $operationLocator;
+        $this->shapeLocator = $shapeLocator;
+    }
+
+    public function getName(): string
+    {
+        return $this->data['name'];
+    }
+
+    /**
+     * @return WaiterAcceptor[]
+     */
+    public function getAcceptors(): array
+    {
+        return \array_map(function (array $data) {
+            return WaiterAcceptor::create($data, $this->shapeLocator);
+        }, $this->data['acceptors']);
+    }
+
+    public function getDelay(): float
+    {
+        return (float) $this->data['delay'];
+    }
+
+    public function getMaxAttempts(): int
+    {
+        return $this->data['maxAttempts'];
+    }
+
+    public function getOperation(): Operation
+    {
+        if (!isset($this->data['operation'])) {
+            throw new \InvalidArgumentException('The operation is not defined.');
+        }
+
+        return ($this->operationLocator)($this->data['operation']);
+    }
+}

--- a/src/CodeGenerator/Definition/WaiterAcceptor.php
+++ b/src/CodeGenerator/Definition/WaiterAcceptor.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\CodeGenerator\Definition;
+
+class WaiterAcceptor
+{
+    public const MATCHER_STATUS = 'status';
+    public const MATCHER_ERROR = 'error';
+
+    public const STATE_SUCCESS = 'success';
+    public const STATE_RETRY = 'retry';
+    public const STATE_FAILURE = 'failure';
+
+    /**
+     * @var array
+     */
+    protected $data;
+
+    /**
+     * @var \Closure
+     */
+    protected $shapeLocator;
+
+    private function __construct()
+    {
+    }
+
+    public static function create(array $data, \Closure $shapeLocator): self
+    {
+        switch ($data['matcher']) {
+            case 'error':
+                $waiter = new ErrorWaiterAcceptor();
+
+                break;
+            default:
+                $waiter = new self();
+
+                break;
+        }
+
+        $waiter->data = $data;
+        $waiter->shapeLocator = $shapeLocator;
+
+        return $waiter;
+    }
+
+    public function getMatcher(): string
+    {
+        return $this->data['matcher'];
+    }
+
+    public function getExpected(): string
+    {
+        return (string) $this->data['expected'];
+    }
+
+    public function getState(): string
+    {
+        return $this->data['state'];
+    }
+}

--- a/src/CodeGenerator/Generator/ApiGenerator.php
+++ b/src/CodeGenerator/Generator/ApiGenerator.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Generator;
 
-use AsyncAws\CodeGenerator\Definition\ServiceDefinition;
 use AsyncAws\CodeGenerator\File\FileWriter;
 
 /**
@@ -24,14 +23,19 @@ class ApiGenerator
         $this->fileWriter = new FileWriter($srcDirectory);
     }
 
-    public function client(ServiceDefinition $definition): ClientGenerator
+    public function client(): ClientGenerator
     {
-        return new ClientGenerator($this->fileWriter, $definition);
+        return new ClientGenerator($this->fileWriter);
     }
 
-    public function operation(ServiceDefinition $definition): OperationGenerator
+    public function operation(): OperationGenerator
     {
-        return new OperationGenerator($this->fileWriter, $definition);
+        return new OperationGenerator($this->fileWriter);
+    }
+
+    public function waiter(): WaiterGenerator
+    {
+        return new WaiterGenerator($this->fileWriter);
     }
 
     public function result(): ResultGenerator

--- a/src/CodeGenerator/Generator/ClientGenerator.php
+++ b/src/CodeGenerator/Generator/ClientGenerator.php
@@ -22,37 +22,27 @@ class ClientGenerator
      */
     private $fileWriter;
 
-    /**
-     * All public classes take a definition as first parameter.
-     *
-     * @var ServiceDefinition
-     */
-    private $definition;
-
-    public function __construct(FileWriter $fileWriter, ServiceDefinition $definition)
+    public function __construct(FileWriter $fileWriter)
     {
         $this->fileWriter = $fileWriter;
-        $this->definition = $definition;
     }
 
     /**
      * Update the API client with a constants function call.
      */
-    public function generate(string $service, string $baseNamespace): void
+    public function generate(ServiceDefinition $definition, string $service, string $baseNamespace): void
     {
         $namespace = ClassFactory::fromExistingClass(\sprintf('%s\\%sClient', $baseNamespace, $service));
 
         $classes = $namespace->getClasses();
         $class = $classes[\array_key_first($classes)];
-        if (null !== $prefix = $this->definition->getEndpointPrefix()) {
-            $class->removeMethod('getServiceCode');
+        if (null !== $prefix = $definition->getEndpointPrefix()) {
             $class->addMethod('getServiceCode')
                 ->setReturnType('string')
                 ->setVisibility(ClassType::VISIBILITY_PROTECTED)
                 ->setBody("return '$prefix';");
         }
-        if (null !== $signatureVersion = $this->definition->getSignatureVersion()) {
-            $class->removeMethod('getSignatureVersion');
+        if (null !== $signatureVersion = $definition->getSignatureVersion()) {
             $class->addMethod('getSignatureVersion')
                 ->setReturnType('string')
                 ->setVisibility(ClassType::VISIBILITY_PROTECTED)

--- a/src/CodeGenerator/Generator/GeneratorHelper.php
+++ b/src/CodeGenerator/Generator/GeneratorHelper.php
@@ -68,9 +68,14 @@ class GeneratorHelper
         return $output;
     }
 
-    public static function addMethodComment(StructureShape $inputShape, string $baseNamespace, bool $allNullable = false, bool $inputSafe = false): array
+    public static function getParamDocblock(StructureShape $inputShape, string $baseNamespace, ?string $alternateClassName, bool $allNullable = false, bool $inputSafe = false): string
     {
-        $body = [];
+        if (empty($inputShape->getMembers())) {
+            // No input array
+            return '@param array' . ($alternateClassName ? '|' . $alternateClassName : '') . ' $input';
+        }
+
+        $body = ['@param array{'];
         foreach ($inputShape->getMembers() as $member) {
             $nullable = !$member->isRequired();
             $memberShape = $member->getShape();
@@ -104,8 +109,9 @@ class GeneratorHelper
                 $body[] = sprintf('  %s: %s,', $member->getName(), $param);
             }
         }
+        $body[] = '}' . ($alternateClassName ? '|' . $alternateClassName : '') . ' $input';
 
-        return $body;
+        return \implode("\n", $body);
     }
 
     public static function getFilterConstantFromType(string $type): ?string

--- a/src/CodeGenerator/Generator/MethodGeneratorTrait.php
+++ b/src/CodeGenerator/Generator/MethodGeneratorTrait.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\CodeGenerator\Generator;
+
+use AsyncAws\CodeGenerator\Definition\ListShape;
+use AsyncAws\CodeGenerator\Definition\MapShape;
+use AsyncAws\CodeGenerator\Definition\Operation;
+use AsyncAws\CodeGenerator\Definition\StructureMember;
+use AsyncAws\CodeGenerator\Definition\StructureShape;
+use AsyncAws\Core\Exception\InvalidArgument;
+use AsyncAws\Core\Result;
+use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\PhpNamespace;
+
+/**
+ * Generate API client methods and result classes.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal
+ */
+trait MethodGeneratorTrait
+{
+    /**
+     * @var XmlDumper
+     */
+    private $xmlDumper;
+
+    /**
+     * Generate classes for the input.
+     */
+    private function generateInputClass(string $service, Operation $operation, string $baseNamespace, StructureShape $inputShape, bool $root = false)
+    {
+        $members = $inputShape->getMembers();
+        $namespace = new PhpNamespace($baseNamespace);
+        $class = $namespace->addClass(GeneratorHelper::safeClassName($inputShape->getName()));
+
+        $constructorBody = '';
+        $requiredProperties = [];
+
+        foreach ($members as $member) {
+            $returnType = null;
+            $memberShape = $member->getShape();
+            $nullable = true;
+            if ($memberShape instanceof StructureShape) {
+                $this->generateInputClass($service, $operation, $baseNamespace, $memberShape);
+                $memberClassName = GeneratorHelper::safeClassName($memberShape->getName());
+                $returnType = $baseNamespace . '\\' . $memberClassName;
+                $parameterType = $memberShape->getName();
+                $constructorBody .= strtr('$this->NAME = isset($input["NAME"]) ? SAFE_CLASS::create($input["NAME"]) : null;' . "\n", ['NAME' => $member->getName(), 'SAFE_CLASS' => $memberClassName]);
+            } elseif ($memberShape instanceof ListShape) {
+                $listMemberShape = $memberShape->getMember()->getShape();
+                $nullable = false;
+
+                // Is this a list of objects?
+                if ($listMemberShape instanceof StructureShape) {
+                    $this->generateInputClass($service, $operation, $baseNamespace, $listMemberShape);
+                    $listMemberClassName = GeneratorHelper::safeClassName($listMemberShape->getName());
+
+                    $parameterType = $listMemberClassName . '[]';
+                    $returnType = $baseNamespace . '\\' . $listMemberClassName;
+                    $constructorBody .= strtr('$this->NAME = array_map(function($item) { return SAFE_CLASS::create($item); }, $input["NAME"] ?? []);' . "\n", ['NAME' => $member->getName(), 'SAFE_CLASS' => GeneratorHelper::safeClassName($listMemberClassName)]);
+                } elseif ($listMemberShape instanceof ListShape || $listMemberShape instanceof MapShape) {
+                    throw new \RuntimeException('Recursive ListShape are not yet implemented');
+                } else {
+                    // It is a scalar, like a string
+                    $parameterType = GeneratorHelper::toPhpType($listMemberShape->getType()) . '[]';
+                    $constructorBody .= strtr('$this->NAME = $input["NAME"] ?? [];' . "\n", ['NAME' => $member->getName()]);
+                }
+            } elseif ($memberShape instanceof MapShape) {
+                $mapValueShape = $memberShape->getValue()->getShape();
+                $nullable = false;
+
+                // Is this a list of objects?
+                if ($mapValueShape instanceof StructureShape) {
+                    $this->generateInputClass($service, $operation, $baseNamespace, $mapValueShape);
+                    $mapValueClassName = GeneratorHelper::safeClassName($mapValueShape->getName());
+
+                    $parameterType = $mapValueClassName . '[]';
+                    $returnType = $baseNamespace . '\\' . $mapValueClassName;
+                    $constructorBody .= strtr('
+                        $this->NAME = [];
+                        foreach ($input["NAME"] ?? [] as $key => $item) {
+                            $this->NAME[$key] = SAFE_CLASS::create($item);
+                        }
+                    ', [
+                        'NAME' => $member->getName(),
+                        'SAFE_CLASS' => GeneratorHelper::safeClassName($mapValueClassName),
+                    ]);
+                } elseif ($mapValueShape instanceof ListShape || $mapValueShape instanceof MapShape) {
+                    throw new \RuntimeException('Recursive ListShape are not yet implemented');
+                } else {
+                    // It is a scalar, like a string
+                    $parameterType = GeneratorHelper::toPhpType($mapValueShape->getType()) . '[]';
+                    $constructorBody .= strtr('$this->NAME = $input["NAME"] ?? [];' . "\n", ['NAME' => $member->getName()]);
+                }
+            } elseif ($member->isStreaming()) {
+                $parameterType = 'string|resource|\Closure';
+                $returnType = null;
+                $constructorBody .= strtr('$this->NAME = $input["NAME"] ?? null;' . "\n", ['NAME' => $member->getName()]);
+            } else {
+                $returnType = $parameterType = GeneratorHelper::toPhpType($memberShape->getType());
+                if ('\DateTimeImmutable' !== $parameterType) {
+                    $constructorBody .= strtr('$this->NAME = $input["NAME"] ?? null;' . "\n", ['NAME' => $member->getName()]);
+                } else {
+                    $constructorBody .= strtr('$this->NAME = !isset($input["NAME"]) ? null : ($input["NAME"] instanceof \DateTimeInterface ? $input["NAME"] : new \DateTimeImmutable($input["NAME"]));' . "\n", ['NAME' => $member->getName()]);
+                    $parameterType = $returnType = '\DateTimeInterface';
+                }
+            }
+
+            $property = $class->addProperty($member->getName())->setPrivate();
+            if (null !== $propertyDocumentation = $memberShape->getDocumentation()) {
+                $property->addComment(GeneratorHelper::parseDocumentation($propertyDocumentation));
+            }
+
+            if ($member->isRequired()) {
+                $requiredProperties[] = $member->getName();
+                $property->addComment('@required');
+            }
+            $property->addComment('@var ' . $parameterType . ($nullable ? '|null' : ''));
+
+            $returnType = '[]' === substr($parameterType, -2) ? 'array' : $returnType;
+
+            $class->addMethod('get' . $member->getName())
+                ->setReturnType($returnType)
+                ->setReturnNullable($nullable)
+                ->setBody(strtr('return $this->NAME;', ['NAME' => $member->getName()]));
+
+            $class->addMethod('set' . $member->getName())
+                ->setReturnType('self')
+                ->setBody(strtr('
+                    $this->NAME = $value;
+                    return $this;
+                ', [
+                    'NAME' => $member->getName(),
+                ]))
+                ->addParameter('value')->setType($returnType)->setNullable($nullable)
+            ;
+        }
+
+        // Add named constructor
+        $class->addMethod('create')
+            ->setStatic(true)
+            ->setReturnType('self')
+            ->setBody(strtr('
+                return $input instanceof self ? $input : new self(ARGS);
+            ', ['ARGS' => empty($constructorBody) ? '' : '$input']))
+            ->addParameter('input');
+
+        if (!empty($constructorBody)) {
+            $constructor = $class->addMethod('__construct');
+            if ($root && null !== $documentationUrl = $operation->getDocumentationUrl()) {
+                $constructor->addComment('@see ' . $documentationUrl);
+            }
+
+            $constructor->addComment(GeneratorHelper::getParamDocblock($inputShape, $baseNamespace, null, $root));
+
+            $inputParameter = $constructor->addParameter('input')->setType('array');
+            if ($root || empty($inputShape->getRequired())) {
+                $inputParameter->setDefaultValue([]);
+            }
+            $constructor->setBody($constructorBody);
+        }
+        if ($root) {
+            $this->inputClassRequestGetters($inputShape, $class, $operation);
+        }
+
+        // Add validate()
+        $namespace->addUse(InvalidArgument::class);
+        $validateBody = '';
+
+        if (!empty($requiredProperties)) {
+            $validateBody = strtr('
+                foreach (["PROPERTIES"] as $name) {
+                    if (null === $this->$name) {
+                        throw new InvalidArgument(sprintf(\'Missing parameter "%s" when validating the "%s". The value cannot be null.\', $name, __CLASS__));
+                    }
+                }
+            ', [
+                'PROPERTIES' => implode('", "', $requiredProperties),
+            ]);
+        }
+
+        foreach ($members as $member) {
+            $memberShape = $member->getShape();
+            if ($memberShape instanceof StructureShape) {
+                $validateBody .= 'if ($this->' . $member->getName() . ') $this->' . $member->getName() . '->validate();' . "\n";
+            } elseif (($memberShape instanceof ListShape && $memberShape->getMember()->getShape() instanceof StructureShape) || ($memberShape instanceof MapShape && $memberShape->getValue()->getShape() instanceof StructureShape)) {
+                $validateBody .= 'foreach ($this->' . $member->getName() . ' as $item) $item->validate();' . "\n";
+            }
+        }
+
+        $class->addMethod('validate')->setPublic()->setReturnType('void')->setBody(empty($validateBody) ? '// There are no required properties' : $validateBody);
+
+        $this->fileWriter->write($namespace);
+    }
+
+    private function inputClassRequestGetters(StructureShape $inputShape, ClassType $class, Operation $operation): void
+    {
+        foreach (['header' => '$headers', 'querystring' => '$query'] as $requestPart => $varName) {
+            $body[$requestPart] = $varName . ' = [];' . "\n";
+            foreach ($inputShape->getMembers() as $member) {
+                // If location is not specified, it will go in the request body.
+                if ($requestPart === ($member->getLocation() ?? 'payload')) {
+                    $body[$requestPart] .= 'if ($this->' . $member->getName() . ' !== null) ' . $varName . '["' . ($member->getLocationName() ?? $member->getName()) . '"] = $this->' . $member->getName() . ';' . "\n";
+                }
+            }
+
+            $body[$requestPart] .= 'return ' . $varName . ';' . "\n";
+        }
+
+        $class->addMethod('requestHeaders')->setReturnType('array')->setBody($body['header']);
+        $class->addMethod('requestQuery')->setReturnType('array')->setBody($body['querystring']);
+
+        if (null !== $payloadProperty = $inputShape->getPayload()) {
+            $member = $inputShape->getMember($payloadProperty);
+            if ($member->isStreaming()) {
+                $bodyType = null;
+                $body = 'return $this->' . $payloadProperty . ' ?? "";';
+            } else {
+                $bodyType = 'string';
+                $body = $this->dumpXml($member, $payloadProperty);
+            }
+        } else {
+            $bodyType = 'array';
+            $body = "\$payload = ['Action' => '{$operation->getName()}', 'Version' => '{$operation->getApiVersion()}'];\n";
+            foreach ($inputShape->getMembers() as $member) {
+                // If location is not specified, it will go in the request body.
+                if ('payload' === ($member->getLocation() ?? 'payload')) {
+                    $body .= 'if ($this->' . $member->getName() . ' !== null) $payload["' . ($member->getLocationName() ?? $member->getName()) . '"] = $this->' . $member->getName() . ';' . "\n";
+                }
+            }
+            $body .= 'return $payload;' . "\n";
+        }
+        $class->addMethod('requestBody')->setReturnType($bodyType)->setBody($body);
+
+        $requestUri = null;
+        foreach ($inputShape->getMembers() as $member) {
+            if ('uri' === $member->getLocation()) {
+                if (!isset($requestUri)) {
+                    $requestUri = '$uri = [];' . "\n";
+                }
+                $requestUri .= \strtr('$uri["LOCATION"] = $this->NAME ?? "";', ['NAME' => $member->getName(), 'LOCATION' => $member->getLocationName()]);
+            }
+        }
+
+        $requestUri = $requestUri ?? '';
+        $requestUri .= 'return "' . str_replace(['{', '+}', '}'], ['{$uri[\'', '}', '\']}'], $operation->getHttpRequestUri()) . '";';
+
+        $class->addMethod('requestUri')->setReturnType('string')->setBody($requestUri);
+    }
+
+    private function dumpXml(StructureMember $member, string $payloadProperty): string
+    {
+        if (null === $this->xmlDumper) {
+            $this->xmlDumper = new XmlDumper();
+        }
+
+        return $this->xmlDumper->dumpXmlRoot($member, $payloadProperty);
+    }
+}

--- a/src/CodeGenerator/Generator/OperationGenerator.php
+++ b/src/CodeGenerator/Generator/OperationGenerator.php
@@ -4,18 +4,11 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Generator;
 
-use AsyncAws\CodeGenerator\Definition\ListShape;
-use AsyncAws\CodeGenerator\Definition\MapShape;
 use AsyncAws\CodeGenerator\Definition\Operation;
-use AsyncAws\CodeGenerator\Definition\ServiceDefinition;
-use AsyncAws\CodeGenerator\Definition\StructureMember;
 use AsyncAws\CodeGenerator\Definition\StructureShape;
 use AsyncAws\CodeGenerator\File\FileWriter;
-use AsyncAws\Core\Exception\InvalidArgument;
 use AsyncAws\Core\Result;
-use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Method;
-use Nette\PhpGenerator\PhpNamespace;
 
 /**
  * Generate API client methods and result classes.
@@ -27,27 +20,16 @@ use Nette\PhpGenerator\PhpNamespace;
  */
 class OperationGenerator
 {
+    use MethodGeneratorTrait;
+
     /**
      * @var FileWriter
      */
     private $fileWriter;
 
-    /**
-     * All public classes take a definition as first parameter.
-     *
-     * @var ServiceDefinition
-     */
-    private $definition;
-
-    /**
-     * @var XmlDumper
-     */
-    private $xmlDumper;
-
-    public function __construct(FileWriter $fileWriter, ServiceDefinition $definition)
+    public function __construct(FileWriter $fileWriter)
     {
         $this->fileWriter = $fileWriter;
-        $this->definition = $definition;
     }
 
     /**
@@ -64,7 +46,6 @@ class OperationGenerator
         $classes = $namespace->getClasses();
         $class = $classes[\array_key_first($classes)];
 
-        $class->removeMethod(\lcfirst($operation->getName()));
         $method = $class->addMethod(\lcfirst($operation->getName()));
         if (null !== $documentation = $operation->getDocumentation()) {
             $method->addComment(GeneratorHelper::parseDocumentation($documentation));
@@ -72,21 +53,10 @@ class OperationGenerator
 
         if (null !== $documentationUrl = $operation->getDocumentationUrl()) {
             $method->addComment('@see ' . $documentationUrl);
-        } elseif (null !== $prefix = $this->definition->getEndpointPrefix()) {
-            $method->addComment('@see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-' . $prefix . '-' . $this->definition->getApiVersion() . '.html#' . \strtolower($operation->getName()));
+        } elseif (null !== $prefix = $operation->getService()->getEndpointPrefix()) {
+            $method->addComment('@see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-' . $prefix . '-' . $operation->getService()->getApiVersion() . '.html#' . \strtolower($operation->getName()));
         }
-
-        $comment = GeneratorHelper::addMethodComment($inputShape, $baseNamespace . '\\Input');
-        if (!empty($comment)) {
-            $method->addComment('@param array{');
-            foreach ($comment as $c) {
-                $method->addComment($c);
-            }
-            $method->addComment('}|' . $safeClassName . ' $input');
-        } else {
-            // No input array
-            $method->addComment('@param array|' . $safeClassName . ' $input');
-        }
+        $method->addComment(GeneratorHelper::getParamDocblock($inputShape, $baseNamespace . '\\Input', $safeClassName));
 
         $operationMethodParameter = $method->addParameter('input');
         if (empty($inputShape->getRequired())) {
@@ -106,243 +76,6 @@ class OperationGenerator
         $this->setMethodBody($inputShape, $method, $operation, $inputShape->getName());
 
         $this->fileWriter->write($namespace);
-    }
-
-    /**
-     * Generate classes for the input.
-     */
-    private function generateInputClass(string $service, Operation $operation, string $baseNamespace, StructureShape $inputShape, bool $root = false)
-    {
-        $members = $inputShape->getMembers();
-        $namespace = new PhpNamespace($baseNamespace);
-        $class = $namespace->addClass(GeneratorHelper::safeClassName($inputShape->getName()));
-
-        $constructorBody = '';
-        $requiredProperties = [];
-
-        foreach ($members as $member) {
-            $returnType = null;
-            $memberShape = $member->getShape();
-            $nullable = true;
-            if ($memberShape instanceof StructureShape) {
-                $this->generateInputClass($service, $operation, $baseNamespace, $memberShape);
-                $memberClassName = GeneratorHelper::safeClassName($memberShape->getName());
-                $returnType = $baseNamespace . '\\' . $memberClassName;
-                $parameterType = $memberShape->getName();
-                $constructorBody .= strtr('$this->NAME = isset($input["NAME"]) ? SAFE_CLASS::create($input["NAME"]) : null;' . "\n", ['NAME' => $member->getName(), 'SAFE_CLASS' => $memberClassName]);
-            } elseif ($memberShape instanceof ListShape) {
-                $listMemberShape = $memberShape->getMember()->getShape();
-                $nullable = false;
-
-                // Is this a list of objects?
-                if ($listMemberShape instanceof StructureShape) {
-                    $this->generateInputClass($service, $operation, $baseNamespace, $listMemberShape);
-                    $listMemberClassName = GeneratorHelper::safeClassName($listMemberShape->getName());
-
-                    $parameterType = $listMemberClassName . '[]';
-                    $returnType = $baseNamespace . '\\' . $listMemberClassName;
-                    $constructorBody .= strtr('$this->NAME = array_map(function($item) { return SAFE_CLASS::create($item); }, $input["NAME"] ?? []);' . "\n", ['NAME' => $member->getName(), 'SAFE_CLASS' => GeneratorHelper::safeClassName($listMemberClassName)]);
-                } elseif ($listMemberShape instanceof ListShape || $listMemberShape instanceof MapShape) {
-                    throw new \RuntimeException('Recursive ListShape are not yet implemented');
-                } else {
-                    // It is a scalar, like a string
-                    $parameterType = GeneratorHelper::toPhpType($listMemberShape->getType()) . '[]';
-                    $constructorBody .= strtr('$this->NAME = $input["NAME"] ?? [];' . "\n", ['NAME' => $member->getName()]);
-                }
-            } elseif ($memberShape instanceof MapShape) {
-                $mapValueShape = $memberShape->getValue()->getShape();
-                $nullable = false;
-
-                // Is this a list of objects?
-                if ($mapValueShape instanceof StructureShape) {
-                    $this->generateInputClass($service, $operation, $baseNamespace, $mapValueShape);
-                    $mapValueClassName = GeneratorHelper::safeClassName($mapValueShape->getName());
-
-                    $parameterType = $mapValueClassName . '[]';
-                    $returnType = $baseNamespace . '\\' . $mapValueClassName;
-                    $constructorBody .= strtr('
-                        $this->NAME = [];
-                        foreach ($input["NAME"] ?? [] as $key => $item) {
-                            $this->NAME[$key] = SAFE_CLASS::create($item);
-                        }
-                    ', [
-                        'NAME' => $member->getName(),
-                        'SAFE_CLASS' => GeneratorHelper::safeClassName($mapValueClassName),
-                    ]);
-                } elseif ($mapValueShape instanceof ListShape || $mapValueShape instanceof MapShape) {
-                    throw new \RuntimeException('Recursive ListShape are not yet implemented');
-                } else {
-                    // It is a scalar, like a string
-                    $parameterType = GeneratorHelper::toPhpType($mapValueShape->getType()) . '[]';
-                    $constructorBody .= strtr('$this->NAME = $input["NAME"] ?? [];' . "\n", ['NAME' => $member->getName()]);
-                }
-            } elseif ($member->isStreaming()) {
-                $parameterType = 'string|resource|\Closure';
-                $returnType = null;
-                $constructorBody .= strtr('$this->NAME = $input["NAME"] ?? null;' . "\n", ['NAME' => $member->getName()]);
-            } else {
-                $returnType = $parameterType = GeneratorHelper::toPhpType($memberShape->getType());
-                if ('\DateTimeImmutable' !== $parameterType) {
-                    $constructorBody .= strtr('$this->NAME = $input["NAME"] ?? null;' . "\n", ['NAME' => $member->getName()]);
-                } else {
-                    $constructorBody .= strtr('$this->NAME = !isset($input["NAME"]) ? null : ($input["NAME"] instanceof \DateTimeInterface ? $input["NAME"] : new \DateTimeImmutable($input["NAME"]));' . "\n", ['NAME' => $member->getName()]);
-                    $parameterType = $returnType = '\DateTimeInterface';
-                }
-            }
-
-            $property = $class->addProperty($member->getName())->setPrivate();
-            if (null !== $propertyDocumentation = $memberShape->getDocumentation()) {
-                $property->addComment(GeneratorHelper::parseDocumentation($propertyDocumentation));
-            }
-
-            if ($member->isRequired()) {
-                $requiredProperties[] = $member->getName();
-                $property->addComment('@required');
-            }
-            $property->addComment('@var ' . $parameterType . ($nullable ? '|null' : ''));
-
-            $returnType = '[]' === substr($parameterType, -2) ? 'array' : $returnType;
-
-            $class->addMethod('get' . $member->getName())
-                ->setReturnType($returnType)
-                ->setReturnNullable($nullable)
-                ->setBody(strtr('return $this->NAME;', ['NAME' => $member->getName()]));
-
-            $class->addMethod('set' . $member->getName())
-                ->setReturnType('self')
-                ->setBody(strtr('
-                    $this->NAME = $value;
-                    return $this;
-                ', [
-                    'NAME' => $member->getName(),
-                ]))
-                ->addParameter('value')->setType($returnType)->setNullable($nullable)
-            ;
-        }
-
-        // Add named constructor
-        $class->addMethod('create')
-            ->setStatic(true)
-            ->setReturnType('self')
-            ->setBody(strtr('
-                return $input instanceof self ? $input : new self(ARGS);
-            ', ['ARGS' => empty($constructorBody) ? '' : '$input']))
-            ->addParameter('input');
-
-        if (!empty($constructorBody)) {
-            $constructor = $class->addMethod('__construct');
-            if ($root && null !== $documentationUrl = $operation->getDocumentationUrl()) {
-                $constructor->addComment('@see ' . $documentationUrl);
-            }
-
-            $constructor->addComment('@param array{');
-            foreach (GeneratorHelper::addMethodComment($inputShape, $baseNamespace, $root) as $comment) {
-                $constructor->addComment($comment);
-            }
-            $constructor->addComment('} $input');
-
-            $inputParameter = $constructor->addParameter('input')->setType('array');
-            if ($root || empty($inputShape->getRequired())) {
-                $inputParameter->setDefaultValue([]);
-            }
-            $constructor->setBody($constructorBody);
-        }
-        if ($root) {
-            $this->inputClassRequestGetters($inputShape, $class, $operation);
-        }
-
-        // Add validate()
-        $namespace->addUse(InvalidArgument::class);
-        $validateBody = '';
-
-        if (!empty($requiredProperties)) {
-            $validateBody = strtr('
-                foreach (["PROPERTIES"] as $name) {
-                    if (null === $this->$name) {
-                        throw new InvalidArgument(sprintf(\'Missing parameter "%s" when validating the "%s". The value cannot be null.\', $name, __CLASS__));
-                    }
-                }
-            ', [
-                'PROPERTIES' => implode('", "', $requiredProperties),
-            ]);
-        }
-
-        foreach ($members as $member) {
-            $memberShape = $member->getShape();
-            if ($memberShape instanceof StructureShape) {
-                $validateBody .= 'if ($this->' . $member->getName() . ') $this->' . $member->getName() . '->validate();' . "\n";
-            } elseif (($memberShape instanceof ListShape && $memberShape->getMember()->getShape() instanceof StructureShape) || ($memberShape instanceof MapShape && $memberShape->getValue()->getShape() instanceof StructureShape)) {
-                $validateBody .= 'foreach ($this->' . $member->getName() . ' as $item) $item->validate();' . "\n";
-            }
-        }
-
-        $class->addMethod('validate')->setPublic()->setReturnType('void')->setBody(empty($validateBody) ? '// There are no required properties' : $validateBody);
-
-        $this->fileWriter->write($namespace);
-    }
-
-    private function inputClassRequestGetters(StructureShape $inputShape, ClassType $class, Operation $operation): void
-    {
-        foreach (['header' => '$headers', 'querystring' => '$query'] as $requestPart => $varName) {
-            $body[$requestPart] = $varName . ' = [];' . "\n";
-            foreach ($inputShape->getMembers() as $member) {
-                // If location is not specified, it will go in the request body.
-                if ($requestPart === ($member->getLocation() ?? 'payload')) {
-                    $body[$requestPart] .= 'if ($this->' . $member->getName() . ' !== null) ' . $varName . '["' . ($member->getLocationName() ?? $member->getName()) . '"] = $this->' . $member->getName() . ';' . "\n";
-                }
-            }
-
-            $body[$requestPart] .= 'return ' . $varName . ';' . "\n";
-        }
-
-        $class->addMethod('requestHeaders')->setReturnType('array')->setBody($body['header']);
-        $class->addMethod('requestQuery')->setReturnType('array')->setBody($body['querystring']);
-
-        if (null !== $payloadProperty = $inputShape->getPayload()) {
-            $member = $inputShape->getMember($payloadProperty);
-            if ($member->isStreaming()) {
-                $bodyType = null;
-                $body = 'return $this->' . $payloadProperty . ' ?? "";';
-            } else {
-                $bodyType = 'string';
-                $body = $this->dumpXml($member, $payloadProperty);
-            }
-        } else {
-            $bodyType = 'array';
-            $body = "\$payload = ['Action' => '{$operation->getName()}', 'Version' => '{$this->definition->getApiVersion()}'];\n";
-            foreach ($inputShape->getMembers() as $member) {
-                // If location is not specified, it will go in the request body.
-                if ('payload' === ($member->getLocation() ?? 'payload')) {
-                    $body .= 'if ($this->' . $member->getName() . ' !== null) $payload["' . ($member->getLocationName() ?? $member->getName()) . '"] = $this->' . $member->getName() . ';' . "\n";
-                }
-            }
-            $body .= 'return $payload;' . "\n";
-        }
-        $class->addMethod('requestBody')->setReturnType($bodyType)->setBody($body);
-
-        $requestUri = null;
-        foreach ($inputShape->getMembers() as $member) {
-            if ('uri' === $member->getLocation()) {
-                if (!isset($requestUri)) {
-                    $requestUri = '$uri = [];' . "\n";
-                }
-                $requestUri .= \strtr('$uri["LOCATION"] = $this->NAME ?? "";', ['NAME' => $member->getName(), 'LOCATION' => $member->getLocationName()]);
-            }
-        }
-
-        $requestUri = $requestUri ?? '';
-        $requestUri .= 'return "' . str_replace(['{', '+}', '}'], ['{$uri[\'', '}', '\']}'], $operation->getHttpRequestUri()) . '";';
-
-        $class->addMethod('requestUri')->setReturnType('string')->setBody($requestUri);
-    }
-
-    private function dumpXml(StructureMember $member, string $payloadProperty): string
-    {
-        if (null === $this->xmlDumper) {
-            $this->xmlDumper = new XmlDumper();
-        }
-
-        return $this->xmlDumper->dumpXmlRoot($member, $payloadProperty);
     }
 
     private function setMethodBody(StructureShape $inputShape, Method $method, Operation $operation, $inputClassName): void

--- a/src/CodeGenerator/Generator/ResultGenerator.php
+++ b/src/CodeGenerator/Generator/ResultGenerator.php
@@ -83,7 +83,6 @@ class ResultGenerator
         if ($root) {
             $namespace->addUse(Result::class);
             $class->addExtend(Result::class);
-            $class->removeMethod('__destruct');
             $class->addMethod('__destruct')
                 ->addComment('Ensure current request is resolved and right exception is thrown.')
                 ->setBody('$this->resolve();');
@@ -185,7 +184,6 @@ class ResultGenerator
 
         $iteratorType = implode('|', $iteratorTypes);
 
-        $class->removeMethod('getIterator');
         $class->addMethod('getIterator')
             ->setReturnType(\Traversable::class)
             ->addComment('Iterates over ' . implode(' then ', $pagination->getResultkey()))
@@ -246,10 +244,10 @@ class ResultGenerator
             if (!$this->awsClient instanceOf CLIENT_CLASSNAME) {
                 throw new \InvalidArgumentException(\'missing client injected in paginated result\');
             }
-            if (!$this->request instanceOf INPUT_CLASSNAME) {
+            if (!$this->input instanceOf INPUT_CLASSNAME) {
                 throw new \InvalidArgumentException(\'missing last request injected in paginated result\');
             }
-            $input = clone $this->request;
+            $input = clone $this->input;
             $page = $this;
             while (true) {
                 if (MORE_CONDITION) {
@@ -289,11 +287,7 @@ class ResultGenerator
 
         // We need a constructor
         $constructor = $class->addMethod('__construct');
-        $constructor->addComment('@param array{');
-        foreach (GeneratorHelper::addMethodComment($shape, $baseNamespace, false, true) as $comment) {
-            $constructor->addComment($comment);
-        }
-        $constructor->addComment('} $input');
+        $constructor->addComment(GeneratorHelper::getParamDocblock($shape, $baseNamespace, null, false, true));
         $constructor->addParameter('input')->setType('array');
 
         $constructorBody = '';

--- a/src/CodeGenerator/Generator/WaiterGenerator.php
+++ b/src/CodeGenerator/Generator/WaiterGenerator.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\CodeGenerator\Generator;
+
+use AsyncAws\CodeGenerator\Definition\ErrorWaiterAcceptor;
+use AsyncAws\CodeGenerator\Definition\Operation;
+use AsyncAws\CodeGenerator\Definition\StructureShape;
+use AsyncAws\CodeGenerator\Definition\Waiter;
+use AsyncAws\CodeGenerator\Definition\WaiterAcceptor;
+use AsyncAws\CodeGenerator\File\FileWriter;
+use AsyncAws\Core\Exception\Http\HttpException;
+use AsyncAws\Core\Exception\RuntimeException;
+use AsyncAws\Core\Result;
+use AsyncAws\Core\Waiter as WaiterResult;
+use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\PhpNamespace;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Generate API client waiters methods.
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal
+ */
+class WaiterGenerator
+{
+    use MethodGeneratorTrait;
+
+    /**
+     * @var FileWriter
+     */
+    private $fileWriter;
+
+    public function __construct(FileWriter $fileWriter)
+    {
+        $this->fileWriter = $fileWriter;
+    }
+
+    /**
+     * Update the API client with a new function call.
+     */
+    public function generate(Waiter $waiter, string $service, string $baseNamespace): void
+    {
+        $operation = $waiter->getOperation();
+        $inputShape = $operation->getInput();
+        $this->generateInputClass($service, $operation, $baseNamespace . '\\Input', $inputShape, true);
+
+        $namespace = ClassFactory::fromExistingClass(\sprintf('%s\\%sClient', $baseNamespace, $service));
+        $namespace->addUse($baseNamespace . '\\Input\\' . GeneratorHelper::safeClassName($inputShape->getName()));
+        $namespace->addUse(HttpException::class);
+        $namespace->addUse(RuntimeException::class);
+
+        $classes = $namespace->getClasses();
+        $class = $classes[\array_key_first($classes)];
+
+        $this->generateMethod($namespace, $class, $waiter, $operation, $inputShape, $baseNamespace, $service);
+
+        $this->fileWriter->write($namespace);
+    }
+
+    private function generateMethod(PhpNamespace $namespace, ClassType $class, Waiter $waiter, Operation $operation, StructureShape $inputShape, string $baseNamespace, string $service)
+    {
+        $namespace->addUse($inputFqdn = $baseNamespace . '\\Input\\' . ($inputClassName = GeneratorHelper::safeClassName($inputShape->getName())));
+        $namespace->addUse($resultFqdn = $baseNamespace . '\\Result\\' . ($resultClassName = GeneratorHelper::safeClassName($waiter->getName() . 'Waiter')));
+
+        $method = $class->addMethod(\lcfirst($waiter->getName()))
+            ->setComment('Check status of operation ' . \lcfirst($operation->getName()))
+            ->addComment('@see ' . \lcfirst($operation->getName()))
+            ->addComment(GeneratorHelper::getParamDocblock($inputShape, $baseNamespace . '\\Input', $inputClassName))
+            ->setReturnType($resultFqdn)
+            ->setBody(strtr('
+$input = SAFE_CLASS::create($input);
+$input->validate();
+
+$response = $this->getResponse(
+    METHOD,
+    $input->requestBody(),
+    $input->requestHeaders(),
+    $this->getEndpoint($input->requestUri(), $input->requestQuery())
+);
+
+return new RESULT_CLASS($response, $this->httpClient, $this, $input);
+            ', [
+                'SAFE_CLASS' => $inputClassName,
+                'METHOD' => \var_export($operation->getHttpMethod(), true),
+                'RESULT_CLASS' => $resultClassName,
+            ]));
+
+        $operationMethodParameter = $method->addParameter('input');
+        if (empty($inputShape->getRequired())) {
+            $operationMethodParameter->setDefaultValue([]);
+        }
+
+        $this->generateWaiterResult($waiter, $baseNamespace, $service);
+    }
+
+    private function generateWaiterResult(Waiter $waiter, string $baseNamespace, string $service): void
+    {
+        $namespace = new PhpNamespace($baseNamespace . '\\Result');
+        $className = GeneratorHelper::safeClassName($waiter->getName() . 'Waiter');
+        $class = $namespace->addClass($className);
+
+        $class->addConstant('WAIT_TIMEOUT', (float) ($waiter->getMaxAttempts() * $waiter->getDelay()))
+            ->setVisibility(ClassType::VISIBILITY_PROTECTED);
+        $class->addConstant('WAIT_DELAY', (float) $waiter->getDelay())
+            ->setVisibility(ClassType::VISIBILITY_PROTECTED);
+
+        $namespace->addUse(WaiterResult::class);
+        $namespace->addUse(Result::class);
+        $namespace->addUse(ResponseInterface::class);
+        $namespace->addUse(HttpException::class);
+
+        $inputSafeClassName = GeneratorHelper::safeClassName($waiter->getOperation()->getInput()->getName());
+        $namespace->addUse($baseNamespace . '\\Input\\' . $inputSafeClassName);
+
+        $clientClassName = $service . 'Client';
+        $namespace->addUse($baseNamespace . '\\' . $clientClassName);
+
+        $class->addExtend(WaiterResult::class);
+
+        $class->addMethod('refreshState')
+            ->setReturnType(WaiterResult::class)
+            ->setVisibility(ClassType::VISIBILITY_PROTECTED)
+            ->setBody(strtr('
+                if (!$this->awsClient instanceOf CLIENT_CLASSNAME) {
+                    throw new \InvalidArgumentException(\'missing client injected in waiter result\');
+                }
+                if (!$this->input instanceOf INPUT_CLASSNAME) {
+                    throw new \InvalidArgumentException(\'missing last request injected in waiter result\');
+                }
+
+                return $this->awsClient->WAITER_NAME($this->input);
+            ', [
+                'CLIENT_CLASSNAME' => $clientClassName,
+                'INPUT_CLASSNAME' => $inputSafeClassName,
+                'WAITER_NAME' => $waiter->getName(),
+            ]))
+        ;
+
+        $method = $class->addMethod('extractState')
+            ->setReturnType('string')
+            ->setProtected()
+            ->setBody(strtr('
+                ACCEPTOR_CODE
+
+                return $exception === null ? self::STATE_PENDING :  self::STATE_FAILURE;
+            ', ['ACCEPTOR_CODE' => \implode("\n", \array_map([$this, 'getAcceptorBody'], $waiter->getAcceptors()))]));
+        $method->addParameter('response')->setType(ResponseInterface::class);
+        $method->addParameter('exception')->setType(HttpException::class)->setNullable(true);
+
+        $this->fileWriter->write($namespace);
+    }
+
+    private function getAcceptorBody(WaiterAcceptor $acceptor): string
+    {
+        if ($acceptor instanceof ErrorWaiterAcceptor) {
+            return $this->getAcceptorErrorBody($acceptor);
+        }
+
+        switch ($acceptor->getMatcher()) {
+            case WaiterAcceptor::MATCHER_STATUS:
+                return $this->getAcceptorStatusBody($acceptor);
+            default:
+                throw new \RuntimeException(sprintf('Acceptor matcher "%s" is not yet implemented', $acceptor->getMatcher()));
+        }
+    }
+
+    private function getAcceptorStatusBody(WaiterAcceptor $acceptor): string
+    {
+        return strtr('
+            if (EXPECTED === $response->getStatusCode()) {
+                return self::BEHAVIOR;
+            }
+        ', [
+            'EXPECTED' => $acceptor->getExpected(),
+            'BEHAVIOR' => $this->getAcceptorBehavior($acceptor),
+        ]);
+    }
+
+    private function getAcceptorErrorBody(ErrorWaiterAcceptor $acceptor): string
+    {
+        $checks = ['$exception !== null'];
+        $error = $acceptor->getError();
+        if (null !== $code = $error->getCode()) {
+            $checks[] = '$exception->getAwsCode() === ' . \var_export($code, true);
+        }
+        if (null !== $code = $error->getStatusCode()) {
+            $checks[] = '$exception->getCode() === ' . \var_export($code, true);
+        }
+
+        return strtr('
+            if (EXPECTED) {
+                return self::BEHAVIOR;
+            }
+        ', [
+            'EXPECTED' => \implode('&&', $checks),
+            'BEHAVIOR' => $this->getAcceptorBehavior($acceptor),
+        ]);
+    }
+
+    private function getAcceptorBehavior(WaiterAcceptor $acceptor): string
+    {
+        switch ($acceptor->getState()) {
+            case WaiterAcceptor::STATE_SUCCESS:
+                return 'STATE_SUCCESS';
+            case WaiterAcceptor::STATE_FAILURE:
+                return 'STATE_FAILURE';
+            case WaiterAcceptor::STATE_RETRY:
+                return 'STATE_PENDING';
+            default:
+                throw new \RuntimeException(sprintf('Acceptor state "%s" is not yet implemented', $acceptor->getState()));
+        }
+    }
+}

--- a/src/Core/Exception/Http/HttpException.php
+++ b/src/Core/Exception/Http/HttpException.php
@@ -5,7 +5,17 @@ declare(strict_types=1);
 namespace AsyncAws\Core\Exception\Http;
 
 use AsyncAws\Core\Exception\Exception;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 interface HttpException extends Exception
 {
+    public function getResponse(): ResponseInterface;
+
+    public function getAwsCode(): ?string;
+
+    public function getAwsType(): ?string;
+
+    public function getAwsMessage(): ?string;
+
+    public function getAwsDetail(): ?string;
 }

--- a/src/Core/Exception/Http/HttpExceptionTrait.php
+++ b/src/Core/Exception/Http/HttpExceptionTrait.php
@@ -11,7 +11,30 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 trait HttpExceptionTrait
 {
+    /**
+     * @var ResponseInterface
+     */
     private $response;
+
+    /**
+     * @var ?string
+     */
+    private $awsCode;
+
+    /**
+     * @var ?string
+     */
+    private $awsType;
+
+    /**
+     * @var ?string
+     */
+    private $awsMessage;
+
+    /**
+     * @var ?string
+     */
+    private $awsDetail;
 
     public function __construct(ResponseInterface $response)
     {
@@ -74,18 +97,37 @@ trait HttpExceptionTrait
         return $this->response;
     }
 
+    public function getAwsCode(): ?string
+    {
+        return $this->awsCode;
+    }
+
+    public function getAwsType(): ?string
+    {
+        return $this->awsType;
+    }
+
+    public function getAwsMessage(): ?string
+    {
+        return $this->awsMessage;
+    }
+
+    public function getAwsDetail(): ?string
+    {
+        return $this->awsDetail;
+    }
+
     private function parseXml(\SimpleXMLElement $xml): string
     {
-        $type = $detail = '';
-
         if (0 < $xml->Error->count()) {
-            $type = $xml->Error->Type->__toString();
-            $code = $xml->Error->Code->__toString();
-            $message = $xml->Error->Message->__toString();
-            $detail = $xml->Error->Detail->__toString();
+            $this->awsType = $xml->Error->Type->__toString();
+            $this->awsCode = $xml->Error->Code->__toString();
+            $this->awsMessage = $xml->Error->Message->__toString();
+            $this->awsDetail = $xml->Error->Detail->__toString();
         } elseif (1 === $xml->Code->count() && 1 === $xml->Message->count()) {
-            $code = $xml->Code->__toString();
-            $message = $xml->Message->__toString();
+            $this->awsType = $this->awsDetail = '';
+            $this->awsCode = $xml->Code->__toString();
+            $this->awsMessage = $xml->Message->__toString();
         } else {
             return '';
         }
@@ -93,10 +135,10 @@ trait HttpExceptionTrait
         return <<<TEXT
 
 
-Code:    $code
-Message: $message
-Type:    $type
-Detail:  $detail
+Code:    $this->awsCode
+Message: $this->awsMessage
+Type:    $this->awsType
+Detail:  $this->awsDetail
 
 TEXT;
     }

--- a/src/Core/Exception/Http/NetworkException.php
+++ b/src/Core/Exception/Http/NetworkException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\Core\Exception\Http;
 
+use AsyncAws\Core\Exception\Exception;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 
 /**
@@ -11,6 +12,6 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class NetworkException extends \RuntimeException implements HttpException, TransportExceptionInterface
+class NetworkException extends \RuntimeException implements Exception, TransportExceptionInterface
 {
 }

--- a/src/Core/Result.php
+++ b/src/Core/Result.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace AsyncAws\Core;
 
-use AsyncAws\Core\Exception\Exception;
 use AsyncAws\Core\Exception\Http\ClientException;
+use AsyncAws\Core\Exception\Http\HttpException;
 use AsyncAws\Core\Exception\Http\NetworkException;
 use AsyncAws\Core\Exception\Http\RedirectionException;
 use AsyncAws\Core\Exception\Http\ServerException;
@@ -25,9 +25,11 @@ class Result
     protected $awsClient;
 
     /**
-     * @var array|object|null
+     * Input used to build the API request that generate this Result.
+     *
+     * @var object|null
      */
-    protected $request;
+    protected $input;
 
     /**
      * @var ResponseInterface|null
@@ -44,7 +46,7 @@ class Result
         $this->response = $response;
         $this->httpClient = $httpClient;
         $this->awsClient = $awsClient;
-        $this->request = $request;
+        $this->input = $request;
     }
 
     /**
@@ -54,7 +56,8 @@ class Result
      *
      * @return bool whether the request is executed or not
      *
-     * @throws Exception
+     * @throws NetworkException
+     * @throws HttpException
      */
     final public function resolve(?float $timeout = null): bool
     {
@@ -128,7 +131,7 @@ class Result
         $this->resolve();
         $this->populateResult($this->response, $this->httpClient);
         unset($this->response);
-        if (null !== $this->httpClient) {
+        if (isset($this->httpClient)) {
             unset($this->httpClient);
         }
     }

--- a/src/Core/Waiter.php
+++ b/src/Core/Waiter.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core;
+
+use AsyncAws\Core\Exception\Http\HttpException;
+use AsyncAws\Core\Exception\Http\NetworkException;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The waiter promise is always returned from every API call to a waiter.
+ */
+class Waiter
+{
+    public const STATE_SUCCESS = 'success';
+    public const STATE_FAILURE = 'failure';
+    public const STATE_PENDING = 'pending';
+
+    protected const WAIT_TIMEOUT = 30.0;
+    protected const WAIT_DELAY = 5.0;
+
+    /**
+     * @var AbstractApi|null
+     */
+    protected $awsClient;
+
+    /**
+     * Input used to build the API request that generate this Waiter.
+     *
+     * @var object|null
+     */
+    protected $input;
+
+    /**
+     * @var ResponseInterface|null
+     */
+    private $response;
+
+    /**
+     * @var HttpClientInterface
+     */
+    private $httpClient;
+
+    /**
+     * @var string|null
+     */
+    private $finalState;
+
+    public function __construct(ResponseInterface $response, HttpClientInterface $httpClient, AbstractApi $awsClient, $request)
+    {
+        $this->response = $response;
+        $this->httpClient = $httpClient;
+        $this->awsClient = $awsClient;
+        $this->input = $request;
+    }
+
+    public function __destruct()
+    {
+        if (isset($this->response)) {
+            $this->response->cancel();
+        }
+    }
+
+    final public function isSuccess(): bool
+    {
+        return self::STATE_SUCCESS === $this->getState();
+    }
+
+    final public function isFailure(): bool
+    {
+        return self::STATE_FAILURE === $this->getState();
+    }
+
+    final public function isPending(): bool
+    {
+        return self::STATE_PENDING === $this->getState();
+    }
+
+    final public function getState(): string
+    {
+        if (null !== $this->finalState) {
+            return $this->finalState;
+        }
+
+        if (!isset($this->response)) {
+            $this->stealResponse($this->refreshState());
+        }
+
+        $exception = null;
+        $this->resolve();
+
+        $state = $this->extractState($this->response, $exception);
+        unset($this->response);
+
+        switch ($state) {
+            case self::STATE_SUCCESS:
+            case self::STATE_FAILURE:
+                $this->finalState = $state;
+
+                break;
+            case self::STATE_PENDING:
+                break;
+            default:
+                throw new \LogicException(sprintf('Unexpected state "%s" from Waiter "%s".', $state, __CLASS__));
+        }
+
+        return $state;
+    }
+
+    /**
+     * Make sure the actual request is executed.
+     *
+     * @param float|null $timeout Duration in seconds before aborting. When null wait until the end of execution.
+     *
+     * @return bool whether the request is executed or not
+     *
+     * @throws NetworkException
+     */
+    final public function resolve(?float $timeout = null): bool
+    {
+        if (!isset($this->response)) {
+            return true;
+        }
+
+        try {
+            if (null !== $timeout && $this->httpClient->stream($this->response, $timeout)->current()->isTimeout()) {
+                return false;
+            }
+        } catch (TransportExceptionInterface $e) {
+            // When a network error occurs
+            throw new NetworkException('Could not contact remote server.', 0, $e);
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns info on the current request.
+     *
+     * @return array{
+     *                resolved: bool,
+     *                response?: ?ResponseInterface,
+     *                status?: int
+     *                }
+     */
+    final public function info(): array
+    {
+        if (!isset($this->response)) {
+            return [
+                'resolved' => true,
+            ];
+        }
+
+        return [
+            'resolved' => false,
+            'response' => $this->response,
+            'status' => (int) $this->response->getInfo('http_code'),
+        ];
+    }
+
+    final public function cancel(): void
+    {
+        if (!isset($this->response)) {
+            return;
+        }
+
+        $this->response->cancel();
+    }
+
+    /**
+     * Wait until the state is success.
+     * Stopped when the state become Failure or the defined timeout is reached.
+     *
+     * @param float $timeout Duration in seconds before aborting
+     * @param float $delay   Duration in seconds between each check
+     */
+    final public function wait(float $timeout = null, float $delay = null): bool
+    {
+        $timeout = $timeout ?? static::WAIT_TIMEOUT;
+        $delay = $delay ?? static::WAIT_DELAY;
+
+        $start = \microtime(true);
+        while (true) {
+            if (!$this->resolve($timeout - (\microtime(true) - $start))) {
+                break;
+            }
+
+            switch ($this->getState()) {
+                case self::STATE_SUCCESS:
+                case self::STATE_FAILURE:
+                    return true;
+            }
+
+            if ($delay > $timeout - (\microtime(true) - $start)) {
+                break;
+            }
+            \usleep((int) ceil($delay * 1000000));
+            $this->stealResponse($this->refreshState());
+        }
+
+        return false;
+    }
+
+    protected function extractState(ResponseInterface $response, ?HttpException $exception): string
+    {
+        return self::STATE_PENDING;
+    }
+
+    protected function refreshState(): Waiter
+    {
+        return $this;
+    }
+
+    private function stealResponse(self $waiter): void
+    {
+        $this->response = $waiter->response;
+        unset($waiter->response);
+    }
+}

--- a/src/S3/Result/ListObjectsV2Output.php
+++ b/src/S3/Result/ListObjectsV2Output.php
@@ -111,10 +111,10 @@ class ListObjectsV2Output extends Result implements \IteratorAggregate
         if (!$this->awsClient instanceof S3Client) {
             throw new \InvalidArgumentException('missing client injected in paginated result');
         }
-        if (!$this->request instanceof ListObjectsV2Request) {
+        if (!$this->input instanceof ListObjectsV2Request) {
             throw new \InvalidArgumentException('missing last request injected in paginated result');
         }
-        $input = clone $this->request;
+        $input = clone $this->input;
         $page = $this;
         while (true) {
             if ($page->getNextContinuationToken()) {
@@ -154,10 +154,10 @@ class ListObjectsV2Output extends Result implements \IteratorAggregate
         if (!$this->awsClient instanceof S3Client) {
             throw new \InvalidArgumentException('missing client injected in paginated result');
         }
-        if (!$this->request instanceof ListObjectsV2Request) {
+        if (!$this->input instanceof ListObjectsV2Request) {
             throw new \InvalidArgumentException('missing last request injected in paginated result');
         }
-        $input = clone $this->request;
+        $input = clone $this->input;
         $page = $this;
         while (true) {
             if ($page->getNextContinuationToken()) {
@@ -218,10 +218,10 @@ class ListObjectsV2Output extends Result implements \IteratorAggregate
         if (!$this->awsClient instanceof S3Client) {
             throw new \InvalidArgumentException('missing client injected in paginated result');
         }
-        if (!$this->request instanceof ListObjectsV2Request) {
+        if (!$this->input instanceof ListObjectsV2Request) {
             throw new \InvalidArgumentException('missing last request injected in paginated result');
         }
-        $input = clone $this->request;
+        $input = clone $this->input;
         $page = $this;
         while (true) {
             if ($page->getNextContinuationToken()) {

--- a/src/Sqs/Result/QueueExistsWaiter.php
+++ b/src/Sqs/Result/QueueExistsWaiter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace AsyncAws\Sqs\Result;
+
+use AsyncAws\Core\Exception\Http\HttpException;
+use AsyncAws\Core\Waiter;
+use AsyncAws\Sqs\Input\GetQueueUrlRequest;
+use AsyncAws\Sqs\SqsClient;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class QueueExistsWaiter extends Waiter
+{
+    protected const WAIT_TIMEOUT = 200.0;
+    protected const WAIT_DELAY = 5.0;
+
+    protected function extractState(ResponseInterface $response, ?HttpException $exception): string
+    {
+        if (200 === $response->getStatusCode()) {
+            return self::STATE_SUCCESS;
+        }
+
+        if (null !== $exception && 'AWS.SimpleQueueService.NonExistentQueue' === $exception->getAwsCode() && 400 === $exception->getCode()) {
+            return self::STATE_PENDING;
+        }
+
+        return null === $exception ? self::STATE_PENDING : self::STATE_FAILURE;
+    }
+
+    protected function refreshState(): Waiter
+    {
+        if (!$this->awsClient instanceof SqsClient) {
+            throw new \InvalidArgumentException('missing client injected in waiter result');
+        }
+        if (!$this->input instanceof GetQueueUrlRequest) {
+            throw new \InvalidArgumentException('missing last request injected in waiter result');
+        }
+
+        return $this->awsClient->QueueExists($this->input);
+    }
+}

--- a/src/Sqs/SqsClient.php
+++ b/src/Sqs/SqsClient.php
@@ -18,6 +18,8 @@ use AsyncAws\Sqs\Result\CreateQueueResult;
 use AsyncAws\Sqs\Result\GetQueueAttributesResult;
 use AsyncAws\Sqs\Result\GetQueueUrlResult;
 use AsyncAws\Sqs\Result\ListQueuesResult;
+use AsyncAws\Sqs\Result\QueueExists;
+use AsyncAws\Sqs\Result\QueueExistsWaiter;
 use AsyncAws\Sqs\Result\ReceiveMessageResult;
 use AsyncAws\Sqs\Result\SendMessageResult;
 
@@ -229,6 +231,31 @@ class SqsClient extends AbstractApi
         );
 
         return new Result($response, $this->httpClient);
+    }
+
+    /**
+     * Check status of operation getQueueUrl.
+     *
+     * @see getQueueUrl
+     *
+     * @param array{
+     *   QueueName: string,
+     *   QueueOwnerAWSAccountId?: string,
+     * }|GetQueueUrlRequest $input
+     */
+    public function queueExists($input): QueueExistsWaiter
+    {
+        $input = GetQueueUrlRequest::create($input);
+        $input->validate();
+
+        $response = $this->getResponse(
+            'POST',
+            $input->requestBody(),
+            $input->requestHeaders(),
+            $this->getEndpoint($input->requestUri(), $input->requestQuery())
+        );
+
+        return new QueueExistsWaiter($response, $this->httpClient, $this, $input);
     }
 
     /**

--- a/src/Sqs/Tests/Integration/SqsClientTest.php
+++ b/src/Sqs/Tests/Integration/SqsClientTest.php
@@ -177,6 +177,22 @@ class SqsClientTest extends TestCase
         self::assertEquals(0, (int) $sqs->getQueueAttributes(['QueueUrl' => $fooQueueUrl])->getAttributes()['ApproximateNumberOfMessages']);
     }
 
+    public function testQueueExists()
+    {
+        $sqs = $this->getClient();
+
+        $sqs->createQueue(['QueueName' => 'foo'])->resolve();
+        $waiter = $sqs->queueExists(['QueueName' => 'foo']);
+        self::assertTrue($waiter->wait());
+        self::assertTrue($waiter->isSuccess());
+
+        $waiter = $sqs->queueExists(['QueueName' => 'does-not-exists']);
+        self::assertFalse($waiter->isSuccess());
+
+        // Can't test the above code, because Fake SQS returns the wrong error
+        // self::assertFalse($waiter->wait(0.01));
+    }
+
     public function testReceiveMessage()
     {
         $sqs = $this->getClient();


### PR DESCRIPTION
Aleternative to #153 that return a full async object instead of blocking resolution.

This PR adds an `WaiterResult extends Result` that contains most of business logic:
PRO:
- user still get a `Result` when calling the client

CON:
- had to change set `$response` to protected
- if user calls `->resolve()` they could have an exception (for instance, 404 not found) which is not a error for the waiter (the method `WaiterResult::wait())` catch such exception and return weither or not it's success or a failure.

Tell me which PR you prefer.