### PR TITLE
Consistency in property and Input Key

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -129,6 +129,9 @@
                 "QueueExists",
                 "ReceiveMessage",
                 "SendMessage"
+            ],
+            "bc_layers": [
+                "canonicalInputKey"
             ]
         },
         "Ssm": {
@@ -153,6 +156,9 @@
                 "AssumeRole",
                 "AssumeRoleWithWebIdentity",
                 "GetCallerIdentity"
+            ],
+            "bc_layers": [
+                "canonicalInputKey"
             ]
         }
     }

--- a/src/CodeGenerator/src/Command/GenerateCommand.php
+++ b/src/CodeGenerator/src/Command/GenerateCommand.php
@@ -105,8 +105,9 @@ class GenerateCommand extends Command
 
             $progressOperation->start(\count($operationNames));
 
+            $bcLayers = \array_unique($manifest['services'][$serviceName]['bc_layers'] ?? []);
             $managedOperations = \array_unique(\array_merge($manifest['services'][$serviceName]['methods'], $operationNames));
-            $definition = new ServiceDefinition($serviceName, $definitionArray, $documentationArray, $paginationArray, $waiterArray, $exampleArray);
+            $definition = new ServiceDefinition($serviceName, $definitionArray, $documentationArray, $paginationArray, $waiterArray, $exampleArray, $bcLayers);
             $serviceGenerator = $this->generator->service($manifest['services'][$serviceName]['namespace'] ?? \sprintf('AsyncAws\\%s', $serviceName), $managedOperations);
 
             $clientClass = $serviceGenerator->client()->generate($definition);

--- a/src/CodeGenerator/src/Definition/ServiceDefinition.php
+++ b/src/CodeGenerator/src/Definition/ServiceDefinition.php
@@ -11,6 +11,8 @@ namespace AsyncAws\CodeGenerator\Definition;
  */
 class ServiceDefinition
 {
+    public const BC_CANONICAL_INPUT = 'canonicalInputKey';
+
     private $name;
 
     private $definition;
@@ -23,7 +25,9 @@ class ServiceDefinition
 
     private $example;
 
-    public function __construct(string $name, array $definition, array $documentation, array $pagination, array $waiter, array $example)
+    private $bcLayers;
+
+    public function __construct(string $name, array $definition, array $documentation, array $pagination, array $waiter, array $example, array $bcLayers)
     {
         $this->name = $name;
         $this->definition = $definition;
@@ -31,6 +35,7 @@ class ServiceDefinition
         $this->pagination = $pagination;
         $this->waiter = $waiter;
         $this->example = $example;
+        $this->bcLayers = $bcLayers;
     }
 
     public function getName(): string
@@ -98,6 +103,16 @@ class ServiceDefinition
     public function getProtocol(): string
     {
         return $this->definition['metadata']['protocol'];
+    }
+
+    public function getBcLayers(): array
+    {
+        return $this->bcLayers;
+    }
+
+    public function hasBcLayer(string $bcName): bool
+    {
+        return \in_array($bcName, $this->bcLayers, true);
     }
 
     private function getPagination(string $name): ?Pagination

--- a/src/CodeGenerator/src/Definition/StructureMember.php
+++ b/src/CodeGenerator/src/Definition/StructureMember.php
@@ -11,6 +11,21 @@ class StructureMember extends Member
         return $this->data['_name'];
     }
 
+    public function canonicalPropertyName(): string
+    {
+        return \ucfirst($this->data['_name']);
+    }
+
+    public function canonicalMethodName(): string
+    {
+        return \ucfirst($this->data['_name']);
+    }
+
+    public function canonicalInputKey(): string
+    {
+        return \ucfirst($this->data['_name']);
+    }
+
     public function getOwnerShape(): StructureShape
     {
         return $this->data['_owner'];

--- a/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
@@ -81,12 +81,12 @@ class TypeGenerator
 
             if ($allNullable || $nullable) {
                 if ($isObject) {
-                    $body[] = sprintf('  %s?: %s,', $member->getName(), 'null|' . $param);
+                    $body[] = sprintf('  %s?: %s,', $member->canonicalInputKey(), 'null|' . $param);
                 } else {
-                    $body[] = sprintf('  %s?: %s,', $member->getName(), $param);
+                    $body[] = sprintf('  %s?: %s,', $member->canonicalInputKey(), $param);
                 }
             } else {
-                $body[] = sprintf('  %s: %s,', $member->getName(), $param);
+                $body[] = sprintf('  %s: %s,', $member->canonicalInputKey(), $param);
             }
         }
         $body = \array_merge($body, $extra);

