### PR TITLE
Dont use buggy version of PHP-cs-fixer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "symfony/service-contracts": "^1.0 || ^2.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2.16",
+        "friendsofphp/php-cs-fixer": "2.16.1",
         "league/flysystem": "^1.0.65 || ^2.0.0-alpha.2",
         "league/flysystem-adapter-test-utilities": "2.x-dev",
         "league/mime-type-detection": "^1.0",


### PR DESCRIPTION
I've reported the bug in https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/4913

This PR will allow the CI to be green again and make sure #475 is not removing code that should not be removed. 