### PR TITLE
Adding naive implementation of multiplexing responses

### DIFF
--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -15,6 +15,7 @@ use AsyncAws\Core\Stream\ResultStream;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 
 /**
  * The response provides a facade to manipulate HttpResponses.
@@ -153,6 +154,23 @@ class Response
     public function getStatusCode(): int
     {
         return $this->httpResponse->getStatusCode();
+    }
+
+    /**
+     * @param self[] $responses
+     */
+    public static function multiplex(array $responses, float $timeout = null): ResponseStreamInterface
+    {
+        $httpResponses = [];
+        $httpClient = null;
+        foreach ($responses as $response) {
+            if (null === $httpClient) {
+                $httpClient = $response->httpClient;
+            }
+            $httpResponses[] = $response->httpResponse;
+        }
+
+        return $httpClient->stream($httpResponses, $timeout);
     }
 
     public function toStream(): ResultStream

--- a/src/Core/src/Result.php
+++ b/src/Core/src/Result.php
@@ -6,6 +6,7 @@ namespace AsyncAws\Core;
 
 use AsyncAws\Core\Exception\Http\HttpException;
 use AsyncAws\Core\Exception\Http\NetworkException;
+use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 
 /**
  * Base class for all return values from a Api Client methods. Example: `FooClient::bar(): Result`.
@@ -79,6 +80,22 @@ class Result
     final public function cancel(): void
     {
         $this->response->cancel();
+    }
+
+    /**
+     * This only work if the http responses are produced by the same HTTP client.
+     * See https://symfony.com/doc/current/components/http_client.html#multiplexing-responses.
+     *
+     * @param self[] $results
+     */
+    public static function multiplex(array $results, float $timeout = null): ResponseStreamInterface
+    {
+        $responses = [];
+        foreach ($results as $result) {
+            $responses[] = $result->response;
+        }
+
+        return Response::multiplex($responses, $timeout);
     }
 
     final protected function registerPrefetch(self $result): void


### PR DESCRIPTION
This is an alternative to what #368 is trying to do. 

Im not sure this is a good idea because: 
1. It exposes Symfony responses to the user
2. The user has no idea what response that is related to what result
3. There is no result classes anymore

Could we build on to this somehow? 

I dont want to merge it in the current state