### PR TITLE
Update http-client-contracts to 1.1.8.

### DIFF
--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -10,7 +10,7 @@
         "ext-json": "*",
         "psr/log": "~1.0",
         "symfony/http-client": "^4.4 || ^5.0",
-        "symfony/http-client-contracts": "^1.0 || ^2.0",
+        "symfony/http-client-contracts": "^1.1.8 || ^2.0",
         "symfony/service-contracts": "^1.0 || ^2.0"
     },
     "extra": {


### PR DESCRIPTION
It was at that version it was documented the httP-code would return int.

Since we have `"symfony/http-client": "^4.4"`, there is impossible to get a version lower that 1.1.8. This is just a "to be technically correct". 