### PR TITLE
Request's Header allows string[] only

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -27,4 +27,5 @@ parameters:
         - '#^Parameter \#3 ...\$args of function sprintf expects bool\|float\|int\|string\|null, AsyncAws\\[^\\]+\\Enum\\[^ ]+ given\.$#'
         - '#^Parameter \#1 \$value of static method AsyncAws\\[^\\]+\\Enum\\[^:]+::exists\(\) expects string, AsyncAws\\[^\\]+\\Enum\\[^ ]+ given\.$#'
         - '#^PHPDoc tag @(var|return) has invalid value \(list<[^:]+::\*>\): Unexpected token "::", expected .>. at offset \d+.$#'
-        - '#^Parameter \#4 \$headers of class AsyncAws\\Core\\Request constructor expects array<array<string>\|string>, array<string, AsyncAws\\[^\\]+\\Enum\\[^ ]+ given\.$#'
+        - '#^Parameter \#3 \$query of class AsyncAws\\Core\\Request constructor expects array<string>, array<string, AsyncAws\\[^\\]+\\Enum\\[^ ]+ given\.$#'
+        - '#^Parameter \#4 \$headers of class AsyncAws\\Core\\Request constructor expects array<string>, array<string, AsyncAws\\[^\\]+\\Enum\\[^ ]+ given\.$#'

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -103,7 +103,7 @@ abstract class AbstractApi
 
         $length = $request->getBody()->length();
         if (null !== $length && !$request->hasHeader('content-length')) {
-            $request->setHeader('content-length', $length);
+            $request->setHeader('content-length', (string) $length);
         }
 
         // Some servers (like testing Docker Images) does not supports `Transfer-Encoding: chunked` requests.

--- a/src/Core/src/Request.php
+++ b/src/Core/src/Request.php
@@ -29,7 +29,8 @@ class Request
     private $parsed;
 
     /**
-     * @param string[]|string[][] $headers
+     * @param string[] $query
+     * @param string[] $headers
      */
     public function __construct(string $method, string $uri, array $query, array $headers, RequestStream $body)
     {
@@ -37,7 +38,7 @@ class Request
         $this->uri = $uri;
         $this->headers = [];
         foreach ($headers as $key => $value) {
-            $this->headers[\strtolower($key)] = $value;
+            $this->headers[\strtolower($key)] = (string) $value;
         }
         $this->body = $body;
         $this->query = $query;
@@ -64,7 +65,7 @@ class Request
         return \array_key_exists(strtolower($name), $this->headers);
     }
 
-    public function setHeader($name, $value): void
+    public function setHeader($name, ?string $value): void
     {
         $this->headers[strtolower($name)] = $value;
     }
@@ -74,10 +75,7 @@ class Request
         return $this->headers;
     }
 
-    /**
-     * @return string|string[]
-     */
-    public function getHeader(string $name)
+    public function getHeader(string $name): ?string
     {
         return $this->headers[strtolower($name)] ?? null;
     }

--- a/src/Integration/Flysystem/S3/src/S3FilesystemV1.php
+++ b/src/Integration/Flysystem/S3/src/S3FilesystemV1.php
@@ -513,11 +513,20 @@ class S3FilesystemV1 extends AbstractAdapter implements CanOverwriteFiles
      */
     protected function normalizeResponse(object $output, ?string $path = null): array
     {
+        if (empty($path)) {
+            if ($output instanceof AwsObject) {
+                $path = $output->getKey();
+            } elseif ($output instanceof CommonPrefix) {
+                $path = $output->getPrefix();
+            }
+            if (empty($path)) {
+                throw new \InvalidArgumentException('The provided path should not be null');
+            }
+
+            $path = $this->removePathPrefix($path);
+        }
         $result = [
-            'path' => $path ?: $this->removePathPrefix(
-            /** @psalm-suppress PossiblyNullArgument */
-            method_exists($output, 'getKey') ? $output->getKey() : (method_exists($output, 'getPrefix') ? $output->getPrefix() : null)
-            ),
+            'path' => $path,
         ];
         $result = array_merge($result, Util::pathinfo($result['path']));
 

--- a/src/Integration/Flysystem/S3/src/S3FilesystemV1.php
+++ b/src/Integration/Flysystem/S3/src/S3FilesystemV1.php
@@ -515,7 +515,8 @@ class S3FilesystemV1 extends AbstractAdapter implements CanOverwriteFiles
     {
         $result = [
             'path' => $path ?: $this->removePathPrefix(
-                method_exists($output, 'getKey') ? $output->getKey() : (method_exists($output, 'getPrefix') ? $output->getPrefix() : null)
+            /** @psalm-suppress PossiblyNullArgument */
+            method_exists($output, 'getKey') ? $output->getKey() : (method_exists($output, 'getPrefix') ? $output->getPrefix() : null)
             ),
         ];
         $result = array_merge($result, Util::pathinfo($result['path']));


### PR DESCRIPTION
We currently don't use `string[][]` and some part of the code don't check for string/array hen fetching headers.