### PR TITLE
Adding ResultMockFactory

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -6,14 +6,17 @@ parameters:
 			path: src/CodeGenerator/src/Command/GenerateCommand.php
 
 		-
+			message: "#^Method AsyncAws\\\\Core\\\\Test\\\\ResultMockFactory\\:\\:create\\(\\) should return T but returns object\\.$#"
+			count: 1
+			path: src/Core/src/Test/ResultMockFactory.php
+
+		-
+			message: "#^Call to an undefined method ReflectionType\\:\\:getName\\(\\)\\.$#"
+			count: 1
+			path: src/Core/src/Test/ResultMockFactory.php
+
+		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Config\\\\Definition\\\\Builder\\\\NodeParentInterface\\:\\:scalarNode\\(\\)\\.$#"
 			count: 1
 			path: src/Integration/Symfony/Bundle/src/DependencyInjection/Configuration.php
 
-		-   "#^PHPDoc tag @param has invalid value#"
-		-   "#^PHPDoc tag @return with type AsyncAws\\\\[^\\\\]+\\\\Enum\\\\[^ ]+ is incompatible with native type string(\\|null)?\\.$#"
-		-   "#^Method AsyncAws\\\\[^ ]+ should return string\\|null but returns AsyncAws\\\\[^\\\\]+\\\\Enum\\\\[^\\.]+\\.$#"
-		-   "#^Property AsyncAws\\\\[^ ]+ \\(AsyncAws\\\\[^\\\\]+\\\\Enum\\\\[^\\)]+\\) does not accept string\\|null\\.$#"
-		-   "#^Parameter \\#3 ...\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, AsyncAws\\\\[^\\\\]+\\\\Enum\\\\[^ ]+ given\\.$#"
-		-   "#^Parameter \\#1 \\$value of static method AsyncAws\\\\[^\\\\]+\\\\Enum\\\\[^:]+::exists\\(\\) expects string, AsyncAws\\\\[^\\\\]+\\\\Enum\\\\[^ ]+ given\\.$#"
-		-   "#^PHPDoc tag @(var|return) has invalid value \\(list<[^:]+::\\*>\\): Unexpected token \"::\", expected '>' at offset \\d+.$#"

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -16,3 +16,10 @@ parameters:
     ignoreErrors:
         - '|Ternary operator condition is always true\.|'
         - '|Negated boolean expression is always false\.|'
+        -   "#^PHPDoc tag @param has invalid value#"
+        -   "#^PHPDoc tag @return with type AsyncAws\\\\[^\\\\]+\\\\Enum\\\\[^ ]+ is incompatible with native type string(\\|null)?\\.$#"
+        -   "#^Method AsyncAws\\\\[^ ]+ should return string\\|null but returns AsyncAws\\\\[^\\\\]+\\\\Enum\\\\[^\\.]+\\.$#"
+        -   "#^Property AsyncAws\\\\[^ ]+ \\(AsyncAws\\\\[^\\\\]+\\\\Enum\\\\[^\\)]+\\) does not accept string\\|null\\.$#"
+        -   "#^Parameter \\#3 ...\\$args of function sprintf expects bool\\|float\\|int\\|string\\|null, AsyncAws\\\\[^\\\\]+\\\\Enum\\\\[^ ]+ given\\.$#"
+        -   "#^Parameter \\#1 \\$value of static method AsyncAws\\\\[^\\\\]+\\\\Enum\\\\[^:]+::exists\\(\\) expects string, AsyncAws\\\\[^\\\\]+\\\\Enum\\\\[^ ]+ given\\.$#"
+        -   "#^PHPDoc tag @(var|return) has invalid value \\(list<[^:]+::\\*>\\): Unexpected token \"::\", expected '>' at offset \\d+.$#"

--- a/src/Core/src/Sts/Result/AssumeRoleResponse.php
+++ b/src/Core/src/Sts/Result/AssumeRoleResponse.php
@@ -43,7 +43,7 @@ class AssumeRoleResponse extends Result
      * request. The request fails if the packed size is greater than 100 percent, which means the policies and tags exceeded
      * the allowed space.
      */
