### PR TITLE
Override theme diff color

### DIFF
--- a/website/assets/style/code.scss
+++ b/website/assets/style/code.scss
@@ -1,5 +1,12 @@
 @import '~highlight.js/styles/darcula.css';
 
+.hljs-deletion {
+    color: #cb7832;
+}
+.hljs-addition {
+    color: #6a8759;
+}
+
 pre code {
     max-width: 50rem;
 }


### PR DESCRIPTION
This PR override the Darcula's diff color:

Before:
![Screenshot from 2020-05-03 18-27-40](https://user-images.githubusercontent.com/578547/80919738-04848700-8d6c-11ea-8709-800d31813207.png)

After:
![Screenshot from 2020-05-03 18-27-30](https://user-images.githubusercontent.com/578547/80919739-051d1d80-8d6c-11ea-9bff-a86a363f008f.png)

Both colors come from the current Darcula palette (green is used for string and red for keywords)