### PR TITLE
Restore is default method

### DIFF
--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.5.1
+
+### Added
+
+- Add `Configuration::isDefault` methods.
+
 ## 0.5.0
 
 ### Added

--- a/src/Core/src/Configuration.php
+++ b/src/Core/src/Configuration.php
@@ -126,4 +126,13 @@ final class Configuration
 
         return isset($this->data[$name]);
     }
+
+    public function isDefault(string $name): bool
+    {
+        if (!isset(self::AVAILABLE_OPTIONS[$name])) {
+            throw new InvalidArgument(\sprintf('Invalid option "%s" passed to "%s::%s". ', $name, __CLASS__, __METHOD__));
+        }
+
+        return isset($this->data[$name], self::DEFAULT_OPTIONS[$name]) && $this->data[$name] === self::DEFAULT_OPTIONS[$name];
+    }
 }

--- a/src/Core/tests/Unit/ConfigurationTest.php
+++ b/src/Core/tests/Unit/ConfigurationTest.php
@@ -30,6 +30,14 @@ class ConfigurationTest extends TestCase
         }
     }
 
+    public function testIsDefault()
+    {
+        $config = Configuration::create(['region' => 'eu-west-3']);
+
+        self::assertTrue($config->isDefault('endpoint'));
+        self::assertFalse($config->isDefault('region'));
+    }
+
     public function provideConfiguration(): iterable
     {
         yield 'simple config' => [['endpoint' => 'foo'], [], ['endpoint' => 'foo']];


### PR DESCRIPTION
Used here https://github.com/symfony/symfony/pull/35992/commits/82b5e7cf1aa625552d09cbffb50dfc4a767eb6dd

I don't know if it worth such public method in AsyncAws.
A workaround in Symfon would be :neutral_face: 
```diff
        $configuration = $this->sesClient->getConfiguration();
-       if (!$configuration->isDefault('endpoint')) {
+       if ($configuration->get('endpoint') === (new Configuration())->get('endpoint')) {
            $endpoint = parse_url($configuration->get('endpoint'));
            $host = $endpoint['host'].($endpoint['port'] ?? null ? ':'.$endpoint['port'] : '');
        } else {
            $host = $configuration->get('region');
        }

        return sprintf('ses+api://%s@%s', $configuration->get('accessKeyId'), $host);
```