-    public function getPackedPolicySize(): int
+    public function getPackedPolicySize(): ?int
     {
         $this->initialize();
 

--- a/src/Core/src/Sts/Result/AssumeRoleResponse.php
+++ b/src/Core/src/Sts/Result/AssumeRoleResponse.php
@@ -43,7 +43,7 @@ class AssumeRoleResponse extends Result
      * request. The request fails if the packed size is greater than 100 percent, which means the policies and tags exceeded
      * the allowed space.
      */
-    public function getPackedPolicySize(): ?int
+    public function getPackedPolicySize(): int
     {
         $this->initialize();
 

--- a/src/Core/src/Test/ResultMockFactory.php
+++ b/src/Core/src/Test/ResultMockFactory.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace AsyncAws\Core\Test;
 
+use AsyncAws\Core\Result;
+
 /**
  * An easy way to create Result objects for your tests.
  *
@@ -24,6 +26,11 @@ class ResultMockFactory
      */
     public static function create(string $class, array $data)
     {
+        $parent = get_parent_class($class);
+        if (false === $parent || $parent !== Result::class) {
+            throw new \LogicException(sprintf('The "%s::%s" can only be used for classes that extend "%s"', __CLASS__, __METHOD__, Result::class));
+        }
+
         $rereflectionClass = new \ReflectionClass($class);
         $object = $rereflectionClass->newInstanceWithoutConstructor();
 

--- a/src/Core/src/Test/ResultMockFactory.php
+++ b/src/Core/src/Test/ResultMockFactory.php
@@ -59,10 +59,12 @@ class ResultMockFactory
             }
 
             $getter = $rereflectionClass->getMethod('get' . $property->getName());
+            /** @psalm-suppress PossiblyNullReference */
             if (!$getter->hasReturnType() || $getter->getReturnType()->allowsNull()) {
                 continue;
             }
 
+            /** @psalm-suppress PossiblyNullReference */
             switch ($getter->getReturnType()->getName()) {
                 case 'int':
                     $propertyValue = 0;

--- a/src/Core/src/Test/ResultMockFactory.php
+++ b/src/Core/src/Test/ResultMockFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core\Test;
+
+/**
+ * An easy way to create Result objects for your tests.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ */
+class ResultMockFactory
+{
+    /**
+     * Instantiate a Result class with some data.
+     *
+     * <code>
+     * ResultMockFactory::create(SendEmailResponse::class, ['MessageId'=>'foo123']);
+     * </code>
+     *
+     * @template T
+     * @psalm-param class-string<T> $class
+     * @return T
+     */
+    public static function create(string $class, array $data)
+    {
+        $rereflectionClass = new \ReflectionClass($class);
+        $object = $rereflectionClass->newInstanceWithoutConstructor();
+
+        foreach ($data as $propertyName => $propertyValue) {
+            $property = $rereflectionClass->getProperty($propertyName);
+            $property->setAccessible(true);
+            $property->setValue($object, $propertyValue);
+        }
+
+        return $object;
+    }
+}

--- a/src/Core/tests/Resources/ExampleResponse.php
+++ b/src/Core/tests/Resources/ExampleResponse.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core\Tests\Resources;
+
+use AsyncAws\Core\Result;
+
+class ExampleResponse extends Result
+{
+    private $int;
+    private $float;
+    private $bool;
+    private $array;
+    private $string;
+
+    public function getInt(): int
+    {
+        return $this->int;
+    }
+
+    public function getFloat(): float
+    {
+        return $this->float;
+    }
+
+    public function getBool(): bool
+    {
+        return $this->bool;
+    }
+
+    public function getArray(): array
+    {
+        return $this->array;
+    }
+
+    public function getString(): string
+    {
+        return $this->string;
+    }
+}

--- a/src/Core/tests/Resources/ExampleResponse.php
+++ b/src/Core/tests/Resources/ExampleResponse.php
@@ -9,9 +9,13 @@ use AsyncAws\Core\Result;
 class ExampleResponse extends Result
 {
     private $int;
+
     private $float;
+
     private $bool;
+
     private $array;
+
     private $string;
 
     public function getInt(): int

--- a/src/Core/tests/Unit/Test/ResultMockFactoryTest.php
+++ b/src/Core/tests/Unit/Test/ResultMockFactoryTest.php
@@ -6,7 +6,6 @@ namespace AsyncAws\Core\Tests\Unit\Test;
 
 use AsyncAws\Core\Sts\Result\AssumedRoleUser;
 use AsyncAws\Core\Sts\Result\AssumeRoleResponse;
-use AsyncAws\Core\Sts\StsClient;
 use AsyncAws\Core\Test\ResultMockFactory;
 use AsyncAws\Core\Tests\Resources\ExampleResponse;
 use PHPUnit\Framework\TestCase;
@@ -17,12 +16,12 @@ class ResultMockFactoryTest extends TestCase
     {
         /** @var AssumeRoleResponse $result */
         $result = ResultMockFactory::create(AssumeRoleResponse::class, [
-            'PackedPolicySize'=>342,
+            'PackedPolicySize' => 342,
         ]);
 
-        $this->assertInstanceOf(AssumeRoleResponse::class, $result);
-        $this->assertNull($result->getAssumedRoleUser());
-        $this->assertEquals(342, $result->getPackedPolicySize());
+        self::assertInstanceOf(AssumeRoleResponse::class, $result);
+        self::assertNull($result->getAssumedRoleUser());
+        self::assertEquals(342, $result->getPackedPolicySize());
     }
 
     public function testCreateAndFillEmptyParams()
@@ -30,18 +29,18 @@ class ResultMockFactoryTest extends TestCase
         /** @var ExampleResponse $result */
         $result = ResultMockFactory::create(ExampleResponse::class);
 
-        $this->assertEquals(0, $result->getInt());
-        $this->assertEquals([], $result->getArray());
-        $this->assertEquals(false, $result->getBool());
-        $this->assertEquals(0.0, $result->getFloat());
-        $this->assertEquals('', $result->getString());
+        self::assertEquals(0, $result->getInt());
+        self::assertEquals([], $result->getArray());
+        self::assertEquals(false, $result->getBool());
+        self::assertEquals(0.0, $result->getFloat());
+        self::assertEquals('', $result->getString());
     }
 
     public function testCreateWithInvalidParameters()
     {
         $this->expectException(\ReflectionException::class);
         ResultMockFactory::create(AssumeRoleResponse::class, [
-            'Foobar'=>'arn123',
+            'Foobar' => 'arn123',
         ]);
     }
 
@@ -49,8 +48,8 @@ class ResultMockFactoryTest extends TestCase
     {
         $this->expectException(\LogicException::class);
         ResultMockFactory::create(AssumedRoleUser::class, [
-            'Arn'=>'arn123',
-            'AssumedRoleId'=>'foo123'
+            'Arn' => 'arn123',
+            'AssumedRoleId' => 'foo123',
         ]);
     }
 }

--- a/src/Core/tests/Unit/Test/ResultMockFactoryTest.php
+++ b/src/Core/tests/Unit/Test/ResultMockFactoryTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core\Tests\Unit\Test;
+
+use AsyncAws\Core\Sts\Result\AssumedRoleUser;
+use AsyncAws\Core\Test\ResultMockFactory;
+use PHPUnit\Framework\TestCase;
+
+class ResultMockFactoryTest extends TestCase
+{
+    public function testCreate()
+    {
+        /** @var AssumedRoleUser $result */
+        $result = ResultMockFactory::create(AssumedRoleUser::class, [
+            'Arn'=>'arn123',
+            'AssumedRoleId'=>'foo123'
+        ]);
+
+        $this->assertInstanceOf(AssumedRoleUser::class, $result);
+        $this->assertEquals('arn123', $result->getArn());
+        $this->assertEquals('foo123', $result->getAssumedRoleId());
+    }
+}

--- a/src/Core/tests/Unit/Test/ResultMockFactoryTest.php
+++ b/src/Core/tests/Unit/Test/ResultMockFactoryTest.php
@@ -8,6 +8,7 @@ use AsyncAws\Core\Sts\Result\AssumedRoleUser;
 use AsyncAws\Core\Sts\Result\AssumeRoleResponse;
 use AsyncAws\Core\Sts\StsClient;
 use AsyncAws\Core\Test\ResultMockFactory;
+use AsyncAws\Core\Tests\Resources\ExampleResponse;
 use PHPUnit\Framework\TestCase;
 
 class ResultMockFactoryTest extends TestCase
@@ -22,6 +23,18 @@ class ResultMockFactoryTest extends TestCase
         $this->assertInstanceOf(AssumeRoleResponse::class, $result);
         $this->assertNull($result->getAssumedRoleUser());
         $this->assertEquals(342, $result->getPackedPolicySize());
+    }
+
+    public function testCreateAndFillEmptyParams()
+    {
+        /** @var ExampleResponse $result */
+        $result = ResultMockFactory::create(ExampleResponse::class);
+
+        $this->assertEquals(0, $result->getInt());
+        $this->assertEquals([], $result->getArray());
+        $this->assertEquals(false, $result->getBool());
+        $this->assertEquals(0.0, $result->getFloat());
+        $this->assertEquals('', $result->getString());
     }
 
     public function testCreateWithInvalidParameters()

--- a/src/Core/tests/Unit/Test/ResultMockFactoryTest.php
+++ b/src/Core/tests/Unit/Test/ResultMockFactoryTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace AsyncAws\Core\Tests\Unit\Test;
 
 use AsyncAws\Core\Sts\Result\AssumedRoleUser;
+use AsyncAws\Core\Sts\Result\AssumeRoleResponse;
+use AsyncAws\Core\Sts\StsClient;
 use AsyncAws\Core\Test\ResultMockFactory;
 use PHPUnit\Framework\TestCase;
 
@@ -12,14 +14,30 @@ class ResultMockFactoryTest extends TestCase
 {
     public function testCreate()
     {
-        /** @var AssumedRoleUser $result */
-        $result = ResultMockFactory::create(AssumedRoleUser::class, [
+        /** @var AssumeRoleResponse $result */
+        $result = ResultMockFactory::create(AssumeRoleResponse::class, [
+            'PackedPolicySize'=>342,
+        ]);
+
+        $this->assertInstanceOf(AssumeRoleResponse::class, $result);
+        $this->assertNull($result->getAssumedRoleUser());
+        $this->assertEquals(342, $result->getPackedPolicySize());
+    }
+
+    public function testCreateWithInvalidParameters()
+    {
+        $this->expectException(\ReflectionException::class);
+        ResultMockFactory::create(AssumeRoleResponse::class, [
+            'Foobar'=>'arn123',
+        ]);
+    }
+
+    public function testCreateWithInvalidClass()
+    {
+        $this->expectException(\LogicException::class);
+        ResultMockFactory::create(AssumedRoleUser::class, [
             'Arn'=>'arn123',
             'AssumedRoleId'=>'foo123'
         ]);
-
-        $this->assertInstanceOf(AssumedRoleUser::class, $result);
-        $this->assertEquals('arn123', $result->getArn());
-        $this->assertEquals('foo123', $result->getAssumedRoleId());
     }
 }


### PR DESCRIPTION
Im not sure this is a good idea. But it might be helpful when testing. 

```php
        /** @var AssumedRoleUser $result */
        $result = ResultMockFactory::create(AssumedRoleUser::class, [
            'Arn'=>'arn123',
            'AssumedRoleId'=>'foo123'
        ]);
```

You can also skip some (or all) mandatory parameters: 

```php
        /** @var AssumedRoleUser $result */
        $result = ResultMockFactory::create(AssumedRoleUser::class);
```