### PR TITLE
Suppress warnings from Roave BC check

### DIFF
--- a/src/Core/.github/workflows/bc.entrypoint
+++ b/src/Core/.github/workflows/bc.entrypoint
@@ -1,0 +1,36 @@
+#!/bin/sh -l
+
+#
+# This file is a hack to suppress warnings from Roave BC check
+#
+
+composer install
+
+# Capture output to variable AND print it
+exec 4711>&1
+OUTPUT=$(/composer/vendor/bin/roave-backward-compatibility-check 2>&1 | tee /dev/fd/4711)
+
+# Remove rows we want to suppress
+OUTPUT=`echo "$OUTPUT" | sed '/Roave\\\BetterReflection\\\Reflection\\\ReflectionClass "PHPUnit\\\Framework\\\TestCase" could not be found in the located source/'d`
+
+# Number of rows we found with "[BC]" in them
+BC_BREAKS=`echo "$OUTPUT" | grep -o '\[BC\]' | wc -l | awk '{ print $1 }'`
+
+# The last row of the output is "X backwards-incompatible changes detected". Find X.
+STATED_BREAKS=`echo "$OUTPUT" | tail -n 1 | awk -F' ' '{ print $1 }'`
+
+# If
+#   We found "[BC]" in the command output after we removed suppressed lines
+# OR
+#   We have suppressed X number of BC breaks. If $STATED_BREAKS is larger than X
+# THEN
+#   exit 1
+
+if [ $BC_BREAKS -gt 0 ] || [ $STATED_BREAKS -gt 7 ]; then
+    echo "EXIT 1"
+    exit 1
+fi
+
+# No BC breaks found
+echo "EXIT 0"
+exit 0

--- a/src/Core/.github/workflows/checks.yml
+++ b/src/Core/.github/workflows/checks.yml
@@ -16,3 +16,5 @@ jobs:
 
       - name: Roave BC Check
         uses: docker://nyholm/roave-bc-check-ga
+        with:
+          entrypoint: ./.github/workflows/bc.entrypoint

--- a/src/Core/.github/workflows/checks.yml
+++ b/src/Core/.github/workflows/checks.yml
@@ -14,6 +14,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
 
+      - name: fetch tags
+        run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*
+
       - name: Roave BC Check
         uses: docker://nyholm/roave-bc-check-ga
         with:


### PR DESCRIPTION
The issue is that we extend TestCase from PHPUnit. It is hard for a static analysis tool to see that we are using `class_alias`