### PR TITLE
Fix requirement on SymfonyBundle

### DIFF
--- a/src/Integration/Symfony/Bundle/composer.json
+++ b/src/Integration/Symfony/Bundle/composer.json
@@ -21,7 +21,8 @@
         "async-aws/ses": "^0.3",
         "async-aws/sqs": "^0.3",
         "matthiasnoback/symfony-config-test": "^4.1",
-        "nyholm/symfony-bundle-test": "^1.6.1"
+        "nyholm/symfony-bundle-test": "^1.6.1",
+        "symfony/framework-bundle": "^4.4 || ^5.0"
     },
     "extra": {
         "branch-alias": {
@@ -37,6 +38,5 @@
         "psr-4": {
             "AsyncAws\\Symfony\\Bundle\\Tests\\": "tests/"
         }
-    },
-    "minimum-stability": "dev"
+    }
 }

--- a/src/Integration/Symfony/Bundle/composer.json
+++ b/src/Integration/Symfony/Bundle/composer.json
@@ -21,8 +21,7 @@
         "async-aws/ses": "^0.3",
         "async-aws/sqs": "^0.3",
         "matthiasnoback/symfony-config-test": "^4.1",
-        "nyholm/symfony-bundle-test": "^1.6.1",
-        "symfony/framework-bundle": "^4.4 || ^5.0"
+        "nyholm/symfony-bundle-test": "^1.6.1"
     },
     "extra": {
         "branch-alias": {

--- a/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/default.yaml
+++ b/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/default.yaml
@@ -1,7 +1,3 @@
-framework:
-    router:
-        utf8: true
-
 async_aws:
     config:
         region: eu-central-1

--- a/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/empty.yaml
+++ b/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/empty.yaml
@@ -1,5 +1,1 @@
-framework:
-  router:
-    utf8: true
-
 async_aws: ~

--- a/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/empty_clients_key.yaml
+++ b/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/empty_clients_key.yaml
@@ -1,7 +1,3 @@
-framework:
-  router:
-    utf8: true
-
 async_aws:
     config:
         region: eu-central-1

--- a/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/no_service_sqs.yaml
+++ b/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/no_service_sqs.yaml
@@ -1,7 +1,3 @@
-framework:
-    router:
-        utf8: true
-
 async_aws:
     clients:
         sqs:

--- a/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/no_services.yaml
+++ b/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/no_services.yaml
@@ -1,6 +1,2 @@
-framework:
-  router:
-    utf8: true
-
 async_aws:
     register_service: false

--- a/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/not_installed_service.yaml
+++ b/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/not_installed_service.yaml
@@ -1,7 +1,3 @@
-framework:
-    router:
-        utf8: true
-
 async_aws:
     config:
         region: eu-central-1


### PR DESCRIPTION
Requires `symfony/framework-bundle: ^4.4` because config router=utf-8
Remove mimimum stability=dev from composer.json