### PR TITLE
[DynamoDB] Add waiter for table not exists after delete

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -31,6 +31,7 @@
                 "Query",
                 "Scan",
                 "TableExists",
+                "TableNotExists",
                 "UpdateItem",
                 "UpdateTable"
             ]

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -30,6 +30,4 @@ parameters:
         - '#^Parameter \#4 \$headers of class AsyncAws\\Core\\Request constructor expects array<array<string>\|string>, array<string, AsyncAws\\[^\\]+\\Enum\\[^ ]+ given\.$#'
         - message: '#^Class AsyncAws\\S3\\(Result|Input)\\[^ ]* not found\.$#'
           path: src/Integration/Flysystem/S3/src
-        - message: '#^Else branch is unreachable because ternary operator condition is always true\.$#'
-          path: src/Service/*/src/Result/*Waiter.php
 

--- a/src/CodeGenerator/src/Definition/ExceptionShape.php
+++ b/src/CodeGenerator/src/Definition/ExceptionShape.php
@@ -6,6 +6,11 @@ namespace AsyncAws\CodeGenerator\Definition;
 
 class ExceptionShape extends Shape
 {
+    public function hasError(): bool
+    {
+        return isset($this->data['error']);
+    }
+
     public function getCode(): ?string
     {
         return $this->data['error']['code'] ?? null;

--- a/src/CodeGenerator/src/Generator/WaiterGenerator.php
+++ b/src/CodeGenerator/src/Generator/WaiterGenerator.php
@@ -218,14 +218,15 @@ class WaiterGenerator
     {
         $checks = [];
         $error = $acceptor->getError();
-        if (null !== $expected = $acceptor->getExpected()) {
+        if ($error->hasError()) {
+            if (null !== $code = $error->getCode()) {
+                $checks[] = '$exception->getAwsCode() === ' . \var_export($code, true);
+            }
+            if (null !== $code = $error->getStatusCode()) {
+                $checks[] = '$exception->getCode() === ' . \var_export($code, true);
+            }
+        } elseif (null !== $expected = $acceptor->getExpected()) {
             $checks[] = '$exception->getAwsCode() === ' . \var_export($expected, true);
-        }
-        if (null !== $code = $error->getCode()) {
-            $checks[] = '$exception->getAwsCode() === ' . \var_export($code, true);
-        }
-        if (null !== $code = $error->getStatusCode()) {
-            $checks[] = '$exception->getCode() === ' . \var_export($code, true);
         }
 
         if (0 === \count($checks)) {

--- a/src/CodeGenerator/src/Generator/WaiterGenerator.php
+++ b/src/CodeGenerator/src/Generator/WaiterGenerator.php
@@ -182,8 +182,6 @@ class WaiterGenerator
                 return $this->getAcceptorStatusBody($acceptor);
             case WaiterAcceptor::MATCHER_PATH:
                 return $this->getAcceptorPathBody($acceptor);
-            case WaiterAcceptor::MATCHER_ERROR:
-                return $this->getAcceptorErrorBody($acceptor);
             default:
                 throw new \RuntimeException(sprintf('Acceptor matcher "%s" is not yet implemented', $acceptor->getMatcher()));
         }
@@ -220,13 +218,13 @@ class WaiterGenerator
         $error = $acceptor->getError();
         if ($error->hasError()) {
             if (null !== $code = $error->getCode()) {
-                $checks[] = '$exception->getAwsCode() === ' . \var_export($code, true);
+                $checks[] = \var_export($code, true) . ' === $exception->getAwsCode()';
             }
             if (null !== $code = $error->getStatusCode()) {
-                $checks[] = '$exception->getCode() === ' . \var_export($code, true);
+                $checks[] = \var_export($code, true) . ' === $exception->getCode()';
             }
         } elseif (null !== $expected = $acceptor->getExpected()) {
-            $checks[] = '$exception->getAwsCode() === ' . \var_export($expected, true);
+            $checks[] = \var_export($expected, true) . ' === $exception->getAwsCode()';
         }
 
         if (0 === \count($checks)) {

--- a/src/Core/src/Exception/Http/HttpExceptionTrait.php
+++ b/src/Core/src/Exception/Http/HttpExceptionTrait.php
@@ -70,6 +70,12 @@ trait HttpExceptionTrait
         // The MIME type isn't explicitly checked because some formats inherit from others
         // Ex: JSON:API follows RFC 7807 semantics, Hydra can be used in any JSON-LD-compatible format
         if ($isJson && $body = json_decode($response->getContent(false), true)) {
+            if (isset($body['__type'])) {
+                $parts = explode('#', $body['__type'], 2);
+                $this->awsCode = $parts[1] ?? $parts[0];
+                $message .= "\n\n" . $body['__type'] . "\n\n";
+            }
+
             if (isset($body['hydra:title']) || isset($body['hydra:description'])) {
                 // see http://www.hydra-cg.com/spec/latest/core/#description-of-http-status-codes-and-errors
                 $separator = isset($body['hydra:title'], $body['hydra:description']) ? "\n\n" : '';
@@ -84,9 +90,6 @@ trait HttpExceptionTrait
             } elseif (isset($body['Message'])) {
                 $this->awsMessage = $body['Message'];
                 $message .= "\n\n" . $body['Message'] . "\n\n";
-            }
-            if (isset($body['__type'])) {
-                list(, $this->awsCode) = explode('#', $body['__type'], 2);
             }
         } else {
             try {

--- a/src/Core/src/Exception/Http/HttpExceptionTrait.php
+++ b/src/Core/src/Exception/Http/HttpExceptionTrait.php
@@ -85,6 +85,9 @@ trait HttpExceptionTrait
                 $this->awsMessage = $body['Message'];
                 $message .= "\n\n" . $body['Message'] . "\n\n";
             }
+            if (isset($body['__type'])) {
+                list(, $this->awsCode) = explode('#', $body['__type'], 2);
+            }
         } else {
             try {
                 $body = $response->getContent(false);

--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -34,11 +34,6 @@ class Response
      */
     private $resolveResult;
 
