### PR TITLE
Resolve the full response

### DIFF
--- a/docs/features/async.md
+++ b/docs/features/async.md
@@ -144,6 +144,10 @@ it will return `false`.
 
 Use `$result->resolve(0)` for a non-blocking call.
 
+The function has also a `$fullResponse` arguments. When false (default value)
+the HTTP client will wait for only the first bytes. Otherwise, the HTTP client
+will wait until receiving the entire response.
+
 ### Batch requests
 
 Consider the following example. It is creating 10 `InvocationRequest`s and printing
@@ -166,7 +170,7 @@ for ($i = 0; $i < 10; ++$i) {
 
 while (!empty($results)) {
     foreach ($results as $i => $result) {
-        if ($result->resolve(0.01)) {
+        if ($result->resolve(0.01, true)) {
             echo $result->getPayload();
             unset($results[$i]);
         }

--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -38,7 +38,7 @@ class Response
     private $resolveResult;
 
     /**
-     * State of the response stream
+     * State of the response stream.
      *
      * @var bool
      */
@@ -91,13 +91,14 @@ class Response
                 if ($fullResponse) {
                     if ($chunk->isLast()) {
                         $this->streamable = false;
+
                         break;
                     }
 
-                    if ($this->streamable && $chunk->getContent() !== '') {
+                    if ($this->streamable && '' !== $chunk->getContent()) {
                         $this->streamable = false;
                     }
-                } elseif($chunk->isFirst()) {
+                } elseif ($chunk->isFirst()) {
                     break;
                 }
             }

--- a/src/Core/src/Result.php
+++ b/src/Core/src/Result.php
@@ -50,16 +50,17 @@ class Result
     /**
      * Make sure the actual request is executed.
      *
-     * @param float|null $timeout Duration in seconds before aborting. When null wait until the end of execution.
+     * @param float|null $timeout      Duration in seconds before aborting. When null wait until the end of execution.
+     * @param bool       $fullResponse Wait until receiving the entire response or only the first bytes
      *
      * @return bool whether the request is executed or not
      *
      * @throws NetworkException
      * @throws HttpException
      */
-    final public function resolve(?float $timeout = null): bool
+    final public function resolve(?float $timeout = null, bool $fullResponse = false): bool
     {
-        return $this->response->resolve($timeout);
+        return $this->response->resolve($timeout, $fullResponse);
     }
 
     /**

--- a/src/Core/tests/Unit/ResultTest.php
+++ b/src/Core/tests/Unit/ResultTest.php
@@ -53,6 +53,18 @@ class ResultTest extends TestCase
         self::assertFalse($data->DoesNotExists ? true : false);
     }
 
+    public function testResolveFully()
+    {
+        $response = new SimpleMockedResponse('OK', [], 200);
+        $client = new MockHttpClient($response);
+        $result = new Result(new Response($client->request('POST', 'http://localhost'), $client));
+
+        self::assertTrue($result->resolve());
+        self::assertTrue($result->resolve());
+        self::assertTrue($result->resolve(null, true));
+        self::assertTrue($result->resolve(null, true));
+    }
+
     public function testThrowExceptionDestruct()
     {
         $response = new SimpleMockedResponse('Bad request', [], 400);


### PR DESCRIPTION
Provide a way to resolve the entire body, instead of just the first bytes.

That provide full async until the end of the response.

Partially fixes #376