### PR TITLE
Make contribution icon absolute instead of fixed

### DIFF
--- a/website/assets/style/contribute.scss
+++ b/website/assets/style/contribute.scss
@@ -1,5 +1,5 @@
 .contribute {
-    position: fixed;
+    position: absolute;
     top: 0;
     right: 0;
 

--- a/website/template/base.twig
+++ b/website/template/base.twig
@@ -68,10 +68,10 @@
     </nav>
 
     <main role="main" id="content" class="content p-4 p-md-5 pt-5">
-    {% include 'contribute.twig' %}
     {% block body %}{% endblock %}
     </main>
 </div>
+{% include 'contribute.twig' %}
 
 {{ renderScript('app') }}
 </body>


### PR DESCRIPTION
There was an issue with the contribution icon and code examples. I fixed it by remove `position:fixed`. 

I also make sure the HTML for this is at the bottom of the page. That will make our content to be read first with screen readers. 

<img width="186" alt="Screenshot 2020-04-04 at 15 47 56" src="https://user-images.githubusercontent.com/1275206/78452542-1c44ee80-768c-11ea-905c-3aef0f634fd8.png">
