### PR TITLE
Use container's http_client when available

### DIFF
--- a/src/Symfony/Bundle/DependencyInjection/AsyncAwsExtension.php
+++ b/src/Symfony/Bundle/DependencyInjection/AsyncAwsExtension.php
@@ -81,11 +81,17 @@ class AsyncAwsExtension extends Extension
             // Use default Symfony logger unless explicitly set to null.
             $logger = new Reference('logger', ContainerInterface::NULL_ON_INVALID_REFERENCE);
         }
+        if (\array_key_exists('http_client', $config)) {
+            $httpClient = $config['http_client'] ? new Reference($config['http_client']) : null;
+        } else {
+            // Use default Symfony http_client unless explicitly set to null.
+            $httpClient = new Reference('http_client', ContainerInterface::NULL_ON_INVALID_REFERENCE);
+        }
 
         $definition = new Definition($clientClass);
         $definition->addArgument($config['config']);
         $definition->addArgument(isset($config['credential_provider']) ? new Reference($config['credential_provider']) : null);
-        $definition->addArgument(isset($config['http_client']) ? new Reference($config['http_client']) : null);
+        $definition->addArgument($httpClient);
         $definition->addArgument($logger);
         $container->setDefinition(sprintf('async_aws.client.%s', $name), $definition);
     }

--- a/src/Symfony/Bundle/DependencyInjection/Configuration.php
+++ b/src/Symfony/Bundle/DependencyInjection/Configuration.php
@@ -21,7 +21,7 @@ class Configuration implements ConfigurationInterface
             ->children()
                 ->booleanNode('register_service')->info('If set to false, no services will be created.')->defaultTrue()->end()
                 ->scalarNode('credential_provider')->info('A service name for AsyncAws\Core\Credentials\CredentialProvider.')->defaultNull()->end()
-                ->scalarNode('http_client')->info('A service name for Symfony\Contracts\HttpClient\HttpClientInterface.')->defaultNull()->end()
+                ->scalarNode('http_client')->info('A service name for Symfony\Contracts\HttpClient\HttpClientInterface.')->end()
                 ->scalarNode('logger')->info('A service name for Psr\Log\LoggerInterface.')->end()
                 ->arrayNode('config')->info('Default config that will be merged will all services.')->normalizeKeys(false)->prototype('variable')->end()->end()
 

--- a/src/Symfony/Bundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/src/Symfony/Bundle/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -26,7 +26,6 @@ class ConfigurationTest extends TestCase
         ], [
             'register_service' => true,
             'credential_provider' => null,
-            'http_client' => null,
             'config' => [],
             'clients' => [],
         ]);


### PR DESCRIPTION
That PR leverage the Framework's http client service (with Debug and WebProfile information)