### PR TITLE
Use annotation to ignore phpstan rule

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,17 +1,2 @@
 parameters:
-	ignoreErrors:
-		-
-			message: '#^Call to an undefined method Symfony\\Component\\Console\\Output\\OutputInterface::section\(\)\.$#'
-			count: 2
-			path: src/CodeGenerator/src/Command/GenerateCommand.php
-
-		-
-			message: '#^Call to an undefined method ReflectionType::getName\(\)\.$#'
-			count: 1
-			path: src/Core/src/Test/ResultMockFactory.php
-
-		-
-			message: '#^Call to an undefined method Symfony\\Component\\Config\\Definition\\Builder\\NodeParentInterface::scalarNode\(\)\.$#'
-			count: 1
-			path: src/Integration/Symfony/Bundle/src/DependencyInjection/Configuration.php
-
+    ignoreErrors:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -12,7 +12,6 @@ parameters:
     excludes_analyse:
         - src/*/tests/*
         - src/**/tests/*
-        - src/CodeGenerator/src/Generator/PhpGenerator/ClassFactory.php
         - src/CodeGenerator/src/Generator/TestGenerator.php
         - src/Core/src/Test/TestCase.php
         - src/Integration/Flysystem/S3/src/S3FilesystemV1.php

--- a/src/CodeGenerator/src/Command/GenerateCommand.php
+++ b/src/CodeGenerator/src/Command/GenerateCommand.php
@@ -16,6 +16,7 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
@@ -61,6 +62,7 @@ class GenerateCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
+        \assert($output instanceof ConsoleOutputInterface);
         $io = new SymfonyStyle($input, $output);
 
         $progressService = (new SymfonyStyle($input, $output->section()))->createProgressBar();

--- a/src/CodeGenerator/src/Command/GenerateCommand.php
+++ b/src/CodeGenerator/src/Command/GenerateCommand.php
@@ -62,7 +62,7 @@ class GenerateCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        \assert($output instanceof ConsoleOutputInterface);
+        /** @var ConsoleOutputInterface $output */
         $io = new SymfonyStyle($input, $output);
 
         $progressService = (new SymfonyStyle($input, $output->section()))->createProgressBar();

--- a/src/CodeGenerator/src/Generator/PhpGenerator/ClassFactory.php
+++ b/src/CodeGenerator/src/Generator/PhpGenerator/ClassFactory.php
@@ -120,9 +120,9 @@ class ClassFactory
         $method->setReturnReference($from->returnsReference());
         $method->setVariadic($from->isVariadic());
         $method->setComment(Helpers::unformatDocComment((string) $from->getDocComment()));
-        if ($from->hasReturnType()) {
-            $method->setReturnType($from->getReturnType()->getName());
-            $method->setReturnNullable($from->getReturnType()->allowsNull());
+        if ($from->hasReturnType() && ($type = $from->getReturnType()) instanceof \ReflectionNamedType) {
+            $method->setReturnType($type->getName());
+            $method->setReturnNullable($type->allowsNull());
         }
 
         return $method;
@@ -140,9 +140,9 @@ class ClassFactory
         if (!$from->isClosure()) {
             $function->setComment(Helpers::unformatDocComment((string) $from->getDocComment()));
         }
-        if ($from->hasReturnType()) {
-            $function->setReturnType($from->getReturnType()->getName());
-            $function->setReturnNullable($from->getReturnType()->allowsNull());
+        if ($from->hasReturnType() && ($type = $from->getReturnType()) instanceof \ReflectionNamedType) {
+            $function->setReturnType($type->getName());
+            $function->setReturnNullable($type->allowsNull());
         }
 
         return $function;
@@ -152,8 +152,10 @@ class ClassFactory
     {
         $param = new Parameter($from->getName());
         $param->setReference($from->isPassedByReference());
-        $param->setType($from->hasType() ? $from->getType()->getName() : null);
-        $param->setNullable($from->hasType() && $from->getType()->allowsNull());
+        if ($from->hasType() && ($type = $from->getType()) instanceof \ReflectionNamedType) {
+            $param->setType($type->getName());
+            $param->setNullable($type->allowsNull());
+        }
         if ($from->isDefaultValueAvailable()) {
             $param->setDefaultValue($from->isDefaultValueConstant()
                 ? new Literal($from->getDefaultValueConstantName())
@@ -175,7 +177,7 @@ class ClassFactory
             ? ClassType::VISIBILITY_PRIVATE
             : ($from->isProtected() ? ClassType::VISIBILITY_PROTECTED : ClassType::VISIBILITY_PUBLIC)
         );
-        if (\PHP_VERSION_ID >= 70400 && ($type = $from->getType())) {
+        if (\PHP_VERSION_ID >= 70400 && ($type = $from->getType()) instanceof \ReflectionNamedType) {
             $prop->setType($type->getName());
             $prop->setNullable($type->allowsNull());
             $prop->setInitialized(\array_key_exists($prop->getName(), $defaults));

--- a/src/Core/src/Test/ResultMockFactory.php
+++ b/src/Core/src/Test/ResultMockFactory.php
@@ -113,13 +113,11 @@ class ResultMockFactory
             }
 
             $getter = $reflectionClass->getMethod('get' . $property->getName());
-            /** @psalm-suppress PossiblyNullReference */
-            if (!$getter->hasReturnType() || $getter->getReturnType()->allowsNull()) {
+            if (!$getter->hasReturnType() || (!($type = $getter->getReturnType()) instanceof \ReflectionNamedType) || $type->allowsNull()) {
                 continue;
             }
 
-            /** @psalm-suppress PossiblyNullReference */
-            switch ($getter->getReturnType()->getName()) {
+            switch ($type->getName()) {
                 case 'int':
                     $propertyValue = 0;
 

--- a/src/Integration/Symfony/Bundle/src/DependencyInjection/Configuration.php
+++ b/src/Integration/Symfony/Bundle/src/DependencyInjection/Configuration.php
@@ -16,6 +16,7 @@ class Configuration implements ConfigurationInterface
         $treeBuilder = new TreeBuilder('async_aws');
         /** @var ArrayNodeDefinition $rootNode */
         $rootNode = $treeBuilder->getRootNode();
+        /** @phpstan-ignore-next-line */
         $rootNode
             ->fixXmlConfig('client')
             ->children()


### PR DESCRIPTION
This PR replaces the phpstan config file by annotation to ignore rule.

It also refactor few part of the code to replace ignored rule php code assertion.