### PR TITLE
Remove dependency to http-client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
             echo ::group::$COMPONENT
             echo "$CURRENT_DIR/$COMPONENT"
             cd "$CURRENT_DIR/$COMPONENT"
-            sed -i -re 's/"async-aws\/core": "[^"]+",/"async-aws\/core": "*@dev",/' composer.json
+            sed -i -re 's/"async-aws\/core": "[^"]+"/"async-aws\/core": "*@dev"/' composer.json
             sed -i -re 's/"require": \{/"repositories": [{"type": "path","url": "..\/..\/Core"}],"require": \{/' composer.json
             cat composer.json
             echo ::endgroup::

--- a/src/CodeGenerator/src/Generator/OperationGenerator.php
+++ b/src/CodeGenerator/src/Generator/OperationGenerator.php
@@ -128,13 +128,13 @@ class OperationGenerator
                 $input = INPUT_CLASS::create($input);
                 $response = $this->getResponse($input->request());
 
-                return new RESULT_CLASS($response, $this->httpClient, $this, $input);
+                return new RESULT_CLASS($response, $this, $input);
             ';
         } else {
             $body = '
                 $response = $this->getResponse(INPUT_CLASS::create($input)->request());
 
-                return new RESULT_CLASS($response, $this->httpClient);
+                return new RESULT_CLASS($response);
             ';
         }
 

--- a/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
@@ -32,7 +32,7 @@ class RestJsonParser implements Parser
     public function generate(StructureShape $shape): string
     {
         if (null !== $payloadProperty = $shape->getPayload()) {
-            return strtr('$this->PROPERTY_NAME = $response->getContent(false);', ['PROPERTY_NAME' => $payloadProperty]);
+            return strtr('$this->PROPERTY_NAME = $response->getContent();', ['PROPERTY_NAME' => $payloadProperty]);
         }
 
         $properties = [];
@@ -51,7 +51,7 @@ class RestJsonParser implements Parser
             return '';
         }
 
-        $body = '$data = $response->toArray(false);' . "\n";
+        $body = '$data = $response->toArray();' . "\n";
         if (null !== $wrapper = $shape->getResultWrapper()) {
             $body .= strtr('$data = $data[WRAPPER];' . "\n", ['WRAPPER' => var_export($wrapper, true)]);
         }

--- a/src/CodeGenerator/src/Generator/ResponseParser/RestXmlParser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/RestXmlParser.php
@@ -55,7 +55,7 @@ class RestXmlParser implements Parser
             return '';
         }
 
-        $body = '$data = new \SimpleXMLElement($response->getContent(false));';
+        $body = '$data = new \SimpleXMLElement($response->getContent());';
         if (null !== $wrapper = $shape->getResultWrapper()) {
             $body .= strtr('$data = $data->WRAPPER;' . "\n", ['WRAPPER' => $wrapper]);
         }

--- a/src/CodeGenerator/src/Generator/TestGenerator.php
+++ b/src/CodeGenerator/src/Generator/TestGenerator.php
@@ -15,6 +15,7 @@ use AsyncAws\CodeGenerator\Generator\Naming\ClassName;
 use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
 use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassFactory;
 use AsyncAws\Core\Credentials\NullProvider;
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use Nette\PhpGenerator\ClassType;
@@ -191,7 +192,7 @@ class TestGenerator
                 STUB
 
                 $client = new MockHttpClient($response);