--- a/src/CodeGenerator/src/Generator/RequestSerializer/QuerySerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/QuerySerializer.php
@@ -64,13 +64,13 @@ class QuerySerializer implements Serializer
             $shape = $member->getShape();
             if ($member->isRequired()) {
                 $body = 'if (null === $v = $this->PROPERTY) {
-                    throw new InvalidArgument(sprintf(\'Missing parameter "PROPERTY" for "%s". The value cannot be null.\', __CLASS__));
+                    throw new InvalidArgument(sprintf(\'Missing parameter "INPUT_KEY" for "%s". The value cannot be null.\', __CLASS__));
                 }
                 MEMBER_CODE';
                 $inputElement = '$v';
             } elseif ($shape instanceof ListShape || $shape instanceof MapShape) {
                 $body = 'MEMBER_CODE';
-                $inputElement = '$this->' . $member->getName();
+                $inputElement = '$this->' . $member->canonicalPropertyName();
             } else {
                 $body = 'if (null !== $v = $this->PROPERTY) {
                     MEMBER_CODE
@@ -79,7 +79,8 @@ class QuerySerializer implements Serializer
             }
 
             return strtr($body, [
-                'PROPERTY' => $member->getName(),
+                'PROPERTY' => $member->canonicalPropertyName(),
+                'INPUT_KEY' => $member->canonicalInputKey(),
                 'MEMBER_CODE' => $this->dumpArrayElement($name = $this->getName($member), $inputElement, $name, $shape),
             ]);
         }, $shape->getMembers()));

--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestJsonSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestJsonSerializer.php
@@ -61,10 +61,10 @@ class RestJsonSerializer implements Serializer
             $shape = $member->getShape();
             if ($shape instanceof ListShape || $shape instanceof MapShape) {
                 $body = 'MEMBER_CODE';
-                $inputElement = '$this->' . $member->getName();
+                $inputElement = '$this->' . $member->canonicalPropertyName();
             } elseif ($member->isRequired()) {
                 $body = 'if (null === $v = $this->PROPERTY) {
-                    throw new InvalidArgument(sprintf(\'Missing parameter "PROPERTY" for "%s". The value cannot be null.\', __CLASS__));
+                    throw new InvalidArgument(sprintf(\'Missing parameter "INPUT_KEY" for "%s". The value cannot be null.\', __CLASS__));
                 }
                 MEMBER_CODE';
                 $inputElement = '$v';
@@ -76,7 +76,8 @@ class RestJsonSerializer implements Serializer
             }
 
             return strtr($body, [
-                'PROPERTY' => $member->getName(),
+                'PROPERTY' => $member->canonicalPropertyName(),
+                'INPUT_KEY' => $member->canonicalInputKey(),
                 'MEMBER_CODE' => $this->dumpArrayElement(sprintf('["%s"]', $name = $this->getName($member)), $inputElement, $name, $shape, $member->isRequired()),
             ]);
         }, $shape->getMembers()));

--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
@@ -70,13 +70,13 @@ class RestXmlSerializer implements Serializer
             $shape = $member->getShape();
             if ($member->isRequired()) {
                 $body = 'if (null === $v = $this->PROPERTY) {
-                    throw new InvalidArgument(sprintf(\'Missing parameter "PROPERTY" for "%s". The value cannot be null.\', __CLASS__));
+                    throw new InvalidArgument(sprintf(\'Missing parameter "INPUT_KEY" for "%s". The value cannot be null.\', __CLASS__));
                 }
                 MEMBER_CODE';
                 $inputElement = '$v';
             } elseif ($shape instanceof ListShape || $shape instanceof MapShape) {
                 $body = 'MEMBER_CODE';
-                $inputElement = '$this->' . $member->getName();
+                $inputElement = '$this->' . $member->canonicalPropertyName();
             } else {
                 $body = 'if (null !== $v = $this->PROPERTY) {
                     MEMBER_CODE
@@ -85,7 +85,8 @@ class RestXmlSerializer implements Serializer
             }
 
             return strtr($body, [
-                'PROPERTY' => $member->getName(),
+                'PROPERTY' => $member->canonicalPropertyName(),
+                'INPUT_KEY' => $member->canonicalInputKey(),
                 'MEMBER_CODE' => $this->dumpXmlShape($member, $member->getShape(), '$node', $inputElement),
             ]);
         }, $shape->getMembers()));
