### PR TITLE
Lock versions for phpstan and php-cs-fixer

### DIFF
--- a/.github/workflows/flysystemV1.yml
+++ b/.github/workflows/flysystemV1.yml
@@ -27,7 +27,7 @@ jobs:
           sed -i -re 's/S3FilesystemV1/S3FilesystemV2/' psalm.xml
 
       - name: PHPStan
-        uses: OskarStark/phpstan-ga@0.12.22
+        uses: OskarStark/phpstan-ga@0.12.23
         with:
           entrypoint: /composer/vendor/bin/phpstan
           args: analyze --no-progress

--- a/.github/workflows/flysystemV1.yml
+++ b/.github/workflows/flysystemV1.yml
@@ -27,7 +27,7 @@ jobs:
           sed -i -re 's/S3FilesystemV1/S3FilesystemV2/' psalm.xml
 
       - name: PHPStan
-        uses: OskarStark/phpstan-ga@master
+        uses: OskarStark/phpstan-ga@0.12.22
         with:
           entrypoint: /composer/vendor/bin/phpstan
           args: analyze --no-progress

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,7 +20,7 @@ jobs:
           composer update --no-interaction --prefer-dist --optimize-autoloader
 
       - name: PHPStan
-        uses: OskarStark/phpstan-ga@0.12.22
+        uses: OskarStark/phpstan-ga@0.12.23
         with:
           entrypoint: /composer/vendor/bin/phpstan
           args: analyze --no-progress

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -20,7 +20,7 @@ jobs:
           composer update --no-interaction --prefer-dist --optimize-autoloader
 
       - name: PHPStan
-        uses: OskarStark/phpstan-ga@master
+        uses: OskarStark/phpstan-ga@0.12.22
         with:
           entrypoint: /composer/vendor/bin/phpstan
           args: analyze --no-progress
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: PHP-CS-Fixer
-        uses: OskarStark/php-cs-fixer-ga@master
+        uses: OskarStark/php-cs-fixer-ga@2.16.3.1
         with:
           args: --dry-run --diff-format udiff
 


### PR DESCRIPTION
Make sure CI on master is not red because some static tool updated their rules. 