### PR TITLE
Run CI on PUSH and PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 on:
-  pull_request:
+  pull_request: ~
   push:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: pull_request
+on: [push, pull_request]
 
 jobs:
 

--- a/.github/workflows/flysystemV1.yml
+++ b/.github/workflows/flysystemV1.yml
@@ -27,13 +27,13 @@ jobs:
           sed -i -re 's/S3FilesystemV1/S3FilesystemV2/' psalm.xml
 
       - name: PHPStan
-        uses: OskarStark/phpstan-ga
+        uses: OskarStark/phpstan-ga@master
         with:
           entrypoint: /composer/vendor/bin/phpstan
           args: analyze --no-progress
 
       - name: Psalm
-        uses: psalm/psalm-github-actions
+        uses: psalm/psalm-github-actions@master
         with:
           args: --no-progress --show-info=false --stats
 

--- a/.github/workflows/flysystemV1.yml
+++ b/.github/workflows/flysystemV1.yml
@@ -1,6 +1,6 @@
 name: FlysystemV1
 
-on: pull_request
+on: [push, pull_request]
 
 jobs:
   phpstan:

--- a/.github/workflows/flysystemV1.yml
+++ b/.github/workflows/flysystemV1.yml
@@ -1,6 +1,10 @@
 name: FlysystemV1
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   phpstan:

--- a/.github/workflows/flysystemV1.yml
+++ b/.github/workflows/flysystemV1.yml
@@ -27,13 +27,13 @@ jobs:
           sed -i -re 's/S3FilesystemV1/S3FilesystemV2/' psalm.xml
 
       - name: PHPStan
-        uses: docker://oskarstark/phpstan-ga
+        uses: OskarStark/phpstan-ga
         with:
           entrypoint: /composer/vendor/bin/phpstan
           args: analyze --no-progress
 
       - name: Psalm
-        uses: docker://vimeo/psalm-github-actions
+        uses: psalm/psalm-github-actions
         with:
           args: --no-progress --show-info=false --stats
 

--- a/.github/workflows/flysystemV1.yml
+++ b/.github/workflows/flysystemV1.yml
@@ -1,7 +1,7 @@
 name: FlysystemV1
 
 on:
-  pull_request:
+  pull_request: ~
   push:
     branches:
       - master

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,7 +20,7 @@ jobs:
           composer update --no-interaction --prefer-dist --optimize-autoloader
 
       - name: PHPStan
-        uses: docker://oskarstark/phpstan-ga
+        uses: OskarStark/phpstan-ga
         with:
           entrypoint: /composer/vendor/bin/phpstan
           args: analyze --no-progress
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: PHP-CS-Fixer
-        uses: docker://oskarstark/php-cs-fixer-ga@2.15.6
+        uses: OskarStark/php-cs-fixer-ga@2.15.6
         with:
           args: --dry-run --diff-format udiff
 
@@ -46,6 +46,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Psalm
-        uses: docker://vimeo/psalm-github-actions
+        uses: psalm/psalm-github-actions
         with:
           args: --no-progress --show-info=false --stats

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: PHP-CS-Fixer
-        uses: OskarStark/php-cs-fixer-ga@2.16.1.2
+        uses: OskarStark/php-cs-fixer-ga@2.16.0
         with:
           args: --dry-run --diff-format udiff
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,6 +1,10 @@
 name: Static analysis
 
-on: [push, pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   phpstan:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,7 +20,7 @@ jobs:
           composer update --no-interaction --prefer-dist --optimize-autoloader
 
       - name: PHPStan
-        uses: OskarStark/phpstan-ga
+        uses: OskarStark/phpstan-ga@master
         with:
           entrypoint: /composer/vendor/bin/phpstan
           args: analyze --no-progress
@@ -46,6 +46,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Psalm
-        uses: psalm/psalm-github-actions
+        uses: psalm/psalm-github-actions@master
         with:
           args: --no-progress --show-info=false --stats

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: PHP-CS-Fixer
-        uses: docker://oskarstark/php-cs-fixer-ga
+        uses: docker://oskarstark/php-cs-fixer-ga@2.15.6
         with:
           args: --dry-run --diff-format udiff
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,6 +1,6 @@
 name: Static analysis
 
-on: pull_request
+on: [push, pull_request]
 
 jobs:
   phpstan:

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: PHP-CS-Fixer
-        uses: OskarStark/php-cs-fixer-ga@2.15.6
+        uses: OskarStark/php-cs-fixer-ga@2.16.1.2
         with:
           args: --dry-run --diff-format udiff
 

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -1,7 +1,7 @@
 name: Static analysis
 
 on:
-  pull_request:
+  pull_request: ~
   push:
     branches:
       - master


### PR DESCRIPTION
This will revert parts of #419. 

We need to run tests and analyses on push. An example of this just happened. We merged #473 after a few days. The CI was green but after we merge it, some rules were updated in PHP-CS-fixer. The master branch should be red, but we could not see it. 
The next PR doing a minor fix results in a super red PR for unrelated stuff. 

If we have run the tests on master branch on push we would have seen that master was red. Also the contributor for the next minor PR could see that the red CI wasn't their fault. 