### PR TITLE
Fix instance provider role fetching

### DIFF
--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.3.4
+
+### Fixed
+
+- Fix Instance Provider Role fetching
+
 ## 0.3.3
 
 ### Added


### PR DESCRIPTION
When fetching metadata from AWS, the response contains a `text/plain` header while `ResponseInterface::toArray` want a `json` header.
```cli
curl http://169.254.169.254/latest/meta-data/iam/security-credentials/XXXX -i                                                                                
HTTP/1.0 200 OK
Accept-Ranges: bytes
Content-Length: 1298
Content-Type: text/plain                <== BOOM
Date: Thu, 12 Mar 2020 21:35:54 GMT
Last-Modified: Thu, 12 Mar 2020 21:32:10 GMT
Connection: close
Server: EC2ws

{
  "Code" : "Success",
  "LastUpdated" : "2020-03-12T21:32:57Z",
  "Type" : "AWS-HMAC",
  "AccessKeyId" : "XXX",
  "SecretAccessKey" : "XXX",
  "Token" : "XXX",     
  "Expiration" : "2020-03-13T03:37:53Z"
}