### PR TITLE
[Lambda] Invoke several concurrent Lambdas (non blocking)

### DIFF
--- a/src/Service/Lambda/src/Closure/BatchAsyncClosureInterface.php
+++ b/src/Service/Lambda/src/Closure/BatchAsyncClosureInterface.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+namespace AsyncAws\Lambda\Closure;
+
+use AsyncAws\Lambda\Result\InvocationResponse;
+
+/**
+ * Ease invokeBatchAsync implementation
+ * Allow unit testing of the callable implementation
+ *
+ * Example:
+ *
+ * // Instead of untestable Business Logic
+ * $callback = function(InvocationResponse $invocationResponse) {
+ *     // Business Logic
+ * };
+ * $callback($invocationResponse);
+ *
+ * // Testable Business Logic
+ * $callback = new BatchAsyncClosure(); // Implements BatchAsyncClosureInterface
+ * $callback($invocationResponse);
+ *
+ * @author Guillaume MOREL <me@gmorel.io>
+ */
+interface BatchAsyncClosureInterface
+{
+    public function __invoke(InvocationResponse $invocationResponse): void;
+}

--- a/src/Service/Lambda/src/LambdaClient.php
+++ b/src/Service/Lambda/src/LambdaClient.php
@@ -62,7 +62,7 @@ class LambdaClient extends AbstractApi
     {
         $response = $this->getResponse(InvocationRequest::create($input)->request(), new RequestContext(['operation' => 'Invoke']));
 
-        return new InvocationResponse($response, $this->httpClient); // @todo see with httpClient as private
+        return new InvocationResponse($response);
     }
 
     /**
@@ -72,7 +72,9 @@ class LambdaClient extends AbstractApi
      * @see https://symfony.com/doc/current/components/http_client.html#concurrent-requests
      *
      * @param InvocationRequest[] $inputs
+     *
      * @return InvocationResponse[]
+     *
      * @throws \Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface
      */
     public function invokeBatchAsync(HttpClientInterface $httpClient, array $inputs, BatchAsyncClosureInterface $callback): array

--- a/src/Service/Lambda/tests/Integration/LambdaClientTest.php
+++ b/src/Service/Lambda/tests/Integration/LambdaClientTest.php
@@ -44,7 +44,7 @@ class LambdaClientTest extends TestCase
             'FunctionName' => 'Index',
             'Payload' => '{"name": "jderusse"}',
         ]);
-        $result = $client->Invoke($input);
+        $result = $client->Invoke($input); // @todo Find why the capital I ?
 
         $result->resolve();
 
@@ -53,6 +53,19 @@ class LambdaClientTest extends TestCase
         self::assertNull($result->getLogResult());
         self::assertSame('"hello jderusse"', $result->getPayload());
         self::assertSame('$LATEST', $result->getExecutedVersion());
+    }
+
+    public function testInvokeBatchAsync(): void
+    {
+        $client = $this->getClient();
+
+//        $input = new InvocationRequest([
+//            'FunctionName' => 'Index',
+//            'Payload' => '{"name": "jderusse"}',
+//        ]);
+        $result = $client->invokeBatchAsync($input);
+
+        // @todo Implement
     }
 
     public function testListLayerVersions(): void


### PR DESCRIPTION
#### Pain Point

We would like to use lambda this way:
https://twitter.com/matthieunapoli/status/1239960294736031744

Basically spawning 10 lambdas and don't process lambda replies in the order they were sent.
Lambda example:
```php
<?php declare(strict_types=1);

require __DIR__ . '/vendor/autoload.php';

return function ($event) {
    $rand = rand (1, 4);
    sleep($rand);

    return 'Hello ' . ($event['name'] ?? 'world') . ': ' . $rand . 's';
};

```

Introduce LambdaClient->invokeBatchAsync()
    Using `HttpClient->stream()`
https://symfony.com/doc/current/components/http_client.html#multiplexing-responses
    
    If you have 10 Lambda triggered: 1, 2, 3, ..., 9, 10
    And each of theses Lambda can reply from 1sec to 4sec
    It won't wait these 10 Lambda to complete to get their result
    For example: 4, 2, 6, ..., 5, 1
    And will call `BatchAsyncClosureInterface` closure async
    
    Usage:
```php
            $requests = [];
            for ($i = 0; $i < 10; ++$i) {
                $requests[] = new InvocationRequest([
                    'FunctionName' => 'app-dev-hellow_world',
                    'Payload' => "{\"name\": $i}",
                ]);
            }
    
            $callback = new BatchAsyncClosure();
    
            $client = $this->createClient($this->httpClient);
            $client->invokeBatchAsync($this->httpClient, $requests, $callback);
```   

```php
class BatchAsyncClosure implements BatchAsyncClosureInterface
{
    public function __invoke(InvocationResponse $invocationResponse): void
    {
        dump($invocationResponse->getPayload());
    }
} 
```

    "Hello 4: 1s"
    "Hello 2: 1s"
    "Hello 6: 1s"
    "Hello 3: 2s"
    "Hello 9: 2s"
    "Hello 7: 2s"
    "Hello 8: 3s"
    "Hello 5: 3s"
    "Hello 0: 4s"
    "Hello 1: 4s"