### PR TITLE
Use SSH key to PUSH bot PR

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,10 +1,7 @@
 name: Checks
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
+# Must be on both "push" and "pull_request" to be triggered by PR created by BOT
+on: [push, pull_request]
 
 jobs:
   composer-normalize:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,6 @@
 name: CI
 
+# Must be on both "push" and "pull_request" to be triggered by PR created by BOT
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,5 +1,6 @@
 name: Static analysis
 
+# Must be on both "push" and "pull_request" to be triggered by PR created by BOT
 on: [push, pull_request]
 
 jobs:

--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -16,8 +16,14 @@ jobs:
         php-version: 7.4
         coverage: none
 
-    - name: Checkout code
-      uses: actions/checkout@v2
+    - name: Set up SSH
+      uses: webfactory/ssh-agent@v0.2.0
+      with:
+        ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+
+    - name: Checkout via SSH
+      run: |
+        git clone --branch master git@github.com:${{ github.repository }}.git .
 
     - name: Download
       run: |
@@ -47,4 +53,3 @@ jobs:
 
           This PR contains the a new defintion for Services.
         branch: bot-code-update
-


### PR DESCRIPTION
Fixes #270 by using a deploy SSH key that will trigger JOB listening on "PUSH" events.

An other solution is to use a personal access token but is not ideal (security concerns) 