-                $result = new INPUT_CLASS($client->request(\'POST\', \'http://localhost\'), $client);
+                $result = new INPUT_CLASS(new Response($client->request(\'POST\', \'http://localhost\'), $client));
 
                 ASSERT
             ', [
@@ -202,6 +203,7 @@ class TestGenerator
                 'STUB' => $stub,
                 'ASSERT' => $this->getResultAssert($operation->getOutput()),
             ]));
+        $namespace->addUse(Response::class);
 
         $this->fileWriter->write($namespace);
     }

--- a/src/CodeGenerator/src/Generator/WaiterGenerator.php
+++ b/src/CodeGenerator/src/Generator/WaiterGenerator.php
@@ -16,6 +16,7 @@ use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
 use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassFactory;
 use AsyncAws\Core\Exception\Http\HttpException;
 use AsyncAws\Core\Exception\RuntimeException;
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\Core\Waiter as WaiterResult;
 use Nette\PhpGenerator\ClassType;
@@ -96,7 +97,7 @@ class WaiterGenerator
                 $input = INPUT_CLASS::create($input);
                 $response = $this->getResponse($input->request());
 
-                return new RESULT_CLASS($response, $this->httpClient, $this, $input);
+                return new RESULT_CLASS($response, $this, $input);
             ', [
                 'INPUT_CLASS' => $inputClass->getName(),
                 'RESULT_CLASS' => $resultClass->getName(),
@@ -159,7 +160,7 @@ class WaiterGenerator
 
                 return $exception === null ? self::STATE_PENDING :  self::STATE_FAILURE;
             ', ['ACCEPTOR_CODE' => \implode("\n", \array_map([$this, 'getAcceptorBody'], $waiter->getAcceptors()))]));
-        $method->addParameter('response')->setType(ResponseInterface::class);
+        $method->addParameter('response')->setType(Response::class);
         $method->addParameter('exception')->setType(HttpException::class)->setNullable(true);
 
         $this->fileWriter->write($namespace);

--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.5.0
+
+### Changed
+
+- The `StreamableBodyInterface::getChunks` now returns a iterrable of string.
+
 ## 0.4.0
 
 ### Added

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -19,7 +19,6 @@ use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\HttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * Base class most APIs are inheriting.
@@ -31,22 +30,22 @@ abstract class AbstractApi
     /**
      * @var HttpClientInterface
      */
-    protected $httpClient;
+    private $httpClient;
 
     /**
      * @var Configuration
      */
-    protected $configuration;
+    private $configuration;
 
     /**
      * @var CredentialProvider
      */
-    protected $credentialProvider;
+    private $credentialProvider;
 
     /**
      * @var LoggerInterface|null
      */
-    protected $logger;
+    private $logger;
 
     /**
      * @var Signer
@@ -86,7 +85,7 @@ abstract class AbstractApi
 
     abstract protected function getSignatureScopeName(): string;
 
-    final protected function getResponse(Request $request): ResponseInterface
+    final protected function getResponse(Request $request): Response
     {
         $request->setEndpoint($this->getEndpoint($request->getUri(), $request->getQuery()));
 
@@ -103,7 +102,9 @@ abstract class AbstractApi
             $requestBody = $requestBody->stringify();
         }
 
-        return $this->httpClient->request($request->getMethod(), $request->getEndpoint(), ['headers' => $request->getHeaders(), 'body' => 0 === $length ? null : $requestBody]);
+        $response = $this->httpClient->request($request->getMethod(), $request->getEndpoint(), ['headers' => $request->getHeaders(), 'body' => 0 === $length ? null : $requestBody]);
+
+        return new Response($response, $this->httpClient);
     }
 
     /**

--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use AsyncAws\Core\Exception\Http\HttpException;
+use AsyncAws\Core\Exception\Http\NetworkException;
+use AsyncAws\Core\Exception\Http\RedirectionException;
+use AsyncAws\Core\Exception\Http\ServerException;
+use AsyncAws\Core\Exception\RuntimeException;
+use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The response provides a facade to manipulate HttpResponses.
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal
+ */
+class Response
+{
+    private $response;
+
+    private $httpClient;
+
+    /**
+     * A Result can be resolved many times. This variable contains the last resolve result.
+     *
+     * @var bool|NetworkException|HttpException|null
+     */
+    private $resolveResult;
+
+    public function __construct(ResponseInterface $response, HttpClientInterface $httpClient)
+    {
+        $this->response = $response;
+        $this->httpClient = $httpClient;
+    }
+
+    public function __destruct()
+    {
+        if (null === $this->resolveResult) {
+            $this->resolve();
+        }
+    }
+
+    /**
+     * Make sure the actual request is executed.
+     *
+     * @param float|null $timeout Duration in seconds before aborting. When null wait until the end of execution.
+     * @param bool       $throw   Whether an exception should be thrown on 3/4/5xx status codes
+     *
+     * @return bool whether the request is executed or not
+     *
+     * @throws NetworkException
+     * @throws HttpException
+     */
+    final public function resolve(?float $timeout = null, bool $throw = true): bool
+    {
+        if (null !== $this->resolveResult) {
+            if ($this->resolveResult instanceof \Exception) {
+                throw $this->resolveResult;
+            }
+
+            if (\is_bool($this->resolveResult)) {
+                return $this->resolveResult;
+            }
+
+            throw new RuntimeException('Unexpected resolve state');
+        }
+
+        try {
+            foreach ($this->httpClient->stream($this->response, $timeout) as $chunk) {
+                if ($chunk->isTimeout()) {
+                    return false;
+                }
+                if ($chunk->isFirst()) {
+                    break;
+                }
+            }
+
+            $statusCode = $this->response->getStatusCode();
+        } catch (TransportExceptionInterface $e) {
+            throw $this->resolveResult = new NetworkException('Could not contact remote server.', 0, $e);
+        }
+
+        if ($throw) {
+            if (500 <= $statusCode) {
+                throw $this->resolveResult = new ServerException($this->response);
+            }
+
+            if (400 <= $statusCode) {
+                throw $this->resolveResult = new ClientException($this->response);
+            }
+
+            if (300 <= $statusCode) {
+                throw $this->resolveResult = new RedirectionException($this->response);
+            }
+        }
+
+        return $this->resolveResult = true;
+    }
+
+    /**
+     * Returns info on the current request.
+     *
+     * @return array{
+     *                resolved: bool,
+     *                response?: ?ResponseInterface,
+     *                status?: int
+     *                }
+     */
+    final public function info(): array
+    {
+        return [
+            'resolved' => null !== $this->resolveResult,
+            'response' => $this->response,
+            'status' => (int) $this->response->getInfo('http_code'),
+        ];
+    }
+
+    final public function cancel(): void
+    {
+        $this->response->cancel();
+        $this->resolveResult = false;
+    }
+
+    final public function getHeaders(): array
+    {
+        $this->resolve();
+
+        return $this->response->getHeaders(false);
+    }
+
+    final public function getContent(): string
+    {
+        $this->resolve();
+
+        return $this->response->getContent(false);
+    }
+
+    final public function toArray(): array
+    {
+        $this->resolve();
+
+        return $this->response->toArray(false);
+    }
+
+    final public function getStatusCode(): int
+    {
+        return $this->response->getStatusCode();
+    }
+
+    final public function toStream(): StreamableBody
+    {
+        return new StreamableBody($this->httpClient->stream($this->response));
+    }
+}

--- a/src/Core/src/StreamableBody.php
+++ b/src/Core/src/StreamableBody.php
@@ -31,9 +31,11 @@ final class StreamableBody implements StreamableBodyInterface
     /**
      * {@inheritdoc}
      */
-    public function getChunks(): ResponseStreamInterface
+    public function getChunks(): iterable
     {
-        return $this->responseStream;
+        foreach ($this->responseStream as $chunk) {
+            yield $chunk->getContent();
+        }
     }
 
     /**

--- a/src/Core/src/StreamableBodyInterface.php
+++ b/src/Core/src/StreamableBodyInterface.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace AsyncAws\Core;
 
-use Symfony\Contracts\HttpClient\ResponseStreamInterface;
-
 /**
  * Stream a response body.
  */
@@ -16,10 +14,12 @@ interface StreamableBodyInterface
      *
      *     $fileHandler = fopen('/output.pdf', 'w');
      *     foreach ($result->getBody()->getChunks() as $chunk) {
-     *       fwrite($fileHandler, $chunk->getContent());
+     *       fwrite($fileHandler, $chunk);
      *     }
+     *
+     * @return iterable<string>
      */
-    public function getChunks(): ResponseStreamInterface;
+    public function getChunks(): iterable;
 
     /**
      * Download content into a temporary resource and return a string.

--- a/src/Core/src/Sts/Result/AssumeRoleResponse.php
+++ b/src/Core/src/Sts/Result/AssumeRoleResponse.php
@@ -2,11 +2,10 @@
 
 namespace AsyncAws\Core\Sts\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\Core\Sts\ValueObject\AssumedRoleUser;
 use AsyncAws\Core\Sts\ValueObject\Credentials;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class AssumeRoleResponse extends Result
 {
@@ -52,9 +51,9 @@ class AssumeRoleResponse extends Result
         return $this->PackedPolicySize;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = new \SimpleXMLElement($response->getContent(false));
+        $data = new \SimpleXMLElement($response->getContent());
         $data = $data->AssumeRoleResult;
 
         $this->Credentials = !$data->Credentials ? null : new Credentials([

--- a/src/Core/src/Sts/Result/AssumeRoleWithWebIdentityResponse.php
+++ b/src/Core/src/Sts/Result/AssumeRoleWithWebIdentityResponse.php
@@ -2,11 +2,10 @@
 
 namespace AsyncAws\Core\Sts\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\Core\Sts\ValueObject\AssumedRoleUser;
 use AsyncAws\Core\Sts\ValueObject\Credentials;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class AssumeRoleWithWebIdentityResponse extends Result
 {
@@ -93,9 +92,9 @@ class AssumeRoleWithWebIdentityResponse extends Result
         return $this->SubjectFromWebIdentityToken;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = new \SimpleXMLElement($response->getContent(false));
+        $data = new \SimpleXMLElement($response->getContent());
         $data = $data->AssumeRoleWithWebIdentityResult;
 
         $this->Credentials = !$data->Credentials ? null : new Credentials([

--- a/src/Core/src/Sts/Result/GetCallerIdentityResponse.php
+++ b/src/Core/src/Sts/Result/GetCallerIdentityResponse.php
@@ -2,9 +2,8 @@
 
 namespace AsyncAws\Core\Sts\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class GetCallerIdentityResponse extends Result
 {
@@ -48,9 +47,9 @@ class GetCallerIdentityResponse extends Result
         return $this->UserId;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = new \SimpleXMLElement($response->getContent(false));
+        $data = new \SimpleXMLElement($response->getContent());
         $data = $data->GetCallerIdentityResult;
 
         $this->UserId = ($v = $data->UserId) ? (string) $v : null;

--- a/src/Core/src/Sts/StsClient.php
+++ b/src/Core/src/Sts/StsClient.php
@@ -40,7 +40,7 @@ class StsClient extends AbstractApi
     {
         $response = $this->getResponse(AssumeRoleRequest::create($input)->request());
 
-        return new AssumeRoleResponse($response, $this->httpClient);
+        return new AssumeRoleResponse($response);
     }
 
     /**
@@ -64,7 +64,7 @@ class StsClient extends AbstractApi
     {
         $response = $this->getResponse(AssumeRoleWithWebIdentityRequest::create($input)->request());
 
-        return new AssumeRoleWithWebIdentityResponse($response, $this->httpClient);
+        return new AssumeRoleWithWebIdentityResponse($response);
     }
 
     /**
@@ -78,7 +78,7 @@ class StsClient extends AbstractApi
     {
         $response = $this->getResponse(GetCallerIdentityRequest::create($input)->request());
 
-        return new GetCallerIdentityResponse($response, $this->httpClient);
+        return new GetCallerIdentityResponse($response);
     }
 
     protected function getServiceCode(): string

--- a/src/Core/src/Test/ResultMockFactory.php
+++ b/src/Core/src/Test/ResultMockFactory.php
@@ -34,6 +34,7 @@ class ResultMockFactory
 
         $rereflectionClass = new \ReflectionClass($class);
         $object = $rereflectionClass->newInstanceWithoutConstructor();
+        $data['initialized'] = true;
 
         foreach ($data as $propertyName => $propertyValue) {
             $property = $rereflectionClass->getProperty($propertyName);

--- a/src/Core/src/Test/SimpleStreamableBody.php
+++ b/src/Core/src/Test/SimpleStreamableBody.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace AsyncAws\Core\Test;
 
 use AsyncAws\Core\StreamableBodyInterface;
-use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 
 /**
  * Simple streamable body used for testing.
@@ -24,9 +23,9 @@ class SimpleStreamableBody implements StreamableBodyInterface
         $this->data = $data;
     }
 
-    public function getChunks(): ResponseStreamInterface
+    public function getChunks(): iterable
     {
-        throw new \LogicException('This class is used used for testing. Function "getChunks" is not implemented. ');
+        yield $this->data;
     }
 
     public function getContentAsString(): string

--- a/src/Core/tests/Unit/Result/AssumeRoleResponseTest.php
+++ b/src/Core/tests/Unit/Result/AssumeRoleResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\Core\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Sts\Result\AssumeRoleResponse;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use PHPUnit\Framework\TestCase;
@@ -39,7 +40,7 @@ class AssumeRoleResponseTest extends TestCase
         ');
 
         $client = new MockHttpClient($response);
-        $result = new AssumeRoleResponse($client->request('POST', 'http://localhost'), $client);
+        $result = new AssumeRoleResponse(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertSame('arn:aws:sts::123456789012:assumed-role/demo/TestAR', $result->getAssumedRoleUser()->getArn());
         self::assertSame('ARO123EXAMPLE123:TestAR', $result->getAssumedRoleUser()->getAssumedRoleId());

--- a/src/Core/tests/Unit/Result/AssumeRoleWithWebIdentityResponseTest.php
+++ b/src/Core/tests/Unit/Result/AssumeRoleWithWebIdentityResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\Core\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Sts\Result\AssumeRoleWithWebIdentityResponse;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
@@ -34,7 +35,7 @@ class AssumeRoleWithWebIdentityResponseTest extends TestCase
         </AssumeRoleWithWebIdentityResponse>');
 
         $client = new MockHttpClient($response);
-        $result = new AssumeRoleWithWebIdentityResponse($client->request('POST', 'http://localhost'), $client);
+        $result = new AssumeRoleWithWebIdentityResponse(new Response($client->request('POST', 'http://localhost'), $client));
 
         // self::assertTODO(expected, $result->getCredentials());
         self::assertSame('amzn1.account.AF6RHO7KZU5XRVQJGXK6HB56KR2A', $result->getSubjectFromWebIdentityToken());

--- a/src/Core/tests/Unit/Result/GetCallerIdentityResponseTest.php
+++ b/src/Core/tests/Unit/Result/GetCallerIdentityResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\Core\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Sts\Result\GetCallerIdentityResponse;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use PHPUnit\Framework\TestCase;
@@ -26,7 +27,7 @@ class GetCallerIdentityResponseTest extends TestCase
         ');
 
         $client = new MockHttpClient($response);
-        $result = new GetCallerIdentityResponse($client->request('POST', 'http://localhost'), $client);
+        $result = new GetCallerIdentityResponse(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertStringContainsString('ARO123EXAMPLE123:my-role-session-name', $result->getUserId());
         self::assertStringContainsString('123456789012', $result->getAccount());

--- a/src/Core/tests/Unit/ResultTest.php
+++ b/src/Core/tests/Unit/ResultTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AsyncAws\Core\Tests\Unit;
 
 use AsyncAws\Core\Exception\Http\ClientException;
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use PHPUnit\Framework\TestCase;
@@ -56,7 +57,7 @@ class ResultTest extends TestCase
     {
         $response = new SimpleMockedResponse('Bad request', [], 400);
         $client = new MockHttpClient($response);
-        $result = new Result($client->request('POST', 'http://localhost'), $client);
+        $result = new Result(new Response($client->request('POST', 'http://localhost'), $client));
 
         $this->expectException(ClientException::class);
         unset($result);
@@ -66,7 +67,7 @@ class ResultTest extends TestCase
     {
         $response = new SimpleMockedResponse('Bad request', [], 400);
         $client = new MockHttpClient($response);
-        $result = new Result($client->request('POST', 'http://localhost'), $client);
+        $result = new Result(new Response($client->request('POST', 'http://localhost'), $client));
 
         try {
             $result->resolve();

--- a/src/Integration/Flysystem/S3/tests/Unit/S3FilesystemV2Test.php
+++ b/src/Integration/Flysystem/S3/tests/Unit/S3FilesystemV2Test.php
@@ -28,8 +28,13 @@ class S3FilesystemV2Test extends TestCase
         $prefix = 'all-files';
         $bucket = 'foobar';
 
-        $client = new MockHttpClient();
-        $result = new PutObjectOutput(new Response($client->request('POST', 'http://localhost'), $client));
+        if (\class_exists(Response::class)) {
+            $client = new MockHttpClient();
+            $result = new PutObjectOutput(new Response($client->request('POST', 'http://localhost'), $client));
+        } else {
+            $client = new MockHttpClient();
+            $result = new PutObjectOutput($client->request('POST', 'http://localhost'), $client);
+        }
 
         $s3Client = $this->getMockBuilder(S3Client::class)
             ->disableOriginalConstructor()

--- a/src/Integration/Flysystem/S3/tests/Unit/S3FilesystemV2Test.php
+++ b/src/Integration/Flysystem/S3/tests/Unit/S3FilesystemV2Test.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace AsyncAws\Flysystem\S3\Tests\Unit;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Flysystem\S3\S3FilesystemV2;
 use AsyncAws\S3\Result\PutObjectOutput;
 use AsyncAws\S3\S3Client;
 use League\Flysystem\Config;
 use League\Flysystem\FilesystemAdapter;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
 
 class S3FilesystemV2Test extends TestCase
 {
@@ -26,10 +28,8 @@ class S3FilesystemV2Test extends TestCase
         $prefix = 'all-files';
         $bucket = 'foobar';
 
-        $result = $this->getMockBuilder(PutObjectOutput::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['resolve'])
-            ->getMock();
+        $client = new MockHttpClient();
+        $result = new PutObjectOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         $s3Client = $this->getMockBuilder(S3Client::class)
             ->disableOriginalConstructor()

--- a/src/Service/.template/composer.json
+++ b/src/Service/.template/composer.json
@@ -10,8 +10,7 @@
     "require": {
         "php": "^7.2.5",
         "ext-json": "*",
-        "async-aws/core": "^0.3",
-        "symfony/http-client-contracts": "^1.0 || ^2.0"
+        "async-aws/core": "^0.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/CloudFormation/composer.json
+++ b/src/Service/CloudFormation/composer.json
@@ -11,8 +11,7 @@
         "php": "^7.2.5",
         "ext-SimpleXML": "*",
         "ext-filter": "*",
-        "async-aws/core": "^0.4",
-        "symfony/http-client-contracts": "^1.0 || ^2.0"
+        "async-aws/core": "^0.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/CloudFormation/src/CloudFormationClient.php
+++ b/src/Service/CloudFormation/src/CloudFormationClient.php
@@ -27,7 +27,7 @@ class CloudFormationClient extends AbstractApi
         $input = DescribeStackEventsInput::create($input);
         $response = $this->getResponse($input->request());
 
-        return new DescribeStackEventsOutput($response, $this->httpClient, $this, $input);
+        return new DescribeStackEventsOutput($response, $this, $input);
     }
 
     /**
@@ -46,7 +46,7 @@ class CloudFormationClient extends AbstractApi
         $input = DescribeStacksInput::create($input);
         $response = $this->getResponse($input->request());
 
-        return new DescribeStacksOutput($response, $this->httpClient, $this, $input);
+        return new DescribeStacksOutput($response, $this, $input);
     }
 
     protected function getServiceCode(): string

--- a/src/Service/CloudFormation/src/Result/DescribeStackEventsOutput.php
+++ b/src/Service/CloudFormation/src/Result/DescribeStackEventsOutput.php
@@ -5,9 +5,8 @@ namespace AsyncAws\CloudFormation\Result;
 use AsyncAws\CloudFormation\CloudFormationClient;
 use AsyncAws\CloudFormation\Input\DescribeStackEventsInput;
 use AsyncAws\CloudFormation\ValueObject\StackEvent;
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class DescribeStackEventsOutput extends Result implements \IteratorAggregate
 {
@@ -108,9 +107,9 @@ class DescribeStackEventsOutput extends Result implements \IteratorAggregate
         }
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = new \SimpleXMLElement($response->getContent(false));
+        $data = new \SimpleXMLElement($response->getContent());
         $data = $data->DescribeStackEventsResult;
 
         $this->StackEvents = !$data->StackEvents ? [] : (function (\SimpleXMLElement $xml): array {

--- a/src/Service/CloudFormation/src/Result/DescribeStacksOutput.php
+++ b/src/Service/CloudFormation/src/Result/DescribeStacksOutput.php
@@ -11,9 +11,8 @@ use AsyncAws\CloudFormation\ValueObject\RollbackTrigger;
 use AsyncAws\CloudFormation\ValueObject\Stack;
 use AsyncAws\CloudFormation\ValueObject\StackDriftInformation;
 use AsyncAws\CloudFormation\ValueObject\Tag;
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class DescribeStacksOutput extends Result implements \IteratorAggregate
 {
@@ -114,9 +113,9 @@ class DescribeStacksOutput extends Result implements \IteratorAggregate
         }
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = new \SimpleXMLElement($response->getContent(false));
+        $data = new \SimpleXMLElement($response->getContent());
         $data = $data->DescribeStacksResult;
 
         $this->Stacks = !$data->Stacks ? [] : (function (\SimpleXMLElement $xml): array {

--- a/src/Service/CloudFormation/tests/Unit/Result/DescribeStackEventsOutputTest.php
+++ b/src/Service/CloudFormation/tests/Unit/Result/DescribeStackEventsOutputTest.php
@@ -4,6 +4,7 @@ namespace AsyncAws\CloudFormation\Tests\Unit\Result;
 
 use AsyncAws\CloudFormation\Result\DescribeStackEventsOutput;
 use AsyncAws\CloudFormation\ValueObject\StackEvent;
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -55,7 +56,7 @@ class DescribeStackEventsOutputTest extends TestCase
 ');
 
         $client = new MockHttpClient($response);
-        $result = new DescribeStackEventsOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new DescribeStackEventsOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         /** @var StackEvent[] $stackEvents */
         $stackEvents = [];

--- a/src/Service/CloudFormation/tests/Unit/Result/DescribeStacksOutputTest.php
+++ b/src/Service/CloudFormation/tests/Unit/Result/DescribeStacksOutputTest.php
@@ -7,6 +7,7 @@ use AsyncAws\CloudFormation\ValueObject\RollbackConfiguration;
 use AsyncAws\CloudFormation\ValueObject\Stack;
 use AsyncAws\CloudFormation\ValueObject\StackDriftInformation;
 use AsyncAws\CloudFormation\ValueObject\Tag;
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -70,7 +71,7 @@ class DescribeStacksOutputTest extends TestCase
 XML;
 
         $client = new MockHttpClient(new SimpleMockedResponse($xml));
-        $result = new DescribeStacksOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new DescribeStacksOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         $stack = null;
         foreach ($result->getStacks(true) as $s) {

--- a/src/Service/DynamoDb/src/DynamoDbClient.php
+++ b/src/Service/DynamoDb/src/DynamoDbClient.php
@@ -51,7 +51,7 @@ class DynamoDbClient extends AbstractApi
     {
         $response = $this->getResponse(CreateTableInput::create($input)->request());
 
-        return new CreateTableOutput($response, $this->httpClient);
+        return new CreateTableOutput($response);
     }
 
     /**
@@ -77,7 +77,7 @@ class DynamoDbClient extends AbstractApi
     {
         $response = $this->getResponse(DeleteItemInput::create($input)->request());
 
-        return new DeleteItemOutput($response, $this->httpClient);
+        return new DeleteItemOutput($response);
     }
 
     /**
@@ -97,7 +97,7 @@ class DynamoDbClient extends AbstractApi
     {
         $response = $this->getResponse(DeleteTableInput::create($input)->request());
 
-        return new DeleteTableOutput($response, $this->httpClient);
+        return new DeleteTableOutput($response);
     }
 
     /**
@@ -114,7 +114,7 @@ class DynamoDbClient extends AbstractApi
     {
         $response = $this->getResponse(DescribeTableInput::create($input)->request());
 
-        return new DescribeTableOutput($response, $this->httpClient);
+        return new DescribeTableOutput($response);
     }
 
     /**
@@ -137,7 +137,7 @@ class DynamoDbClient extends AbstractApi
     {
         $response = $this->getResponse(GetItemInput::create($input)->request());
 
-        return new GetItemOutput($response, $this->httpClient);
+        return new GetItemOutput($response);
     }
 
     /**
@@ -156,7 +156,7 @@ class DynamoDbClient extends AbstractApi
         $input = ListTablesInput::create($input);
         $response = $this->getResponse($input->request());
 
-        return new ListTablesOutput($response, $this->httpClient, $this, $input);
+        return new ListTablesOutput($response, $this, $input);
     }
 
     /**
@@ -185,7 +185,7 @@ class DynamoDbClient extends AbstractApi
     {
         $response = $this->getResponse(PutItemInput::create($input)->request());
 
-        return new PutItemOutput($response, $this->httpClient);
+        return new PutItemOutput($response);
     }
 
     /**
@@ -219,7 +219,7 @@ class DynamoDbClient extends AbstractApi
         $input = QueryInput::create($input);
         $response = $this->getResponse($input->request());
 
-        return new QueryOutput($response, $this->httpClient, $this, $input);
+        return new QueryOutput($response, $this, $input);
     }
 
     /**
@@ -252,7 +252,7 @@ class DynamoDbClient extends AbstractApi
         $input = ScanInput::create($input);
         $response = $this->getResponse($input->request());
 
-        return new ScanOutput($response, $this->httpClient, $this, $input);
+        return new ScanOutput($response, $this, $input);
     }
 
     /**
@@ -282,7 +282,7 @@ class DynamoDbClient extends AbstractApi
     {
         $response = $this->getResponse(UpdateItemInput::create($input)->request());
 
-        return new UpdateItemOutput($response, $this->httpClient);
+        return new UpdateItemOutput($response);
     }
 
     /**
@@ -306,7 +306,7 @@ class DynamoDbClient extends AbstractApi
     {
         $response = $this->getResponse(UpdateTableInput::create($input)->request());
 
-        return new UpdateTableOutput($response, $this->httpClient);
+        return new UpdateTableOutput($response);
     }
 
     protected function getServiceCode(): string

--- a/src/Service/DynamoDb/src/Result/CreateTableOutput.php
+++ b/src/Service/DynamoDb/src/Result/CreateTableOutput.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\DynamoDb\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\DynamoDb\ValueObject\ArchivalSummary;
 use AsyncAws\DynamoDb\ValueObject\AttributeDefinition;
@@ -18,8 +19,6 @@ use AsyncAws\DynamoDb\ValueObject\RestoreSummary;
 use AsyncAws\DynamoDb\ValueObject\SSEDescription;
 use AsyncAws\DynamoDb\ValueObject\StreamSpecification;
 use AsyncAws\DynamoDb\ValueObject\TableDescription;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class CreateTableOutput extends Result
 {
@@ -35,9 +34,9 @@ class CreateTableOutput extends Result
         return $this->TableDescription;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = $response->toArray(false);
+        $data = $response->toArray();
 
         $this->TableDescription = empty($data['TableDescription']) ? null : new TableDescription([
             'AttributeDefinitions' => empty($data['TableDescription']['AttributeDefinitions']) ? [] : (function (array $json): array {

--- a/src/Service/DynamoDb/src/Result/DeleteItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/DeleteItemOutput.php
@@ -2,13 +2,12 @@
 
 namespace AsyncAws\DynamoDb\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\DynamoDb\ValueObject\AttributeValue;
 use AsyncAws\DynamoDb\ValueObject\Capacity;
 use AsyncAws\DynamoDb\ValueObject\ConsumedCapacity;
 use AsyncAws\DynamoDb\ValueObject\ItemCollectionMetrics;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class DeleteItemOutput extends Result
 {
@@ -59,9 +58,9 @@ class DeleteItemOutput extends Result
         return $this->ItemCollectionMetrics;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = $response->toArray(false);
+        $data = $response->toArray();
 
         $this->Attributes = empty($data['Attributes']) ? [] : (function (array $json): array {
             $items = [];

--- a/src/Service/DynamoDb/src/Result/DeleteTableOutput.php
+++ b/src/Service/DynamoDb/src/Result/DeleteTableOutput.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\DynamoDb\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\DynamoDb\ValueObject\ArchivalSummary;
 use AsyncAws\DynamoDb\ValueObject\AttributeDefinition;
@@ -18,8 +19,6 @@ use AsyncAws\DynamoDb\ValueObject\RestoreSummary;
 use AsyncAws\DynamoDb\ValueObject\SSEDescription;
 use AsyncAws\DynamoDb\ValueObject\StreamSpecification;
 use AsyncAws\DynamoDb\ValueObject\TableDescription;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class DeleteTableOutput extends Result
 {
@@ -35,9 +34,9 @@ class DeleteTableOutput extends Result
         return $this->TableDescription;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = $response->toArray(false);
+        $data = $response->toArray();
 
         $this->TableDescription = empty($data['TableDescription']) ? null : new TableDescription([
             'AttributeDefinitions' => empty($data['TableDescription']['AttributeDefinitions']) ? [] : (function (array $json): array {

--- a/src/Service/DynamoDb/src/Result/DescribeTableOutput.php
+++ b/src/Service/DynamoDb/src/Result/DescribeTableOutput.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\DynamoDb\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\DynamoDb\ValueObject\ArchivalSummary;
 use AsyncAws\DynamoDb\ValueObject\AttributeDefinition;
@@ -18,8 +19,6 @@ use AsyncAws\DynamoDb\ValueObject\RestoreSummary;
 use AsyncAws\DynamoDb\ValueObject\SSEDescription;
 use AsyncAws\DynamoDb\ValueObject\StreamSpecification;
 use AsyncAws\DynamoDb\ValueObject\TableDescription;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class DescribeTableOutput extends Result
 {
@@ -35,9 +34,9 @@ class DescribeTableOutput extends Result
         return $this->Table;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = $response->toArray(false);
+        $data = $response->toArray();
 
         $this->Table = empty($data['Table']) ? null : new TableDescription([
             'AttributeDefinitions' => empty($data['Table']['AttributeDefinitions']) ? [] : (function (array $json): array {

--- a/src/Service/DynamoDb/src/Result/GetItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/GetItemOutput.php
@@ -2,12 +2,11 @@
 
 namespace AsyncAws\DynamoDb\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\DynamoDb\ValueObject\AttributeValue;
 use AsyncAws\DynamoDb\ValueObject\Capacity;
 use AsyncAws\DynamoDb\ValueObject\ConsumedCapacity;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class GetItemOutput extends Result
 {
@@ -43,9 +42,9 @@ class GetItemOutput extends Result
         return $this->Item;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = $response->toArray(false);
+        $data = $response->toArray();
 
         $this->Item = empty($data['Item']) ? [] : (function (array $json): array {
             $items = [];

--- a/src/Service/DynamoDb/src/Result/ListTablesOutput.php
+++ b/src/Service/DynamoDb/src/Result/ListTablesOutput.php
@@ -2,11 +2,10 @@
 
 namespace AsyncAws\DynamoDb\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\DynamoDb\DynamoDbClient;
 use AsyncAws\DynamoDb\Input\ListTablesInput;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class ListTablesOutput extends Result implements \IteratorAggregate
 {
@@ -108,9 +107,9 @@ class ListTablesOutput extends Result implements \IteratorAggregate
         }
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = $response->toArray(false);
+        $data = $response->toArray();
 
         $this->TableNames = empty($data['TableNames']) ? [] : (function (array $json): array {
             $items = [];

--- a/src/Service/DynamoDb/src/Result/PutItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/PutItemOutput.php
@@ -2,13 +2,12 @@
 
 namespace AsyncAws\DynamoDb\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\DynamoDb\ValueObject\AttributeValue;
 use AsyncAws\DynamoDb\ValueObject\Capacity;
 use AsyncAws\DynamoDb\ValueObject\ConsumedCapacity;
 use AsyncAws\DynamoDb\ValueObject\ItemCollectionMetrics;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class PutItemOutput extends Result
 {
@@ -59,9 +58,9 @@ class PutItemOutput extends Result
         return $this->ItemCollectionMetrics;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = $response->toArray(false);
+        $data = $response->toArray();
 
         $this->Attributes = empty($data['Attributes']) ? [] : (function (array $json): array {
             $items = [];

--- a/src/Service/DynamoDb/src/Result/QueryOutput.php
+++ b/src/Service/DynamoDb/src/Result/QueryOutput.php
@@ -2,14 +2,13 @@
 
 namespace AsyncAws\DynamoDb\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\DynamoDb\DynamoDbClient;
 use AsyncAws\DynamoDb\Input\QueryInput;
 use AsyncAws\DynamoDb\ValueObject\AttributeValue;
 use AsyncAws\DynamoDb\ValueObject\Capacity;
 use AsyncAws\DynamoDb\ValueObject\ConsumedCapacity;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class QueryOutput extends Result implements \IteratorAggregate
 {
@@ -159,9 +158,9 @@ class QueryOutput extends Result implements \IteratorAggregate
         return $this->ScannedCount;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = $response->toArray(false);
+        $data = $response->toArray();
 
         $this->Items = empty($data['Items']) ? [] : (function (array $json): array {
             $items = [];

--- a/src/Service/DynamoDb/src/Result/ScanOutput.php
+++ b/src/Service/DynamoDb/src/Result/ScanOutput.php
@@ -2,14 +2,13 @@
 
 namespace AsyncAws\DynamoDb\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\DynamoDb\DynamoDbClient;
 use AsyncAws\DynamoDb\Input\ScanInput;
 use AsyncAws\DynamoDb\ValueObject\AttributeValue;
 use AsyncAws\DynamoDb\ValueObject\Capacity;
 use AsyncAws\DynamoDb\ValueObject\ConsumedCapacity;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class ScanOutput extends Result implements \IteratorAggregate
 {
@@ -159,9 +158,9 @@ class ScanOutput extends Result implements \IteratorAggregate
         return $this->ScannedCount;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = $response->toArray(false);
+        $data = $response->toArray();
 
         $this->Items = empty($data['Items']) ? [] : (function (array $json): array {
             $items = [];

--- a/src/Service/DynamoDb/src/Result/UpdateItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/UpdateItemOutput.php
@@ -2,13 +2,12 @@
 
 namespace AsyncAws\DynamoDb\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\DynamoDb\ValueObject\AttributeValue;
 use AsyncAws\DynamoDb\ValueObject\Capacity;
 use AsyncAws\DynamoDb\ValueObject\ConsumedCapacity;
 use AsyncAws\DynamoDb\ValueObject\ItemCollectionMetrics;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class UpdateItemOutput extends Result
 {
@@ -59,9 +58,9 @@ class UpdateItemOutput extends Result
         return $this->ItemCollectionMetrics;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = $response->toArray(false);
+        $data = $response->toArray();
 
         $this->Attributes = empty($data['Attributes']) ? [] : (function (array $json): array {
             $items = [];

--- a/src/Service/DynamoDb/src/Result/UpdateTableOutput.php
+++ b/src/Service/DynamoDb/src/Result/UpdateTableOutput.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\DynamoDb\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\DynamoDb\ValueObject\ArchivalSummary;
 use AsyncAws\DynamoDb\ValueObject\AttributeDefinition;
@@ -18,8 +19,6 @@ use AsyncAws\DynamoDb\ValueObject\RestoreSummary;
 use AsyncAws\DynamoDb\ValueObject\SSEDescription;
 use AsyncAws\DynamoDb\ValueObject\StreamSpecification;
 use AsyncAws\DynamoDb\ValueObject\TableDescription;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class UpdateTableOutput extends Result
 {
@@ -35,9 +34,9 @@ class UpdateTableOutput extends Result
         return $this->TableDescription;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = $response->toArray(false);
+        $data = $response->toArray();
 
         $this->TableDescription = empty($data['TableDescription']) ? null : new TableDescription([
             'AttributeDefinitions' => empty($data['TableDescription']['AttributeDefinitions']) ? [] : (function (array $json): array {

--- a/src/Service/DynamoDb/tests/Unit/Result/CreateTableOutputTest.php
+++ b/src/Service/DynamoDb/tests/Unit/Result/CreateTableOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\DynamoDb\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\DynamoDb\Result\CreateTableOutput;
@@ -48,7 +49,7 @@ class CreateTableOutputTest extends TestCase
         }');
 
         $client = new MockHttpClient($response);
-        $result = new CreateTableOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new CreateTableOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertEquals('Artist', $result->getTableDescription()->getAttributeDefinitions()[0]->getAttributeName());
         self::assertEquals('SongTitle', $result->getTableDescription()->getAttributeDefinitions()[1]->getAttributeName());

--- a/src/Service/DynamoDb/tests/Unit/Result/DeleteItemOutputTest.php
+++ b/src/Service/DynamoDb/tests/Unit/Result/DeleteItemOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\DynamoDb\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\DynamoDb\Result\DeleteItemOutput;
@@ -20,7 +21,7 @@ class DeleteItemOutputTest extends TestCase
         }');
 
         $client = new MockHttpClient($response);
-        $result = new DeleteItemOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new DeleteItemOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertEquals(1, $result->getConsumedCapacity()->getCapacityUnits());
         self::assertEquals('Music', $result->getConsumedCapacity()->getTableName());

--- a/src/Service/DynamoDb/tests/Unit/Result/DeleteTableOutputTest.php
+++ b/src/Service/DynamoDb/tests/Unit/Result/DeleteTableOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\DynamoDb\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\DynamoDb\Result\DeleteTableOutput;
@@ -28,7 +29,7 @@ class DeleteTableOutputTest extends TestCase
         }');
 
         $client = new MockHttpClient($response);
-        $result = new DeleteTableOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new DeleteTableOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertEquals(0, $result->getTableDescription()->getItemCount());
         self::assertEquals(1, $result->getTableDescription()->getProvisionedThroughput()->getNumberOfDecreasesToday());

--- a/src/Service/DynamoDb/tests/Unit/Result/DescribeTableOutputTest.php
+++ b/src/Service/DynamoDb/tests/Unit/Result/DescribeTableOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\DynamoDb\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\DynamoDb\Result\DescribeTableOutput;
@@ -48,7 +49,7 @@ class DescribeTableOutputTest extends TestCase
         }');
 
         $client = new MockHttpClient($response);
-        $result = new DescribeTableOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new DescribeTableOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertEquals('Artist', $result->getTable()->getAttributeDefinitions()[0]->getAttributeName());
         self::assertEquals('SongTitle', $result->getTable()->getAttributeDefinitions()[1]->getAttributeName());

--- a/src/Service/DynamoDb/tests/Unit/Result/GetItemOutputTest.php
+++ b/src/Service/DynamoDb/tests/Unit/Result/GetItemOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\DynamoDb\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\DynamoDb\Result\GetItemOutput;
@@ -27,7 +28,7 @@ class GetItemOutputTest extends TestCase
         }');
 
         $client = new MockHttpClient($response);
-        $result = new GetItemOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new GetItemOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertEquals('Songs About Life', $result->getItem()['AlbumTitle']->getS());
         self::assertEquals('Acme Band', $result->getItem()['Artist']->getS());

--- a/src/Service/DynamoDb/tests/Unit/Result/ListTablesOutputTest.php
+++ b/src/Service/DynamoDb/tests/Unit/Result/ListTablesOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\DynamoDb\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\DynamoDb\Result\ListTablesOutput;
@@ -23,7 +24,7 @@ class ListTablesOutputTest extends TestCase
         }');
 
         $client = new MockHttpClient($response);
-        $result = new ListTablesOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new ListTablesOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         $tableNames = $result->getTableNames(true);
         foreach ($tableNames as $name) {

--- a/src/Service/DynamoDb/tests/Unit/Result/PutItemOutputTest.php
+++ b/src/Service/DynamoDb/tests/Unit/Result/PutItemOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\DynamoDb\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\DynamoDb\Result\PutItemOutput;
@@ -21,7 +22,7 @@ class PutItemOutputTest extends TestCase
         }');
 
         $client = new MockHttpClient($response);
-        $result = new PutItemOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new PutItemOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertEquals(1, $result->getConsumedCapacity()->getCapacityUnits());
         self::assertEquals('Music', $result->getConsumedCapacity()->getTableName());

--- a/src/Service/DynamoDb/tests/Unit/Result/QueryOutputTest.php
+++ b/src/Service/DynamoDb/tests/Unit/Result/QueryOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\DynamoDb\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\DynamoDb\Result\QueryOutput;
@@ -30,7 +31,7 @@ class QueryOutputTest extends TestCase
         }');
 
         $client = new MockHttpClient($response);
-        $result = new QueryOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new QueryOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         $items = $result->getItems(true);
         foreach ($items as $name => $item) {

--- a/src/Service/DynamoDb/tests/Unit/Result/ScanOutputTest.php
+++ b/src/Service/DynamoDb/tests/Unit/Result/ScanOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\DynamoDb\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\DynamoDb\Result\ScanOutput;
@@ -37,7 +38,7 @@ class ScanOutputTest extends TestCase
         }');
 
         $client = new MockHttpClient($response);
-        $result = new ScanOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new ScanOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         $items = $result->getItems(true);
         foreach ($items as $name => $item) {

--- a/src/Service/DynamoDb/tests/Unit/Result/UpdateItemOutputTest.php
+++ b/src/Service/DynamoDb/tests/Unit/Result/UpdateItemOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\DynamoDb\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\DynamoDb\Result\UpdateItemOutput;
@@ -30,7 +31,7 @@ class UpdateItemOutputTest extends TestCase
         }');
 
         $client = new MockHttpClient($response);
-        $result = new UpdateItemOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new UpdateItemOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         $attributes = $result->getAttributes();
         self::assertCount(4, $attributes);

--- a/src/Service/DynamoDb/tests/Unit/Result/UpdateTableOutputTest.php
+++ b/src/Service/DynamoDb/tests/Unit/Result/UpdateTableOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\DynamoDb\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\DynamoDb\Result\UpdateTableOutput;
@@ -49,7 +50,7 @@ class UpdateTableOutputTest extends TestCase
         }');
 
         $client = new MockHttpClient($response);
-        $result = new UpdateTableOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new UpdateTableOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertEquals('Artist', $result->getTableDescription()->getAttributeDefinitions()[0]->getAttributeName());
         self::assertEquals('SongTitle', $result->getTableDescription()->getAttributeDefinitions()[1]->getAttributeName());

--- a/src/Service/Lambda/composer.json
+++ b/src/Service/Lambda/composer.json
@@ -10,8 +10,7 @@
     "require": {
         "php": "^7.2.5",
         "ext-json": "*",
-        "async-aws/core": "^0.4",
-        "symfony/http-client-contracts": "^1.0 || ^2.0"
+        "async-aws/core": "^0.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/Lambda/src/LambdaClient.php
+++ b/src/Service/Lambda/src/LambdaClient.php
@@ -36,7 +36,7 @@ class LambdaClient extends AbstractApi
     {
         $response = $this->getResponse(AddLayerVersionPermissionRequest::create($input)->request());
 
-        return new AddLayerVersionPermissionResponse($response, $this->httpClient);
+        return new AddLayerVersionPermissionResponse($response);
     }
 
     /**
@@ -58,7 +58,7 @@ class LambdaClient extends AbstractApi
     {
         $response = $this->getResponse(InvocationRequest::create($input)->request());
 
-        return new InvocationResponse($response, $this->httpClient);
+        return new InvocationResponse($response);
     }
 
     /**
@@ -81,7 +81,7 @@ class LambdaClient extends AbstractApi
         $input = ListLayerVersionsRequest::create($input);
         $response = $this->getResponse($input->request());
 
-        return new ListLayerVersionsResponse($response, $this->httpClient, $this, $input);
+        return new ListLayerVersionsResponse($response, $this, $input);
     }
 
     /**
@@ -103,7 +103,7 @@ class LambdaClient extends AbstractApi
     {
         $response = $this->getResponse(PublishLayerVersionRequest::create($input)->request());
 
-        return new PublishLayerVersionResponse($response, $this->httpClient);
+        return new PublishLayerVersionResponse($response);
     }
 
     protected function getServiceCode(): string

--- a/src/Service/Lambda/src/Result/AddLayerVersionPermissionResponse.php
+++ b/src/Service/Lambda/src/Result/AddLayerVersionPermissionResponse.php
@@ -2,9 +2,8 @@
 
 namespace AsyncAws\Lambda\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class AddLayerVersionPermissionResponse extends Result
 {
@@ -32,9 +31,9 @@ class AddLayerVersionPermissionResponse extends Result
         return $this->Statement;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = $response->toArray(false);
+        $data = $response->toArray();
 
         $this->Statement = isset($data['Statement']) ? (string) $data['Statement'] : null;
         $this->RevisionId = isset($data['RevisionId']) ? (string) $data['RevisionId'] : null;

--- a/src/Service/Lambda/src/Result/InvocationResponse.php
+++ b/src/Service/Lambda/src/Result/InvocationResponse.php
@@ -2,9 +2,8 @@
 
 namespace AsyncAws\Lambda\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class InvocationResponse extends Result
 {
@@ -72,15 +71,15 @@ class InvocationResponse extends Result
         return $this->StatusCode;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
         $this->StatusCode = $response->getStatusCode();
-        $headers = $response->getHeaders(false);
+        $headers = $response->getHeaders();
 
         $this->FunctionError = $headers['x-amz-function-error'][0] ?? null;
         $this->LogResult = $headers['x-amz-log-result'][0] ?? null;
         $this->ExecutedVersion = $headers['x-amz-executed-version'][0] ?? null;
 
-        $this->Payload = $response->getContent(false);
+        $this->Payload = $response->getContent();
     }
 }

--- a/src/Service/Lambda/src/Result/ListLayerVersionsResponse.php
+++ b/src/Service/Lambda/src/Result/ListLayerVersionsResponse.php
@@ -2,12 +2,11 @@
 
 namespace AsyncAws\Lambda\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\Lambda\Input\ListLayerVersionsRequest;
 use AsyncAws\Lambda\LambdaClient;
 use AsyncAws\Lambda\ValueObject\LayerVersionsListItem;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class ListLayerVersionsResponse extends Result implements \IteratorAggregate
 {
@@ -107,9 +106,9 @@ class ListLayerVersionsResponse extends Result implements \IteratorAggregate
         return $this->NextMarker;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = $response->toArray(false);
+        $data = $response->toArray();
 
         $this->NextMarker = isset($data['NextMarker']) ? (string) $data['NextMarker'] : null;
         $this->LayerVersions = empty($data['LayerVersions']) ? [] : (function (array $json): array {

--- a/src/Service/Lambda/src/Result/PublishLayerVersionResponse.php
+++ b/src/Service/Lambda/src/Result/PublishLayerVersionResponse.php
@@ -2,11 +2,10 @@
 
 namespace AsyncAws\Lambda\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\Lambda\Enum\Runtime;
 use AsyncAws\Lambda\ValueObject\LayerVersionContentOutput;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class PublishLayerVersionResponse extends Result
 {
@@ -111,9 +110,9 @@ class PublishLayerVersionResponse extends Result
         return $this->Version;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = $response->toArray(false);
+        $data = $response->toArray();
 
         $this->Content = empty($data['Content']) ? null : new LayerVersionContentOutput([
             'Location' => isset($data['Content']['Location']) ? (string) $data['Content']['Location'] : null,

--- a/src/Service/Lambda/tests/Integration/LambdaClientTest.php
+++ b/src/Service/Lambda/tests/Integration/LambdaClientTest.php
@@ -5,10 +5,10 @@ namespace AsyncAws\Lambda\Tests\Integration;
 use AsyncAws\Core\Credentials\NullProvider;
 use AsyncAws\Lambda\Input\AddLayerVersionPermissionRequest;
 use AsyncAws\Lambda\Input\InvocationRequest;
-use AsyncAws\Lambda\Input\LayerVersionContentInput;
 use AsyncAws\Lambda\Input\ListLayerVersionsRequest;
 use AsyncAws\Lambda\Input\PublishLayerVersionRequest;
 use AsyncAws\Lambda\LambdaClient;
+use AsyncAws\Lambda\ValueObject\LayerVersionContentInput;
 use PHPUnit\Framework\TestCase;
 
 class LambdaClientTest extends TestCase

--- a/src/Service/Lambda/tests/Unit/Result/AddLayerVersionPermissionResponseTest.php
+++ b/src/Service/Lambda/tests/Unit/Result/AddLayerVersionPermissionResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\Lambda\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\Lambda\Result\AddLayerVersionPermissionResponse;
@@ -18,7 +19,7 @@ class AddLayerVersionPermissionResponseTest extends TestCase
         }');
 
         $client = new MockHttpClient($response);
-        $result = new AddLayerVersionPermissionResponse($client->request('POST', 'http://localhost'), $client);
+        $result = new AddLayerVersionPermissionResponse(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertSame('fooBar', $result->getStatement());
         self::assertSame('123456', $result->getRevisionId());

--- a/src/Service/Lambda/tests/Unit/Result/InvocationResponseTest.php
+++ b/src/Service/Lambda/tests/Unit/Result/InvocationResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\Lambda\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Lambda\Result\InvocationResponse;
 use PHPUnit\Framework\TestCase;
@@ -16,7 +17,7 @@ class InvocationResponseTest extends TestCase
         $response = new SimpleMockedResponse($json, ['content-type' => 'application/json'], 200);
 
         $client = new MockHttpClient($response);
-        $result = new InvocationResponse($client->request('POST', 'http://localhost'), $client);
+        $result = new InvocationResponse(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertEquals($json, $result->getPayload());
         self::assertEquals(200, $result->getStatusCode());

--- a/src/Service/Lambda/tests/Unit/Result/ListLayerVersionsResponseTest.php
+++ b/src/Service/Lambda/tests/Unit/Result/ListLayerVersionsResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\Lambda\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\Lambda\Result\LayerVersionsListItem;
@@ -32,7 +33,7 @@ class ListLayerVersionsResponseTest extends TestCase
         $response = new SimpleMockedResponse(json_encode($data));
 
         $client = new MockHttpClient($response);
-        $result = new ListLayerVersionsResponse($client->request('POST', 'http://localhost'), $client);
+        $result = new ListLayerVersionsResponse(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertEquals($nextMarker, $result->getNextMarker());
         /** @var LayerVersionsListItem $version */

--- a/src/Service/Lambda/tests/Unit/Result/PublishLayerVersionResponseTest.php
+++ b/src/Service/Lambda/tests/Unit/Result/PublishLayerVersionResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\Lambda\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\Lambda\Result\PublishLayerVersionResponse;
@@ -29,7 +30,7 @@ class PublishLayerVersionResponseTest extends TestCase
         ');
 
         $client = new MockHttpClient($response);
-        $result = new PublishLayerVersionResponse($client->request('POST', 'http://localhost'), $client);
+        $result = new PublishLayerVersionResponse(new Response($client->request('POST', 'http://localhost'), $client));
 
         // self::assertTODO(expected, $result->getContent());
         self::assertSame('arn:::fn:arn', $result->getLayerArn());

--- a/src/Service/S3/composer.json
+++ b/src/Service/S3/composer.json
@@ -13,8 +13,7 @@
         "ext-dom": "*",
         "ext-filter": "*",
         "ext-hash": "*",
-        "async-aws/core": "^0.4",
-        "symfony/http-client-contracts": "^1.0 || ^2.0"
+        "async-aws/core": "^0.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/S3/src/Result/CopyObjectOutput.php
+++ b/src/Service/S3/src/Result/CopyObjectOutput.php
@@ -2,12 +2,11 @@
 
 namespace AsyncAws\S3\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\S3\Enum\RequestCharged;
 use AsyncAws\S3\Enum\ServerSideEncryption;
 use AsyncAws\S3\ValueObject\CopyObjectResult;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class CopyObjectOutput extends Result
 {
@@ -138,9 +137,9 @@ class CopyObjectOutput extends Result
         return $this->VersionId;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $headers = $response->getHeaders(false);
+        $headers = $response->getHeaders();
 
         $this->Expiration = $headers['x-amz-expiration'][0] ?? null;
         $this->CopySourceVersionId = $headers['x-amz-copy-source-version-id'][0] ?? null;
@@ -152,7 +151,7 @@ class CopyObjectOutput extends Result
         $this->SSEKMSEncryptionContext = $headers['x-amz-server-side-encryption-context'][0] ?? null;
         $this->RequestCharged = $headers['x-amz-request-charged'][0] ?? null;
 
-        $data = new \SimpleXMLElement($response->getContent(false));
+        $data = new \SimpleXMLElement($response->getContent());
         $this->CopyObjectResult = !$data ? null : new CopyObjectResult([
             'ETag' => ($v = $data->ETag) ? (string) $v : null,
             'LastModified' => ($v = $data->LastModified) ? new \DateTimeImmutable((string) $v) : null,

--- a/src/Service/S3/src/Result/CreateBucketOutput.php
+++ b/src/Service/S3/src/Result/CreateBucketOutput.php
@@ -2,9 +2,8 @@
 
 namespace AsyncAws\S3\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class CreateBucketOutput extends Result
 {
@@ -21,9 +20,9 @@ class CreateBucketOutput extends Result
         return $this->Location;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $headers = $response->getHeaders(false);
+        $headers = $response->getHeaders();
 
         $this->Location = $headers['location'][0] ?? null;
     }

--- a/src/Service/S3/src/Result/DeleteObjectOutput.php
+++ b/src/Service/S3/src/Result/DeleteObjectOutput.php
@@ -2,10 +2,9 @@
 
 namespace AsyncAws\S3\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\S3\Enum\RequestCharged;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class DeleteObjectOutput extends Result
 {
@@ -45,9 +44,9 @@ class DeleteObjectOutput extends Result
         return $this->VersionId;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $headers = $response->getHeaders(false);
+        $headers = $response->getHeaders();
 
         $this->DeleteMarker = isset($headers['x-amz-delete-marker'][0]) ? filter_var($headers['x-amz-delete-marker'][0], \FILTER_VALIDATE_BOOLEAN) : null;
         $this->VersionId = $headers['x-amz-version-id'][0] ?? null;

--- a/src/Service/S3/src/Result/DeleteObjectsOutput.php
+++ b/src/Service/S3/src/Result/DeleteObjectsOutput.php
@@ -2,12 +2,11 @@
 
 namespace AsyncAws\S3\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\S3\Enum\RequestCharged;
 use AsyncAws\S3\ValueObject\DeletedObject;
 use AsyncAws\S3\ValueObject\Error;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class DeleteObjectsOutput extends Result
 {
@@ -54,13 +53,13 @@ class DeleteObjectsOutput extends Result
         return $this->RequestCharged;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $headers = $response->getHeaders(false);
+        $headers = $response->getHeaders();
 
         $this->RequestCharged = $headers['x-amz-request-charged'][0] ?? null;
 
-        $data = new \SimpleXMLElement($response->getContent(false));
+        $data = new \SimpleXMLElement($response->getContent());
         $this->Deleted = !$data->Deleted ? [] : (function (\SimpleXMLElement $xml): array {
             $items = [];
             foreach ($xml as $item) {

--- a/src/Service/S3/src/Result/GetObjectAclOutput.php
+++ b/src/Service/S3/src/Result/GetObjectAclOutput.php
@@ -2,13 +2,12 @@
 
 namespace AsyncAws\S3\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\S3\Enum\RequestCharged;
 use AsyncAws\S3\ValueObject\Grant;
 use AsyncAws\S3\ValueObject\Grantee;
 use AsyncAws\S3\ValueObject\Owner;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class GetObjectAclOutput extends Result
 {
@@ -51,13 +50,13 @@ class GetObjectAclOutput extends Result
         return $this->RequestCharged;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $headers = $response->getHeaders(false);
+        $headers = $response->getHeaders();
 
         $this->RequestCharged = $headers['x-amz-request-charged'][0] ?? null;
 
-        $data = new \SimpleXMLElement($response->getContent(false));
+        $data = new \SimpleXMLElement($response->getContent());
         $this->Owner = !$data->Owner ? null : new Owner([
             'DisplayName' => ($v = $data->Owner->DisplayName) ? (string) $v : null,
             'ID' => ($v = $data->Owner->ID) ? (string) $v : null,

--- a/src/Service/S3/src/Result/GetObjectOutput.php
+++ b/src/Service/S3/src/Result/GetObjectOutput.php
@@ -2,8 +2,8 @@
 
 namespace AsyncAws\S3\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
-use AsyncAws\Core\StreamableBody;
 use AsyncAws\Core\StreamableBodyInterface;
 use AsyncAws\S3\Enum\ObjectLockLegalHoldStatus;
 use AsyncAws\S3\Enum\ObjectLockMode;
@@ -11,8 +11,6 @@ use AsyncAws\S3\Enum\ReplicationStatus;
 use AsyncAws\S3\Enum\RequestCharged;
 use AsyncAws\S3\Enum\ServerSideEncryption;
 use AsyncAws\S3\Enum\StorageClass;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class GetObjectOutput extends Result
 {
@@ -419,9 +417,9 @@ class GetObjectOutput extends Result
         return $this->WebsiteRedirectLocation;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $headers = $response->getHeaders(false);
+        $headers = $response->getHeaders();
 
         $this->DeleteMarker = isset($headers['x-amz-delete-marker'][0]) ? filter_var($headers['x-amz-delete-marker'][0], \FILTER_VALIDATE_BOOLEAN) : null;
         $this->AcceptRanges = $headers['accept-ranges'][0] ?? null;
@@ -460,6 +458,6 @@ class GetObjectOutput extends Result
             }
         }
 
-        $this->Body = new StreamableBody($httpClient->stream($response));
+        $this->Body = $response->toStream();
     }
 }

--- a/src/Service/S3/src/Result/HeadObjectOutput.php
+++ b/src/Service/S3/src/Result/HeadObjectOutput.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\S3\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\S3\Enum\ObjectLockLegalHoldStatus;
 use AsyncAws\S3\Enum\ObjectLockMode;
@@ -9,8 +10,6 @@ use AsyncAws\S3\Enum\ReplicationStatus;
 use AsyncAws\S3\Enum\RequestCharged;
 use AsyncAws\S3\Enum\ServerSideEncryption;
 use AsyncAws\S3\Enum\StorageClass;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class HeadObjectOutput extends Result
 {
@@ -391,9 +390,9 @@ class HeadObjectOutput extends Result
         return $this->WebsiteRedirectLocation;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $headers = $response->getHeaders(false);
+        $headers = $response->getHeaders();
 
         $this->DeleteMarker = isset($headers['x-amz-delete-marker'][0]) ? filter_var($headers['x-amz-delete-marker'][0], \FILTER_VALIDATE_BOOLEAN) : null;
         $this->AcceptRanges = $headers['accept-ranges'][0] ?? null;

--- a/src/Service/S3/src/Result/ListObjectsV2Output.php
+++ b/src/Service/S3/src/Result/ListObjectsV2Output.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\S3\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\S3\Enum\EncodingType;
 use AsyncAws\S3\Input\ListObjectsV2Request;
@@ -9,8 +10,6 @@ use AsyncAws\S3\S3Client;
 use AsyncAws\S3\ValueObject\AwsObject;
 use AsyncAws\S3\ValueObject\CommonPrefix;
 use AsyncAws\S3\ValueObject\Owner;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class ListObjectsV2Output extends Result implements \IteratorAggregate
 {
@@ -277,9 +276,9 @@ class ListObjectsV2Output extends Result implements \IteratorAggregate
         return $this->StartAfter;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = new \SimpleXMLElement($response->getContent(false));
+        $data = new \SimpleXMLElement($response->getContent());
         $this->IsTruncated = ($v = $data->IsTruncated) ? filter_var((string) $v, \FILTER_VALIDATE_BOOLEAN) : null;
         $this->Contents = !$data->Contents ? [] : (function (\SimpleXMLElement $xml): array {
             $items = [];

--- a/src/Service/S3/src/Result/PutObjectAclOutput.php
+++ b/src/Service/S3/src/Result/PutObjectAclOutput.php
@@ -2,10 +2,9 @@
 
 namespace AsyncAws\S3\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\S3\Enum\RequestCharged;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class PutObjectAclOutput extends Result
 {
@@ -21,9 +20,9 @@ class PutObjectAclOutput extends Result
         return $this->RequestCharged;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $headers = $response->getHeaders(false);
+        $headers = $response->getHeaders();
 
         $this->RequestCharged = $headers['x-amz-request-charged'][0] ?? null;
     }

--- a/src/Service/S3/src/Result/PutObjectOutput.php
+++ b/src/Service/S3/src/Result/PutObjectOutput.php
@@ -2,11 +2,10 @@
 
 namespace AsyncAws\S3\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\S3\Enum\RequestCharged;
 use AsyncAws\S3\Enum\ServerSideEncryption;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class PutObjectOutput extends Result
 {
@@ -129,9 +128,9 @@ class PutObjectOutput extends Result
         return $this->VersionId;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $headers = $response->getHeaders(false);
+        $headers = $response->getHeaders();
 
         $this->Expiration = $headers['x-amz-expiration'][0] ?? null;
         $this->ETag = $headers['etag'][0] ?? null;

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -76,7 +76,7 @@ class S3Client extends AbstractApi
     {
         $response = $this->getResponse(CopyObjectRequest::create($input)->request());
 
-        return new CopyObjectOutput($response, $this->httpClient);
+        return new CopyObjectOutput($response);
     }
 
     /**
@@ -102,7 +102,7 @@ class S3Client extends AbstractApi
     {
         $response = $this->getResponse(CreateBucketRequest::create($input)->request());
 
-        return new CreateBucketOutput($response, $this->httpClient);
+        return new CreateBucketOutput($response);
     }
 
     /**
@@ -124,7 +124,7 @@ class S3Client extends AbstractApi
     {
         $response = $this->getResponse(DeleteObjectRequest::create($input)->request());
 
-        return new DeleteObjectOutput($response, $this->httpClient);
+        return new DeleteObjectOutput($response);
     }
 
     /**
@@ -146,7 +146,7 @@ class S3Client extends AbstractApi
     {
         $response = $this->getResponse(DeleteObjectsRequest::create($input)->request());
 
-        return new DeleteObjectsOutput($response, $this->httpClient);
+        return new DeleteObjectsOutput($response);
     }
 
     /**
@@ -181,7 +181,7 @@ class S3Client extends AbstractApi
     {
         $response = $this->getResponse(GetObjectRequest::create($input)->request());
 
-        return new GetObjectOutput($response, $this->httpClient);
+        return new GetObjectOutput($response);
     }
 
     /**
@@ -201,7 +201,7 @@ class S3Client extends AbstractApi
     {
         $response = $this->getResponse(GetObjectAclRequest::create($input)->request());
 
-        return new GetObjectAclOutput($response, $this->httpClient);
+        return new GetObjectAclOutput($response);
     }
 
     /**
@@ -230,7 +230,7 @@ class S3Client extends AbstractApi
     {
         $response = $this->getResponse(HeadObjectRequest::create($input)->request());
 
-        return new HeadObjectOutput($response, $this->httpClient);
+        return new HeadObjectOutput($response);
     }
 
     /**
@@ -257,7 +257,7 @@ class S3Client extends AbstractApi
         $input = ListObjectsV2Request::create($input);
         $response = $this->getResponse($input->request());
 
-        return new ListObjectsV2Output($response, $this->httpClient, $this, $input);
+        return new ListObjectsV2Output($response, $this, $input);
     }
 
     /**
@@ -302,7 +302,7 @@ class S3Client extends AbstractApi
     {
         $response = $this->getResponse(PutObjectRequest::create($input)->request());
 
-        return new PutObjectOutput($response, $this->httpClient);
+        return new PutObjectOutput($response);
     }
 
     /**
@@ -330,7 +330,7 @@ class S3Client extends AbstractApi
     {
         $response = $this->getResponse(PutObjectAclRequest::create($input)->request());
 
-        return new PutObjectAclOutput($response, $this->httpClient);
+        return new PutObjectAclOutput($response);
     }
 
     protected function getServiceCode(): string

--- a/src/Service/S3/tests/Unit/Result/CopyObjectOutputTest.php
+++ b/src/Service/S3/tests/Unit/Result/CopyObjectOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\S3\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\S3\Result\CopyObjectOutput;
@@ -19,7 +20,7 @@ class CopyObjectOutputTest extends TestCase
         </CopyObjectResult>');
 
         $client = new MockHttpClient($response);
-        $result = new CopyObjectOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new CopyObjectOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertNotNull($result->getCopyObjectResult());
         self::assertEquals('"6805f2cfc46c0f04559748bb039d69ae"', $result->getCopyObjectResult()->getETag());

--- a/src/Service/S3/tests/Unit/Result/CreateBucketOutputTest.php
+++ b/src/Service/S3/tests/Unit/Result/CreateBucketOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\S3\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\S3\Result\CreateBucketOutput;
@@ -15,7 +16,7 @@ class CreateBucketOutputTest extends TestCase
         $response = new SimpleMockedResponse('', ['Location' => '/examplebucket']);
 
         $client = new MockHttpClient($response);
-        $result = new CreateBucketOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new CreateBucketOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertSame('/examplebucket', $result->getLocation());
     }

--- a/src/Service/S3/tests/Unit/Result/DeleteObjectOutputTest.php
+++ b/src/Service/S3/tests/Unit/Result/DeleteObjectOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\S3\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\S3\Result\DeleteObjectOutput;
@@ -19,7 +20,7 @@ class DeleteObjectOutputTest extends TestCase
         ]);
 
         $client = new MockHttpClient($response);
-        $result = new DeleteObjectOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new DeleteObjectOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertTrue($result->getDeleteMarker());
         self::assertSame('3/L4kqtJlcpXroDTDmJ+rmSpXd3dIbrHY+MTRCxf3vjVBH40Nr8X8gdRQBpUMLUo', $result->getVersionId());

--- a/src/Service/S3/tests/Unit/Result/DeleteObjectsOutputTest.php
+++ b/src/Service/S3/tests/Unit/Result/DeleteObjectsOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\S3\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\S3\Result\DeleteObjectsOutput;
@@ -33,7 +34,7 @@ class DeleteObjectsOutputTest extends TestCase
         );
 
         $client = new MockHttpClient($response);
-        $result = new DeleteObjectsOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new DeleteObjectsOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertCount(1, $result->getDeleted());
         self::assertEquals('sample1.txt', $result->getDeleted()[0]->getKey());

--- a/src/Service/S3/tests/Unit/Result/GetObjectAclOutputTest.php
+++ b/src/Service/S3/tests/Unit/Result/GetObjectAclOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\S3\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\S3\Result\GetObjectAclOutput;
 use AsyncAws\S3\ValueObject\Grant;
@@ -43,7 +44,7 @@ class GetObjectAclOutputTest extends TestCase
 </AccessControlPolicy>', $headers);
 
         $client = new MockHttpClient($response);
-        $result = new GetObjectAclOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new GetObjectAclOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertEquals('requester', $result->getRequestCharged());
         self::assertEquals('78830d484ca31cf82348f0168785e7929a89f1409630f003170a6b48addfeb9b', $result->getOwner()->getID());
@@ -81,7 +82,7 @@ class GetObjectAclOutputTest extends TestCase
         ');
 
         $client = new MockHttpClient($response);
-        $result = new GetObjectAclOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new GetObjectAclOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         $grants = $result->getGrants();
         self::assertCount(2, $grants);

--- a/src/Service/S3/tests/Unit/Result/GetObjectOutputTest.php
+++ b/src/Service/S3/tests/Unit/Result/GetObjectOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\S3\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\S3\Result\GetObjectOutput;
 use PHPUnit\Framework\TestCase;
@@ -25,7 +26,7 @@ class GetObjectOutputTest extends TestCase
         $response = new SimpleMockedResponse('', $headers);
 
         $client = new MockHttpClient($response);
-        $result = new GetObjectOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new GetObjectOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         // self::assertTODO(expected, $result->getBody());
         self::assertStringContainsString('98bf7d8c15784f0a3d63204441e1e2aa', $result->getETag());
@@ -52,7 +53,7 @@ class GetObjectOutputTest extends TestCase
         ];
         $response = new SimpleMockedResponse('content', $headers);
         $client = new MockHttpClient($response);
-        $result = new GetObjectOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new GetObjectOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         $metadata = $result->getMetadata();
         self::assertCount(1, $metadata);

--- a/src/Service/S3/tests/Unit/Result/HeadObjectOutputTest.php
+++ b/src/Service/S3/tests/Unit/Result/HeadObjectOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\S3\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\S3\Result\HeadObjectOutput;
 use PHPUnit\Framework\TestCase;
@@ -26,7 +27,7 @@ class HeadObjectOutputTest extends TestCase
         $response = new SimpleMockedResponse('', $headers);
 
         $client = new MockHttpClient($response);
-        $result = new HeadObjectOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new HeadObjectOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertNull($result->getDeleteMarker());
         self::assertEquals('bytes', $result->getAcceptRanges());

--- a/src/Service/S3/tests/Unit/Result/ListObjectsV2OutputTest.php
+++ b/src/Service/S3/tests/Unit/Result/ListObjectsV2OutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\S3\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\S3\Result\ListObjectsV2Output;
 use PHPUnit\Framework\TestCase;
@@ -25,7 +26,7 @@ class ListObjectsV2OutputTest extends TestCase
 </ListBucketResult>');
 
         $client = new MockHttpClient($response);
-        $result = new ListObjectsV2Output($client->request('POST', 'http://localhost'), $client);
+        $result = new ListObjectsV2Output(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertFalse($result->getIsTruncated());
         self::assertEquals('async-aws-test', $result->getName());
@@ -55,7 +56,7 @@ class ListObjectsV2OutputTest extends TestCase
         ');
 
         $client = new MockHttpClient($response);
-        $result = new ListObjectsV2Output($client->request('POST', 'http://localhost'), $client);
+        $result = new ListObjectsV2Output(new Response($client->request('POST', 'http://localhost'), $client));
 
         $content = $result->getContents(true);
         self::assertCount(0, $content);

--- a/src/Service/S3/tests/Unit/Result/PutObjectAclOutputTest.php
+++ b/src/Service/S3/tests/Unit/Result/PutObjectAclOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\S3\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\S3\Result\PutObjectAclOutput;
@@ -23,7 +24,7 @@ class PutObjectAclOutputTest extends TestCase
         ]);
 
         $client = new MockHttpClient($response);
-        $result = new PutObjectAclOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new PutObjectAclOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertSame('requester', $result->getRequestCharged());
     }

--- a/src/Service/S3/tests/Unit/Result/PutObjectOutputTest.php
+++ b/src/Service/S3/tests/Unit/Result/PutObjectOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\S3\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\S3\Result\PutObjectAclOutput;
@@ -21,7 +22,7 @@ class PutObjectOutputTest extends TestCase
         ]);
 
         $client = new MockHttpClient($response);
-        $result = new PutObjectAclOutput($client->request('POST', 'http://localhost'), $client);
+        $result = new PutObjectAclOutput(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertSame('requester', $result->getRequestCharged());
     }

--- a/src/Service/Ses/composer.json
+++ b/src/Service/Ses/composer.json
@@ -10,8 +10,7 @@
     "require": {
         "php": "^7.2.5",
         "ext-json": "*",
-        "async-aws/core": "^0.4",
-        "symfony/http-client-contracts": "^1.0 || ^2.0"
+        "async-aws/core": "^0.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/Ses/src/Result/SendEmailResponse.php
+++ b/src/Service/Ses/src/Result/SendEmailResponse.php
@@ -2,9 +2,8 @@
 
 namespace AsyncAws\Ses\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class SendEmailResponse extends Result
 {
@@ -20,9 +19,9 @@ class SendEmailResponse extends Result
         return $this->MessageId;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = $response->toArray(false);
+        $data = $response->toArray();
 
         $this->MessageId = isset($data['MessageId']) ? (string) $data['MessageId'] : null;
     }

--- a/src/Service/Ses/src/SesClient.php
+++ b/src/Service/Ses/src/SesClient.php
@@ -27,7 +27,7 @@ class SesClient extends AbstractApi
     {
         $response = $this->getResponse(SendEmailRequest::create($input)->request());
 
-        return new SendEmailResponse($response, $this->httpClient);
+        return new SendEmailResponse($response);
     }
 
     protected function getServiceCode(): string

--- a/src/Service/Ses/tests/Unit/Result/SendEmailResponseTest.php
+++ b/src/Service/Ses/tests/Unit/Result/SendEmailResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\Ses\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\Ses\Result\SendEmailResponse;
@@ -17,7 +18,7 @@ class SendEmailResponseTest extends TestCase
         }');
 
         $client = new MockHttpClient($response);
-        $result = new SendEmailResponse($client->request('POST', 'http://localhost'), $client);
+        $result = new SendEmailResponse(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertSame('EXAMPLE78603177f-7a5433e7-8edb-42ae-af10-f0181f34d6ee-000000', $result->getMessageId());
     }

--- a/src/Service/Sns/composer.json
+++ b/src/Service/Sns/composer.json
@@ -10,8 +10,7 @@
     "require": {
         "php": "^7.2.5",
         "ext-SimpleXML": "*",
-        "async-aws/core": "^0.4",
-        "symfony/http-client-contracts": "^1.0 || ^2.0"
+        "async-aws/core": "^0.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/Sns/src/Result/PublishResponse.php
+++ b/src/Service/Sns/src/Result/PublishResponse.php
@@ -2,9 +2,8 @@
 
 namespace AsyncAws\Sns\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class PublishResponse extends Result
 {
@@ -20,9 +19,9 @@ class PublishResponse extends Result
         return $this->MessageId;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = new \SimpleXMLElement($response->getContent(false));
+        $data = new \SimpleXMLElement($response->getContent());
         $data = $data->PublishResult;
 
         $this->MessageId = ($v = $data->MessageId) ? (string) $v : null;

--- a/src/Service/Sns/src/SnsClient.php
+++ b/src/Service/Sns/src/SnsClient.php
@@ -27,7 +27,7 @@ class SnsClient extends AbstractApi
     {
         $response = $this->getResponse(PublishInput::create($input)->request());
 
-        return new PublishResponse($response, $this->httpClient);
+        return new PublishResponse($response);
     }
 
     protected function getServiceCode(): string

--- a/src/Service/Sns/tests/Unit/Result/PublishResponseTest.php
+++ b/src/Service/Sns/tests/Unit/Result/PublishResponseTest.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\Sns\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Sns\Result\PublishResponse;
 use PHPUnit\Framework\TestCase;
@@ -24,7 +25,7 @@ class PublishResponseTest extends TestCase
 </PublishResponse>');
 
         $client = new MockHttpClient($response);
-        $result = new PublishResponse($client->request('POST', 'http://localhost'), $client);
+        $result = new PublishResponse(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertEquals('567910cd-659e-55d4-8ccb-5aaf14679dc0', $result->getMessageId());
     }

--- a/src/Service/Sqs/composer.json
+++ b/src/Service/Sqs/composer.json
@@ -10,8 +10,7 @@
     "require": {
         "php": "^7.2.5",
         "ext-SimpleXML": "*",
-        "async-aws/core": "^0.4",
-        "symfony/http-client-contracts": "^1.0 || ^2.0"
+        "async-aws/core": "^0.5"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/Sqs/src/Result/CreateQueueResult.php
+++ b/src/Service/Sqs/src/Result/CreateQueueResult.php
@@ -2,9 +2,8 @@
 
 namespace AsyncAws\Sqs\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class CreateQueueResult extends Result
 {
@@ -20,9 +19,9 @@ class CreateQueueResult extends Result
         return $this->QueueUrl;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = new \SimpleXMLElement($response->getContent(false));
+        $data = new \SimpleXMLElement($response->getContent());
         $data = $data->CreateQueueResult;
 
         $this->QueueUrl = ($v = $data->QueueUrl) ? (string) $v : null;

--- a/src/Service/Sqs/src/Result/GetQueueAttributesResult.php
+++ b/src/Service/Sqs/src/Result/GetQueueAttributesResult.php
@@ -2,9 +2,8 @@
 
 namespace AsyncAws\Sqs\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class GetQueueAttributesResult extends Result
 {
@@ -23,9 +22,9 @@ class GetQueueAttributesResult extends Result
         return $this->Attributes;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = new \SimpleXMLElement($response->getContent(false));
+        $data = new \SimpleXMLElement($response->getContent());
         $data = $data->GetQueueAttributesResult;
 
         $this->Attributes = !$data->Attribute ? [] : (function (\SimpleXMLElement $xml): array {

--- a/src/Service/Sqs/src/Result/GetQueueUrlResult.php
+++ b/src/Service/Sqs/src/Result/GetQueueUrlResult.php
@@ -2,9 +2,8 @@
 
 namespace AsyncAws\Sqs\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class GetQueueUrlResult extends Result
 {
@@ -20,9 +19,9 @@ class GetQueueUrlResult extends Result
         return $this->QueueUrl;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = new \SimpleXMLElement($response->getContent(false));
+        $data = new \SimpleXMLElement($response->getContent());
         $data = $data->GetQueueUrlResult;
 
         $this->QueueUrl = ($v = $data->QueueUrl) ? (string) $v : null;

--- a/src/Service/Sqs/src/Result/ListQueuesResult.php
+++ b/src/Service/Sqs/src/Result/ListQueuesResult.php
@@ -2,9 +2,8 @@
 
 namespace AsyncAws\Sqs\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class ListQueuesResult extends Result implements \IteratorAggregate
 {
@@ -33,9 +32,9 @@ class ListQueuesResult extends Result implements \IteratorAggregate
         return $this->QueueUrls;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = new \SimpleXMLElement($response->getContent(false));
+        $data = new \SimpleXMLElement($response->getContent());
         $data = $data->ListQueuesResult;
 
         $this->QueueUrls = !$data->QueueUrl ? [] : (function (\SimpleXMLElement $xml): array {

--- a/src/Service/Sqs/src/Result/QueueExistsWaiter.php
+++ b/src/Service/Sqs/src/Result/QueueExistsWaiter.php
@@ -6,14 +6,13 @@ use AsyncAws\Core\Exception\Http\HttpException;
 use AsyncAws\Core\Waiter;
 use AsyncAws\Sqs\Input\GetQueueUrlRequest;
 use AsyncAws\Sqs\SqsClient;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class QueueExistsWaiter extends Waiter
 {
     protected const WAIT_TIMEOUT = 200.0;
     protected const WAIT_DELAY = 5.0;
 
-    protected function extractState(ResponseInterface $response, ?HttpException $exception): string
+    protected function extractState(\AsyncAws\Core\Response $response, ?HttpException $exception): string
     {
         if (200 === $response->getStatusCode()) {
             return self::STATE_SUCCESS;

--- a/src/Service/Sqs/src/Result/ReceiveMessageResult.php
+++ b/src/Service/Sqs/src/Result/ReceiveMessageResult.php
@@ -2,11 +2,10 @@
 
 namespace AsyncAws\Sqs\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\Sqs\ValueObject\Message;
 use AsyncAws\Sqs\ValueObject\MessageAttributeValue;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class ReceiveMessageResult extends Result
 {
@@ -25,9 +24,9 @@ class ReceiveMessageResult extends Result
         return $this->Messages;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = new \SimpleXMLElement($response->getContent(false));
+        $data = new \SimpleXMLElement($response->getContent());
         $data = $data->ReceiveMessageResult;
 
         $this->Messages = !$data->Message ? [] : (function (\SimpleXMLElement $xml): array {

--- a/src/Service/Sqs/src/Result/SendMessageResult.php
+++ b/src/Service/Sqs/src/Result/SendMessageResult.php
@@ -2,9 +2,8 @@
 
 namespace AsyncAws\Sqs\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
-use Symfony\Contracts\HttpClient\HttpClientInterface;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class SendMessageResult extends Result
 {
@@ -80,9 +79,9 @@ class SendMessageResult extends Result
         return $this->SequenceNumber;
     }
 
-    protected function populateResult(ResponseInterface $response, HttpClientInterface $httpClient): void
+    protected function populateResult(Response $response): void
     {
-        $data = new \SimpleXMLElement($response->getContent(false));
+        $data = new \SimpleXMLElement($response->getContent());
         $data = $data->SendMessageResult;
 
         $this->MD5OfMessageBody = ($v = $data->MD5OfMessageBody) ? (string) $v : null;

--- a/src/Service/Sqs/src/SqsClient.php
+++ b/src/Service/Sqs/src/SqsClient.php
@@ -43,7 +43,7 @@ class SqsClient extends AbstractApi
     {
         $response = $this->getResponse(ChangeMessageVisibilityRequest::create($input)->request());
 
-        return new Result($response, $this->httpClient);
+        return new Result($response);
     }
 
     /**
@@ -62,7 +62,7 @@ class SqsClient extends AbstractApi
     {
         $response = $this->getResponse(CreateQueueRequest::create($input)->request());
 
-        return new CreateQueueResult($response, $this->httpClient);
+        return new CreateQueueResult($response);
     }
 
     /**
@@ -82,7 +82,7 @@ class SqsClient extends AbstractApi
     {
         $response = $this->getResponse(DeleteMessageRequest::create($input)->request());
 
-        return new Result($response, $this->httpClient);
+        return new Result($response);
     }
 
     /**
@@ -99,7 +99,7 @@ class SqsClient extends AbstractApi
     {
         $response = $this->getResponse(DeleteQueueRequest::create($input)->request());
 
-        return new Result($response, $this->httpClient);
+        return new Result($response);
     }
 
     /**
@@ -116,7 +116,7 @@ class SqsClient extends AbstractApi
     {
         $response = $this->getResponse(GetQueueAttributesRequest::create($input)->request());
 
-        return new GetQueueAttributesResult($response, $this->httpClient);
+        return new GetQueueAttributesResult($response);
     }
 
     /**
@@ -133,7 +133,7 @@ class SqsClient extends AbstractApi
     {
         $response = $this->getResponse(GetQueueUrlRequest::create($input)->request());
 
-        return new GetQueueUrlResult($response, $this->httpClient);
+        return new GetQueueUrlResult($response);
     }
 
     /**
@@ -150,7 +150,7 @@ class SqsClient extends AbstractApi
     {
         $response = $this->getResponse(ListQueuesRequest::create($input)->request());
 
-        return new ListQueuesResult($response, $this->httpClient);
+        return new ListQueuesResult($response);
     }
 
     /**
@@ -166,7 +166,7 @@ class SqsClient extends AbstractApi
     {
         $response = $this->getResponse(PurgeQueueRequest::create($input)->request());
 
-        return new Result($response, $this->httpClient);
+        return new Result($response);
     }
 
     /**
@@ -184,7 +184,7 @@ class SqsClient extends AbstractApi
         $input = GetQueueUrlRequest::create($input);
         $response = $this->getResponse($input->request());
 
-        return new QueueExistsWaiter($response, $this->httpClient, $this, $input);
+        return new QueueExistsWaiter($response, $this, $input);
     }
 
     /**
@@ -209,7 +209,7 @@ class SqsClient extends AbstractApi
     {
         $response = $this->getResponse(ReceiveMessageRequest::create($input)->request());
 
-        return new ReceiveMessageResult($response, $this->httpClient);
+        return new ReceiveMessageResult($response);
     }
 
     /**
@@ -231,7 +231,7 @@ class SqsClient extends AbstractApi
     {
         $response = $this->getResponse(SendMessageRequest::create($input)->request());
 
-        return new SendMessageResult($response, $this->httpClient);
+        return new SendMessageResult($response);
     }
 
     protected function getServiceCode(): string

--- a/src/Service/Sqs/tests/Unit/Result/CreateQueueResultTest.php
+++ b/src/Service/Sqs/tests/Unit/Result/CreateQueueResultTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\Sqs\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Sqs\Result\CreateQueueResult;
 use PHPUnit\Framework\TestCase;
@@ -27,7 +28,7 @@ XML
         );
 
         $client = new MockHttpClient($response);
-        $result = new CreateQueueResult($client->request('POST', 'http://localhost'), $client);
+        $result = new CreateQueueResult(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertEquals('https://queue.amazonaws.com/123456789012/MyQueue', $result->getQueueUrl());
     }

--- a/src/Service/Sqs/tests/Unit/Result/GetQueueAttributesResultTest.php
+++ b/src/Service/Sqs/tests/Unit/Result/GetQueueAttributesResultTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\Sqs\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Sqs\Result\GetQueueAttributesResult;
 use PHPUnit\Framework\TestCase;
@@ -61,7 +62,7 @@ XML
         );
 
         $client = new MockHttpClient($response);
-        $result = new GetQueueAttributesResult($client->request('POST', 'http://localhost'), $client);
+        $result = new GetQueueAttributesResult(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertArrayHasKey('MaximumMessageSize', $result->getAttributes());
         self::assertEquals('8192', $result->getAttributes()['MaximumMessageSize']);

--- a/src/Service/Sqs/tests/Unit/Result/GetQueueUrlResultTest.php
+++ b/src/Service/Sqs/tests/Unit/Result/GetQueueUrlResultTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\Sqs\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Sqs\Result\GetQueueUrlResult;
 use PHPUnit\Framework\TestCase;
@@ -26,7 +27,7 @@ XML
         );
 
         $client = new MockHttpClient($response);
-        $result = new GetQueueUrlResult($client->request('POST', 'http://localhost'), $client);
+        $result = new GetQueueUrlResult(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertEquals('https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue', $result->getQueueUrl());
     }

--- a/src/Service/Sqs/tests/Unit/Result/ListQueuesResultTest.php
+++ b/src/Service/Sqs/tests/Unit/Result/ListQueuesResultTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\Sqs\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Sqs\Result\ListQueuesResult;
 use PHPUnit\Framework\TestCase;
@@ -26,7 +27,7 @@ XML
         );
 
         $client = new MockHttpClient($response);
-        $result = new ListQueuesResult($client->request('POST', 'http://localhost'), $client);
+        $result = new ListQueuesResult(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertContains('https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue', $result->getQueueUrls());
         self::assertContains('https://sqs.us-east-2.amazonaws.com/123456789012/MyQueue', $result);

--- a/src/Service/Sqs/tests/Unit/Result/ReceiveMessageResultTest.php
+++ b/src/Service/Sqs/tests/Unit/Result/ReceiveMessageResultTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\Sqs\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Sqs\Result\ReceiveMessageResult;
 use PHPUnit\Framework\TestCase;
@@ -51,7 +52,7 @@ XML
         );
 
         $client = new MockHttpClient($response);
-        $result = new ReceiveMessageResult($client->request('POST', 'http://localhost'), $client);
+        $result = new ReceiveMessageResult(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertCount(1, $result->getMessages());
         $message = $result->getMessages()[0];

--- a/src/Service/Sqs/tests/Unit/Result/SendMessageResultTest.php
+++ b/src/Service/Sqs/tests/Unit/Result/SendMessageResultTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\Sqs\Tests\Unit\Result;
 
+use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Sqs\Result\SendMessageResult;
 use PHPUnit\Framework\TestCase;
@@ -28,7 +29,7 @@ XML
         );
 
         $client = new MockHttpClient($response);
-        $result = new SendMessageResult($client->request('POST', 'http://localhost'), $client);
+        $result = new SendMessageResult(new Response($client->request('POST', 'http://localhost'), $client));
 
         self::assertEquals('5fea7756-0ea4-451a-a703-a558b933e274', $result->getMessageId());
         self::assertEquals('fafb00f5732ab283681e124bf8747ed1', $result->getMD5OfMessageBody());


### PR DESCRIPTION
This PR removes the coupling between Services and http-client by exposing a new `Response` object to client

PRO:
- code in Result and Waiter have been merged
- remove dependencies to symfony/http-client in each services
- AbstractApi does not contains protected properties

CON
- BC break for all services, that have to require `core: ^0.5`


WDYT?