### PR TITLE
Mark test fail by default

### DIFF
--- a/src/CodeGenerator/src/Generator/TestGenerator.php
+++ b/src/CodeGenerator/src/Generator/TestGenerator.php
@@ -31,7 +31,7 @@ use Symfony\Component\HttpClient\MockHttpClient;
  */
 class TestGenerator
 {
-    private const MARKER = 'self::markTestIncomplete(\'Not implemented\');';
+    private const MARKER = 'self::fail(\'Not implemented\');';
 
     /**
      * @var NamespaceRegistry


### PR DESCRIPTION
Now all test are implemented, we should not allow `incomplet` anymore