### PR TITLE
Make ResponseBody rewindable

### DIFF
--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -160,7 +160,7 @@ class Response
     {
         $this->resolve();
 
-        if (is_callable([$this->httpResponse, 'toStream'])) {
+        if (\is_callable([$this->httpResponse, 'toStream'])) {
             return new ResponseBodyResourceStream($this->httpResponse->toStream());
         }
 

--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -158,12 +158,11 @@ class Response
 
     public function toStream(): ResultStream
     {
+        $this->resolve();
+
         if (is_callable([$this->httpResponse, 'toStream'])) {
             return new ResponseBodyResourceStream($this->httpResponse->toStream());
         }
-
-        // ensure no exceptions are thrown
-        $this->resolve();
 
         return new ResponseBodyStream($this->httpClient->stream($this->httpResponse));
     }

--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -10,6 +10,7 @@ use AsyncAws\Core\Exception\Http\NetworkException;
 use AsyncAws\Core\Exception\Http\RedirectionException;
 use AsyncAws\Core\Exception\Http\ServerException;
 use AsyncAws\Core\Exception\RuntimeException;
+use AsyncAws\Core\Stream\ResponseBodyResourceStream;
 use AsyncAws\Core\Stream\ResponseBodyStream;
 use AsyncAws\Core\Stream\ResultStream;
 use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
@@ -157,6 +158,13 @@ class Response
 
     public function toStream(): ResultStream
     {
+        if (\method_exists($this->httpResponse, 'toStream')) {
+            return new ResponseBodyResourceStream($this->httpResponse->toStream());
+        }
+
+        // ensure no exceptions are thrown
+        $this->resolve();
+
         return new ResponseBodyStream($this->httpClient->stream($this->httpResponse));
     }
 }

--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -158,7 +158,7 @@ class Response
 
     public function toStream(): ResultStream
     {
-        if (\method_exists($this->httpResponse, 'toStream')) {
+        if (is_callable([$this->httpResponse, 'toStream'])) {
             return new ResponseBodyResourceStream($this->httpResponse->toStream());
         }
 

--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -130,6 +130,10 @@ class Response
         $this->resolveResult = false;
     }
 
+    /**
+     * @throws NetworkException
+     * @throws HttpException
+     */
     public function getHeaders(): array
     {
         $this->resolve();
@@ -137,6 +141,10 @@ class Response
         return $this->httpResponse->getHeaders(false);
     }
 
+    /**
+     * @throws NetworkException
+     * @throws HttpException
+     */
     public function getContent(): string
     {
         $this->resolve();
@@ -144,6 +152,10 @@ class Response
         return $this->httpResponse->getContent(false);
     }
 
+    /**
+     * @throws NetworkException
+     * @throws HttpException
+     */
     public function toArray(): array
     {
         $this->resolve();
@@ -156,6 +168,10 @@ class Response
         return $this->httpResponse->getStatusCode();
     }
 
+    /**
+     * @throws NetworkException
+     * @throws HttpException
+     */
     public function toStream(): ResultStream
     {
         $this->resolve();

--- a/src/Core/src/Stream/ResponseBodyResourceStream.php
+++ b/src/Core/src/Stream/ResponseBodyResourceStream.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core\Stream;
+
+/**
+ * Stream a resource body.
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class ResponseBodyResourceStream implements ResultStream
+{
+    /**
+     * @var resource
+     */
+    private $responseStream;
+
+    public function __construct($responseStream)
+    {
+        $this->responseStream = $responseStream;
+    }
+
+    public function __toString()
+    {
+        return $this->getContentAsString();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getChunks(): iterable
+    {
+        $pos = \ftell($this->responseStream);
+
+        try {
+            if (!\rewind($this->responseStream)) {
+                throw new \InvalidArgumentException('Failed to rewind the stream');
+            }
+
+            while (!\feof($this->responseStream)) {
+                yield \fread($this->responseStream, 64 * 1024);
+            }
+        } finally {
+            \fseek($this->responseStream, $pos);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContentAsString(): string
+    {
+        $pos = \ftell($this->responseStream);
+
+        try {
+            if (!\rewind($this->responseStream)) {
+                throw new \InvalidArgumentException('Failed to rewind the stream');
+            }
+
+            return \stream_get_contents($this->responseStream);
+        } finally {
+            \fseek($this->responseStream, $pos);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContentAsResource()
+    {
+        return $this->responseStream;
+    }
+}

--- a/src/Core/src/Stream/ResponseBodyResourceStream.php
+++ b/src/Core/src/Stream/ResponseBodyResourceStream.php
@@ -7,7 +7,7 @@ namespace AsyncAws\Core\Stream;
 use AsyncAws\Core\Exception\RuntimeException;
 
 /**
- * Provides a ResultStream from a resource filled by an HTTP response body
+ * Provides a ResultStream from a resource filled by an HTTP response body.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
@@ -37,6 +37,7 @@ class ResponseBodyResourceStream implements ResultStream
         if (0 !== $pos && !\rewind($this->resource)) {
             throw new RuntimeException('The stream is not rewindable');
         }
+
         try {
             while (!\feof($this->resource)) {
                 yield \fread($this->resource, 64 * 1024);

--- a/src/Core/src/Stream/ResponseBodyStream.php
+++ b/src/Core/src/Stream/ResponseBodyStream.php
@@ -9,7 +9,7 @@ use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 
 /**
  * Stream a HTTP response body.
- * This class is a BC layer for Http Response that does not supports toStream.
+ * This class is a BC layer for Http Response that does not support `toStream()`.
  * When calling `getChunks` you must read all the chunks before being able to call this method (or another method) again.
  * When calling `getContentAsResource`, it first, fully read the Response Body in a blocking way.
  *
@@ -49,7 +49,7 @@ class ResponseBodyStream implements ResultStream
             return $this->fallback->getChunks();
         }
         if ($this->partialRead) {
-            throw new LogicException(\sprintf('You can not call "%s". Another process doesn\'t reading "getChunks" till  the end.', __METHOD__));
+            throw new LogicException(\sprintf('You can not call "%s". Another process doesn\'t reading "getChunks" till the end.', __METHOD__));
         }
 
         $resource = \fopen('php://temp', 'rb+');

--- a/src/Core/src/Stream/ResponseBodyStream.php
+++ b/src/Core/src/Stream/ResponseBodyStream.php
@@ -9,7 +9,7 @@ use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 /**
  * Stream a HTTP response body.
  * This class is a NC layer for Http Client that does not supports toStream
- * When calling `getChunks` or `getContentAsResource` it first, fully read download the Response Body in a blocking way
+ * When calling `getChunks` or `getContentAsResource` it first, fully read download the Response Body in a blocking way.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Jérémy Derussé <jeremy@derusse.com>

--- a/src/Core/src/Stream/ResponseBodyStream.php
+++ b/src/Core/src/Stream/ResponseBodyStream.php
@@ -20,11 +20,6 @@ class ResponseBodyStream implements ResultStream
     private $responseStream;
 
     /**
-     * @var resource|null
-     */
-    private $resource;
-
-    /**
      * @var ResponseBodyResourceStream|null
      */
     private $fallback;
@@ -48,16 +43,15 @@ class ResponseBodyStream implements ResultStream
             return $this->fallback->getChunks();
         }
 
-        if (null === $this->resource) {
-            $this->resource = \fopen('php://temp', 'rb+');
-        }
+        $resource = \fopen('php://temp', 'rb+');
         foreach ($this->responseStream as $chunk) {
             $chunkContent = $chunk->getContent();
-            \fwrite($this->resource, $chunkContent);
-            yield $chunkContent;
+            \fwrite($resource, $chunkContent);
         }
 
-        $this->fallback = new ResponseBodyResourceStream($this->resource);
+        $this->fallback = new ResponseBodyResourceStream($resource);
+
+        return $this->fallback->getChunks();
     }
 
     /**

--- a/src/Core/src/Stream/ResponseBodyStream.php
+++ b/src/Core/src/Stream/ResponseBodyStream.php
@@ -8,6 +8,8 @@ use Symfony\Contracts\HttpClient\ResponseStreamInterface;
 
 /**
  * Stream a HTTP response body.
+ * This class is a NC layer for Http Client that does not supports toStream
+ * When calling `getChunks` or `getContentAsResource` it first, fully read download the Response Body in a blocking way
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Jérémy Derussé <jeremy@derusse.com>

--- a/src/Service/S3/tests/Integration/S3ClientTest.php
+++ b/src/Service/S3/tests/Integration/S3ClientTest.php
@@ -191,6 +191,27 @@ class S3ClientTest extends TestCase
         self::assertEquals('image/jpg', $result->getContentType());
     }
 
+    public function testGetObjectConsistent(): void
+    {
+        $client = $this->getClient();
+        $client->putObject([
+            'Bucket' => 'foo',
+            'Key' => 'bar',
+            'Body' => 'content',
+            'ContentType' => 'image/jpg',
+        ])->resolve();
+
+        $result = $client->getObject([
+            'Bucket' => 'foo',
+            'Key' => 'bar',
+        ]);
+        self::assertEquals('content', $result->getBody()->getContentAsString());
+        // calling it twice to ensure consitency
+        self::assertEquals('content', $result->getBody()->getContentAsString());
+        self::assertEquals('content', \stream_get_contents($result->getBody()->getContentAsResource()));
+        self::assertEquals('content', \implode('', \iterator_to_array($result->getBody()->getChunks())));
+    }
+
     public function testGetObjectAcl(): void
     {
         $client = $this->getClient();


### PR DESCRIPTION
calling several time `ResponseBodyStream::getContentAsString` throws an exception (should be visible in prefer-lowest test).
This PR:
- use HttpClient `ResponseTrait::toStream` method that provide a stream when available
- otherwise use the `ResponseBodyStream` but store the stream in a `php://temp` resource in order to be re-read