@@ -179,12 +180,12 @@ class RestXmlSerializer implements Serializer
         if (!empty($shape->getEnum())) {
             $enumClassName = $this->namespaceRegistry->getEnum($shape);
             $body = 'if (!ENUM_CLASS::exists(INPUT)) {
-                    throw new InvalidArgument(sprintf(\'Invalid parameter "PROPERTY" for "%s". The value "%s" is not a valid "ENUM_CLASS".\', __CLASS__, INPUT));
+                    throw new InvalidArgument(sprintf(\'Invalid parameter "INPUT_KEY" for "%s". The value "%s" is not a valid "ENUM_CLASS".\', __CLASS__, INPUT));
                 }
             ' . $body;
             $replacements += [
                 'ENUM_CLASS' => $enumClassName->getName(),
-                'PROPERTY' => $member->getLocationName() ?? ($member instanceof StructureMember ? $member->getName() : 'member'),
+                'INPUT_KEY' => $member->getLocationName() ?? ($member instanceof StructureMember ? $member->getName() : 'member'),
             ];
         }
 

--- a/src/Core/src/Sts/ValueObject/PolicyDescriptorType.php
+++ b/src/Core/src/Sts/ValueObject/PolicyDescriptorType.php
@@ -10,16 +10,20 @@ final class PolicyDescriptorType
      *
      * @see https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html
      */
-    private $arn;
+    private $Arn;
 
     /**
      * @param array{
-     *   arn?: null|string,
+     *   Arn?: null|string,
      * } $input
      */
     public function __construct(array $input)
     {
-        $this->arn = $input['arn'] ?? null;
+        if (isset($input['arn'])) {
+            @trigger_error(sprintf('Using key arn in "%s" is deprecated. Use Arn instead.', __CLASS__), \E_USER_DEPRECATED);
+            $input['Arn'] = $input['arn'];
+        }
+        $this->Arn = $input['Arn'] ?? null;
     }
 
     public static function create($input): self
@@ -27,9 +31,9 @@ final class PolicyDescriptorType
         return $input instanceof self ? $input : new self($input);
     }
 
-    public function getarn(): ?string
+    public function getArn(): ?string
     {
-        return $this->arn;
+        return $this->Arn;
     }
 
     /**
@@ -38,7 +42,7 @@ final class PolicyDescriptorType
     public function requestBody(): array
     {
         $payload = [];
-        if (null !== $v = $this->arn) {
+        if (null !== $v = $this->Arn) {
             $payload['arn'] = $v;
         }
 

--- a/src/Service/CodeDeploy/src/CodeDeployClient.php
+++ b/src/Service/CodeDeploy/src/CodeDeployClient.php
@@ -16,9 +16,9 @@ class CodeDeployClient extends AbstractApi
      * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-codedeploy-2014-10-06.html#putlifecycleeventhookexecutionstatus
      *
      * @param array{
-     *   deploymentId?: string,
-     *   lifecycleEventHookExecutionId?: string,
-     *   status?: \AsyncAws\CodeDeploy\Enum\LifecycleEventStatus::*,
+     *   DeploymentId?: string,
+     *   LifecycleEventHookExecutionId?: string,
+     *   Status?: \AsyncAws\CodeDeploy\Enum\LifecycleEventStatus::*,
      *   @region?: string,
      * }|PutLifecycleEventHookExecutionStatusInput $input
      */

--- a/src/Service/CodeDeploy/src/Input/PutLifecycleEventHookExecutionStatusInput.php
+++ b/src/Service/CodeDeploy/src/Input/PutLifecycleEventHookExecutionStatusInput.php
@@ -15,7 +15,7 @@ final class PutLifecycleEventHookExecutionStatusInput extends Input
      *
      * @var string|null
      */
-    private $deploymentId;
+    private $DeploymentId;
 
     /**
      * The execution ID of a deployment's lifecycle hook. A deployment lifecycle hook is specified in the `hooks` section of
@@ -23,28 +23,28 @@ final class PutLifecycleEventHookExecutionStatusInput extends Input
      *
      * @var string|null
      */
-    private $lifecycleEventHookExecutionId;
+    private $LifecycleEventHookExecutionId;
 
     /**
      * The result of a Lambda function that validates a deployment lifecycle event (`Succeeded` or `Failed`).
      *
      * @var null|LifecycleEventStatus::*
      */
-    private $status;
+    private $Status;
 
     /**
      * @param array{
-     *   deploymentId?: string,
-     *   lifecycleEventHookExecutionId?: string,
-     *   status?: \AsyncAws\CodeDeploy\Enum\LifecycleEventStatus::*,
+     *   DeploymentId?: string,
+     *   LifecycleEventHookExecutionId?: string,
+     *   Status?: \AsyncAws\CodeDeploy\Enum\LifecycleEventStatus::*,
      *   @region?: string,
      * } $input
      */
     public function __construct(array $input = [])
     {
-        $this->deploymentId = $input['deploymentId'] ?? null;
-        $this->lifecycleEventHookExecutionId = $input['lifecycleEventHookExecutionId'] ?? null;
-        $this->status = $input['status'] ?? null;
+        $this->DeploymentId = $input['DeploymentId'] ?? null;
+        $this->LifecycleEventHookExecutionId = $input['LifecycleEventHookExecutionId'] ?? null;
+        $this->Status = $input['Status'] ?? null;
         parent::__construct($input);
     }
 
@@ -53,22 +53,22 @@ final class PutLifecycleEventHookExecutionStatusInput extends Input
         return $input instanceof self ? $input : new self($input);
     }
 
-    public function getdeploymentId(): ?string
+    public function getDeploymentId(): ?string
     {
-        return $this->deploymentId;
+        return $this->DeploymentId;
     }
 
-    public function getlifecycleEventHookExecutionId(): ?string
+    public function getLifecycleEventHookExecutionId(): ?string
     {
-        return $this->lifecycleEventHookExecutionId;
+        return $this->LifecycleEventHookExecutionId;
     }
 
     /**
      * @return LifecycleEventStatus::*|null
      */
-    public function getstatus(): ?string
+    public function getStatus(): ?string
     {
-        return $this->status;
+        return $this->Status;
     }
 
     /**
@@ -96,16 +96,16 @@ final class PutLifecycleEventHookExecutionStatusInput extends Input
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));
     }
 
-    public function setdeploymentId(?string $value): self
+    public function setDeploymentId(?string $value): self
     {
-        $this->deploymentId = $value;
+        $this->DeploymentId = $value;
 
         return $this;
     }
 
-    public function setlifecycleEventHookExecutionId(?string $value): self
+    public function setLifecycleEventHookExecutionId(?string $value): self
     {
-        $this->lifecycleEventHookExecutionId = $value;
+        $this->LifecycleEventHookExecutionId = $value;
 
         return $this;
     }
@@ -113,9 +113,9 @@ final class PutLifecycleEventHookExecutionStatusInput extends Input
     /**
      * @param LifecycleEventStatus::*|null $value
      */
-    public function setstatus(?string $value): self
+    public function setStatus(?string $value): self
     {
-        $this->status = $value;
+        $this->Status = $value;
 
         return $this;
     }
@@ -123,13 +123,13 @@ final class PutLifecycleEventHookExecutionStatusInput extends Input
     private function requestBody(): array
     {
         $payload = [];
-        if (null !== $v = $this->deploymentId) {
+        if (null !== $v = $this->DeploymentId) {
             $payload['deploymentId'] = $v;
         }
-        if (null !== $v = $this->lifecycleEventHookExecutionId) {
+        if (null !== $v = $this->LifecycleEventHookExecutionId) {
             $payload['lifecycleEventHookExecutionId'] = $v;
         }
-        if (null !== $v = $this->status) {
+        if (null !== $v = $this->Status) {
             if (!LifecycleEventStatus::exists($v)) {
                 throw new InvalidArgument(sprintf('Invalid parameter "status" for "%s". The value "%s" is not a valid "LifecycleEventStatus".', __CLASS__, $v));
             }

--- a/src/Service/CodeDeploy/src/Result/PutLifecycleEventHookExecutionStatusOutput.php
+++ b/src/Service/CodeDeploy/src/Result/PutLifecycleEventHookExecutionStatusOutput.php
@@ -11,13 +11,13 @@ class PutLifecycleEventHookExecutionStatusOutput extends Result
      * The execution ID of the lifecycle event hook. A hook is specified in the `hooks` section of the deployment's AppSpec
      * file.
      */
-    private $lifecycleEventHookExecutionId;
+    private $LifecycleEventHookExecutionId;
 
-    public function getlifecycleEventHookExecutionId(): ?string
+    public function getLifecycleEventHookExecutionId(): ?string
     {
         $this->initialize();
 
-        return $this->lifecycleEventHookExecutionId;
+        return $this->LifecycleEventHookExecutionId;
     }
 
     protected function populateResult(Response $response): void

--- a/src/Service/S3/src/Result/GetObjectOutput.php
+++ b/src/Service/S3/src/Result/GetObjectOutput.php
@@ -451,7 +451,7 @@ class GetObjectOutput extends Result
         $this->ObjectLockRetainUntilDate = isset($headers['x-amz-object-lock-retain-until-date'][0]) ? new \DateTimeImmutable($headers['x-amz-object-lock-retain-until-date'][0]) : null;
         $this->ObjectLockLegalHoldStatus = $headers['x-amz-object-lock-legal-hold'][0] ?? null;
 
-        $this->Metadata = [];
+        $this->NAME = [];
         foreach ($headers as $name => $value) {
             if ('x-amz-meta-' === substr($name, 0, 11)) {
                 $this->Metadata[$name] = $value[0];

--- a/src/Service/S3/src/Result/HeadObjectOutput.php
+++ b/src/Service/S3/src/Result/HeadObjectOutput.php
@@ -422,7 +422,7 @@ class HeadObjectOutput extends Result
         $this->ObjectLockRetainUntilDate = isset($headers['x-amz-object-lock-retain-until-date'][0]) ? new \DateTimeImmutable($headers['x-amz-object-lock-retain-until-date'][0]) : null;
         $this->ObjectLockLegalHoldStatus = $headers['x-amz-object-lock-legal-hold'][0] ?? null;
 
-        $this->Metadata = [];
+        $this->NAME = [];
         foreach ($headers as $name => $value) {
             if ('x-amz-meta-' === substr($name, 0, 11)) {
                 $this->Metadata[$name] = $value[0];

--- a/src/Service/Sqs/src/Input/CreateQueueRequest.php
+++ b/src/Service/Sqs/src/Input/CreateQueueRequest.php
@@ -33,13 +33,13 @@ final class CreateQueueRequest extends Input
      *
      * @var string[]
      */
-    private $tags;
+    private $Tags;
 
     /**
      * @param array{
      *   QueueName?: string,
      *   Attributes?: string[],
-     *   tags?: string[],
+     *   Tags?: string[],
      *   @region?: string,
      * } $input
      */
@@ -47,7 +47,11 @@ final class CreateQueueRequest extends Input
     {
         $this->QueueName = $input['QueueName'] ?? null;
         $this->Attributes = $input['Attributes'] ?? [];
-        $this->tags = $input['tags'] ?? [];
+        if (isset($input['tags'])) {
+            @trigger_error(sprintf('Using key tags in "%s" is deprecated. Use Tags instead.', __CLASS__), \E_USER_DEPRECATED);
+            $input['Tags'] = $input['tags'];
+        }
+        $this->Tags = $input['Tags'] ?? [];
         parent::__construct($input);
     }
 
@@ -72,9 +76,9 @@ final class CreateQueueRequest extends Input
     /**
      * @return string[]
      */
-    public function gettags(): array
+    public function getTags(): array
     {
-        return $this->tags;
+        return $this->Tags;
     }
 
     /**
@@ -118,9 +122,9 @@ final class CreateQueueRequest extends Input
     /**
      * @param string[] $value
      */
-    public function settags(array $value): self
+    public function setTags(array $value): self
     {
-        $this->tags = $value;
+        $this->Tags = $value;
 
         return $this;
     }
@@ -141,7 +145,7 @@ final class CreateQueueRequest extends Input
         }
 
         $index = 0;
-        foreach ($this->tags as $mapKey => $mapValue) {
+        foreach ($this->Tags as $mapKey => $mapValue) {
             ++$index;
             $payload["Tag.$index.Key"] = $mapKey;
             $payload["Tag.$index.Value"] = $mapValue;

--- a/src/Service/Sqs/src/SqsClient.php
+++ b/src/Service/Sqs/src/SqsClient.php
@@ -57,7 +57,7 @@ class SqsClient extends AbstractApi
      * @param array{
      *   QueueName: string,
      *   Attributes?: string[],
-     *   tags?: string[],
+     *   Tags?: string[],
      *   @region?: string,
      * }|CreateQueueRequest $input
      */


### PR DESCRIPTION
This is an alternative of #538 that also define a consistency for properties and Input.

It provides a BC Layer and migration path for input key case.

It also provide a kind of "feature flag" per service (defined via the manifest). Use to define which service should contains a BC layer (sts, sqs) or not (code deploy).