-    /**
-     * @var HttpException
-     */
-    private $exception;
-
     public function __construct(ResponseInterface $response, HttpClientInterface $httpClient)
     {
         $this->response = $response;
@@ -56,14 +51,13 @@ class Response
      * Make sure the actual request is executed.
      *
      * @param float|null $timeout Duration in seconds before aborting. When null wait until the end of execution.
-     * @param bool       $throw   Whether an exception should be thrown on 3/4/5xx status codes
      *
      * @return bool whether the request is executed or not
      *
      * @throws NetworkException
      * @throws HttpException
      */
-    final public function resolve(?float $timeout = null, bool $throw = true): bool
+    final public function resolve(?float $timeout = null): bool
     {
         if (null !== $this->resolveResult) {
             if ($this->resolveResult instanceof \Exception) {
@@ -93,16 +87,15 @@ class Response
         }
 
         if (500 <= $statusCode) {
-            $this->exception = new ServerException($this->response);
+            throw $this->resolveResult = new ServerException($this->response);
         }
+
         if (400 <= $statusCode) {
-            $this->exception = new ClientException($this->response);
+            throw $this->resolveResult = new ClientException($this->response);
         }
+
         if (300 <= $statusCode) {
-            $this->exception = new RedirectionException($this->response);
-        }
-        if ($throw && null !== $this->exception) {
-            throw $this->resolveResult = $this->exception;
+            throw $this->resolveResult = new RedirectionException($this->response);
         }
 
         return $this->resolveResult = true;
@@ -161,12 +154,5 @@ class Response
     final public function toStream(): StreamableBody
     {
         return new StreamableBody($this->httpClient->stream($this->response));
-    }
-
-    final public function getException(): ?HttpException
-    {
-        $this->resolve();
-
-        return $this->exception;
     }
 }

--- a/src/Core/src/Waiter.php
+++ b/src/Core/src/Waiter.php
@@ -94,10 +94,9 @@ class Waiter
             $this->stealResponse($this->refreshState());
         }
 
-        $exception = null;
         $this->resolve();
 
-        $state = $this->extractState($this->response, $exception);
+        $state = $this->extractState($this->response, $this->response->getException());
         $this->needRefresh = true;
 
         switch ($state) {

--- a/src/Service/DynamoDb/src/DynamoDbClient.php
+++ b/src/Service/DynamoDb/src/DynamoDbClient.php
@@ -24,6 +24,7 @@ use AsyncAws\DynamoDb\Result\PutItemOutput;
 use AsyncAws\DynamoDb\Result\QueryOutput;
 use AsyncAws\DynamoDb\Result\ScanOutput;
 use AsyncAws\DynamoDb\Result\TableExistsWaiter;
+use AsyncAws\DynamoDb\Result\TableNotExistsWaiter;
 use AsyncAws\DynamoDb\Result\UpdateItemOutput;
 use AsyncAws\DynamoDb\Result\UpdateTableOutput;
 
@@ -271,6 +272,23 @@ class DynamoDbClient extends AbstractApi
         $response = $this->getResponse($input->request());
 
         return new TableExistsWaiter($response, $this, $input);
+    }
+
+    /**
+     * Check status of operation describeTable.
+     *
+     * @see describeTable
+     *
+     * @param array{
+     *   TableName: string,
+     * }|DescribeTableInput $input
+     */
+    public function tableNotExists($input): TableNotExistsWaiter
+    {
+        $input = DescribeTableInput::create($input);
+        $response = $this->getResponse($input->request());
+
+        return new TableNotExistsWaiter($response, $this, $input);
     }
 
     /**

--- a/src/Service/DynamoDb/src/Result/TableExistsWaiter.php
+++ b/src/Service/DynamoDb/src/Result/TableExistsWaiter.php
@@ -11,12 +11,16 @@ use AsyncAws\DynamoDb\Input\DescribeTableInput;
 class TableExistsWaiter extends Waiter
 {
     protected const WAIT_TIMEOUT = 500.0;
-    protected const WAIT_DELAY = 5.0;
+    protected const WAIT_DELAY = 20.0;
 
     protected function extractState(Response $response, ?HttpException $exception): string
     {
         if (200 === $response->getStatusCode() && 'ACTIVE' === ($response->toArray()['Table']['TableStatus'] ?? null)) {
             return self::STATE_SUCCESS;
+        }
+
+        if (null !== $exception && 'ResourceNotFoundException' === $exception->getAwsCode()) {
+            return self::STATE_PENDING;
         }
 
         /** @psalm-suppress TypeDoesNotContainType */

--- a/src/Service/DynamoDb/src/Result/TableNotExistsWaiter.php
+++ b/src/Service/DynamoDb/src/Result/TableNotExistsWaiter.php
@@ -11,16 +11,12 @@ use AsyncAws\DynamoDb\Input\DescribeTableInput;
 class TableNotExistsWaiter extends Waiter
 {
     protected const WAIT_TIMEOUT = 500.0;
-    protected const WAIT_DELAY = 2.0;
+    protected const WAIT_DELAY = 20.0;
 
     protected function extractState(Response $response, ?HttpException $exception): string
     {
-        if (400 === $response->getStatusCode()) {
-            // {"__type":"com.amazonaws.dynamodb.v20120810#ResourceNotFoundException","message":"Requested resource not found: Table: errors not found"}
-            list(, $errorType) = explode('#', $response->toArray()['__type'] ?? '', 2);
-            if ('ResourceNotFoundException' === $errorType) {
-                return self::STATE_SUCCESS;
-            }
+        if (null !== $exception && 'ResourceNotFoundException' === $exception->getAwsCode()) {
+            return self::STATE_SUCCESS;
         }
 
         /** @psalm-suppress TypeDoesNotContainType */

--- a/src/Service/DynamoDb/tests/Unit/DynamoDbClientTest.php
+++ b/src/Service/DynamoDb/tests/Unit/DynamoDbClientTest.php
@@ -26,6 +26,8 @@ use AsyncAws\DynamoDb\Result\ListTablesOutput;
 use AsyncAws\DynamoDb\Result\PutItemOutput;
 use AsyncAws\DynamoDb\Result\QueryOutput;
 use AsyncAws\DynamoDb\Result\ScanOutput;
+use AsyncAws\DynamoDb\Result\TableExistsWaiter;
+use AsyncAws\DynamoDb\Result\TableNotExistsWaiter;
 use AsyncAws\DynamoDb\Result\UpdateItemOutput;
 use AsyncAws\DynamoDb\Result\UpdateTableOutput;
 use AsyncAws\DynamoDb\ValueObject\KeySchemaElement;
@@ -157,6 +159,34 @@ class DynamoDbClientTest extends TestCase
         $result = $client->Scan($input);
 
         self::assertInstanceOf(ScanOutput::class, $result);
+        self::assertFalse($result->info()['resolved']);
+    }
+
+    public function testTableExists(): void
+    {
+        $client = new DynamoDbClient([], new NullProvider(), new MockHttpClient());
+
+        $input = new DescribeTableInput([
+            'TableName' => 'Foobar',
+
+        ]);
+        $result = $client->tableExists($input);
+
+        self::assertInstanceOf(TableExistsWaiter::class, $result);
+        self::assertFalse($result->info()['resolved']);
+    }
+
+    public function testTableNotExists(): void
+    {
+        $client = new DynamoDbClient([], new NullProvider(), new MockHttpClient());
+
+        $input = new DescribeTableInput([
+            'TableName' => 'Foobar',
+
+        ]);
+        $result = $client->tableNotExists($input);
+
+        self::assertInstanceOf(TableNotExistsWaiter::class, $result);
         self::assertFalse($result->info()['resolved']);
     }
 

--- a/src/Service/Sqs/src/Result/QueueExistsWaiter.php
+++ b/src/Service/Sqs/src/Result/QueueExistsWaiter.php
@@ -19,7 +19,7 @@ class QueueExistsWaiter extends Waiter
             return self::STATE_SUCCESS;
         }
 
-        if (null !== $exception && 'QueueDoesNotExist' === $exception->getAwsCode() && 'AWS.SimpleQueueService.NonExistentQueue' === $exception->getAwsCode() && 400 === $exception->getCode()) {
+        if (null !== $exception && 'AWS.SimpleQueueService.NonExistentQueue' === $exception->getAwsCode() && 400 === $exception->getCode()) {
             return self::STATE_PENDING;
         }
 

--- a/src/Service/Sqs/src/Result/QueueExistsWaiter.php
+++ b/src/Service/Sqs/src/Result/QueueExistsWaiter.php
@@ -19,7 +19,7 @@ class QueueExistsWaiter extends Waiter
             return self::STATE_SUCCESS;
         }
 
-        if (null !== $exception && 'AWS.SimpleQueueService.NonExistentQueue' === $exception->getAwsCode() && 400 === $exception->getCode()) {
+        if (null !== $exception && 'QueueDoesNotExist' === $exception->getAwsCode() && 'AWS.SimpleQueueService.NonExistentQueue' === $exception->getAwsCode() && 400 === $exception->getCode()) {
             return self::STATE_PENDING;
         }
 


### PR DESCRIPTION
This waiter is in the official SDK.
https://github.com/aws/aws-sdk-php/blob/3.133.39/src/data/dynamodb/2012-08-10/waiters-2.json

Usage: 
```php
$dynamodbClient->deleteTable(['TableName' => 'errors']);
$dynamodbClient->tableNotExists(['TableName' => 'errors'])->wait();
```