### PR TITLE
Don't mix env variable with configuration keys

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -78,7 +78,7 @@ $client = new AwsClientFactory([
 
 ## Using Credentials from Environment Variables
 
-AsyncAWS recognize Env variables that are used by most of official AWS tools and SDK.
+AsyncAWS recognize Env variables that are used by most official AWS tools and SDK.
 
 ```cli
 $ export AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
@@ -88,6 +88,9 @@ $ export AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 $ export AWS_SESSION_TOKEN=AQoDYXdzEJr...<remainder of security token>
    # The session key for your AWS account. This is needed only when you are using temporary credentials.
 ```
+
+> **NOTE**: You cannot mix env variables with configuration config with
+> hard-coded configuration.
 
 ```php
 use AsyncAws\Core\AwsClientFactory;

--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.3.2
+
+### Fixed
+
+- `Configuration` don't mix anymore attributes injected by php array and env variables.
+
 ## 0.3.1
 
 ### Added


### PR DESCRIPTION
This fixes #280 
When user a provides config via an array of key, AsyncAws should not always try filling the blank with env variable.

This mimics the AWS php SDK behavior by grouping env variables together.