### PR TITLE
Fix Action & Version sent in JsonRest

### DIFF
--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestJsonSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestJsonSerializer.php
@@ -65,14 +65,16 @@ class RestJsonSerializer implements Serializer
             ]);
         }, $shape->getMembers()));
 
+        if ('' === trim($body)) {
+            return 'return "{}";';
+        }
+
         return strtr('
-                $payload = [\'Action\' => OPERATION_NAME, \'Version\' => API_VERSION];
+                $payload = [];
                 CHILDREN_CODE
 
                 return json_encode($payload);
             ', [
-            'OPERATION_NAME' => \var_export($operation->getName(), true),
-            'API_VERSION' => \var_export($operation->getApiVersion(), true),
             'CHILDREN_CODE' => false !== \strpos($body, '$indices') ? '$indices = new \stdClass();' . $body : $body,
         ]);
     }

--- a/src/Service/Lambda/src/Input/AddLayerVersionPermissionRequest.php
+++ b/src/Service/Lambda/src/Input/AddLayerVersionPermissionRequest.php
@@ -130,7 +130,7 @@ class AddLayerVersionPermissionRequest
 
     public function requestBody(): string
     {
-        $payload = ['Action' => 'AddLayerVersionPermission', 'Version' => '2015-03-31'];
+        $payload = [];
 
         $payload['StatementId'] = $this->StatementId;
         $payload['Action'] = $this->Action;

--- a/src/Service/Lambda/src/Input/ListLayerVersionsRequest.php
+++ b/src/Service/Lambda/src/Input/ListLayerVersionsRequest.php
@@ -79,9 +79,7 @@ class ListLayerVersionsRequest
 
     public function requestBody(): string
     {
-        $payload = ['Action' => 'ListLayerVersions', 'Version' => '2015-03-31'];
-
-        return json_encode($payload);
+        return '{}';
     }
 
     public function requestHeaders(): array

--- a/src/Service/Lambda/src/Input/PublishLayerVersionRequest.php
+++ b/src/Service/Lambda/src/Input/PublishLayerVersionRequest.php
@@ -97,7 +97,7 @@ class PublishLayerVersionRequest
 
     public function requestBody(): string
     {
-        $payload = ['Action' => 'PublishLayerVersion', 'Version' => '2015-03-31'];
+        $payload = [];
         $indices = new \stdClass();
         if (null !== $v = $this->Description) {
             $payload['Description'] = $v;

--- a/src/Service/Lambda/tests/Unit/Input/AddLayerVersionPermissionRequestTest.php
+++ b/src/Service/Lambda/tests/Unit/Input/AddLayerVersionPermissionRequestTest.php
@@ -33,7 +33,6 @@ class AddLayerVersionPermissionRequestTest extends TestCase
     {
         $expected = '{
            "Action": "lambda:GetLayerVersion",
-           "Version": "2015-03-31",
            "StatementId": "fooBar",
            "Principal": "123456789",
            "OrganizationId": "*"

--- a/src/Service/Lambda/tests/Unit/Input/ListLayerVersionsRequestTest.php
+++ b/src/Service/Lambda/tests/Unit/Input/ListLayerVersionsRequestTest.php
@@ -28,8 +28,6 @@ class ListLayerVersionsRequestTest extends TestCase
     public function testRequestBody(): void
     {
         $expected = '{
-            "Action": "ListLayerVersions",
-            "Version": "2015-03-31"
         }';
 
         self::assertJsonStringEqualsJsonString($expected, $this->input->requestBody());

--- a/src/Service/Lambda/tests/Unit/Input/PublishLayerVersionRequestTest.php
+++ b/src/Service/Lambda/tests/Unit/Input/PublishLayerVersionRequestTest.php
@@ -38,8 +38,6 @@ class PublishLayerVersionRequestTest extends TestCase
     {
         // see https://docs.aws.amazon.com/lambda/latest/dg/API_PublishLayerVersion.html
         $expected = '{
-            "Action": "PublishLayerVersion",
-            "Version": "2015-03-31",
             "Description": "small description",
             "Content": {
                 "S3Bucket": "myBucket",

--- a/src/Service/Ses/src/Input/SendEmailRequest.php
+++ b/src/Service/Ses/src/Input/SendEmailRequest.php
@@ -126,7 +126,7 @@ class SendEmailRequest
 
     public function requestBody(): string
     {
-        $payload = ['Action' => 'SendEmail', 'Version' => '2019-09-27'];
+        $payload = [];
         $indices = new \stdClass();
         if (null !== $v = $this->FromEmailAddress) {
             $payload['FromEmailAddress'] = $v;

--- a/src/Service/Ses/tests/Unit/Input/SendEmailRequestTest.php
+++ b/src/Service/Ses/tests/Unit/Input/SendEmailRequestTest.php
@@ -44,8 +44,6 @@ class SendEmailRequestTest extends TestCase
 
         // see example-1.json from SDK
         $expected = '{
-            "Action": "SendEmail",
-            "Version": "2019-09-27",
             "FromEmailAddress": "jeremy@derusse.com",
             "Destination": {
                 "ToAddresses": [


### PR DESCRIPTION
When copy/pasting code from QuerySerializer to JsonRestSerializer, we also sent `Action` and `Version` which are not needed. 