### PR TITLE
Fix configuration not fallback to default

### DIFF
--- a/src/Core/src/Configuration.php
+++ b/src/Core/src/Configuration.php
@@ -83,8 +83,16 @@ class Configuration
             }
         }
 
+        foreach (self::DEFAULT_OPTIONS as $option => $defaultValue) {
+            if (isset($options[$option])) {
+                continue;
+            }
+
+            $options[$option] = $defaultValue;
+        }
+
         $configuration = new Configuration();
-        $configuration->data = \array_merge(self::DEFAULT_OPTIONS, $options);
+        $configuration->data = $options;
 
         return $configuration;
     }


### PR DESCRIPTION
```php
Configuration::create(['endpoint' => null]);
```
should fallback to default value.