### PR TITLE
Improve accessibility

### DIFF
--- a/website/assets/style/_variables.scss
+++ b/website/assets/style/_variables.scss
@@ -1,8 +1,8 @@
 $dark: #313244;
-$red: #E05D34;
+$red: #e05d34;
 $white: #fdf5e3;
-$darkGreen: #429D25;
-$lightGreen: #C0C88B;
+$darkGreen: #35801E;
+$lightGreen: #c0c88b;
 
 $font-primary: 'Poppins',Arial, sans-serif;
 $primary: $lightGreen;

--- a/website/assets/style/main.scss
+++ b/website/assets/style/main.scss
@@ -24,7 +24,8 @@ a {
     transition: .3s all ease;
     color: $darkGreen;
     &:hover, &:focus {
-        text-decoration: none !important;
+        color: darken($darkGreen, 25%);
+        text-decoration: underline;
         outline: none !important;
         box-shadow: none;
     }


### PR DESCRIPTION
switch link from `#429D25` to `#35801E` to get a 4.5 ratio on sidebar (https://webaim.org/resources/contrastchecker/?fcolor=35801E&bcolor=FDF5E3)

add underline on hover/focus anchors

Fixes #408 and #410 