### PR TITLE
[Monolog CloudWatch] Rename composer package

### DIFF
--- a/src/Integration/Monolog/CloudWatch/composer.json
+++ b/src/Integration/Monolog/CloudWatch/composer.json
@@ -12,7 +12,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.2.5",
-        "async-aws/cloud-watch-logs": "^0.1-dev",
+        "async-aws/cloud-watch-logs": "^0.1",
         "monolog/monolog": "^1.1 || ^2.0"
     },
     "extra": {

--- a/src/Integration/Monolog/CloudWatch/composer.json
+++ b/src/Integration/Monolog/CloudWatch/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "async-aws/monolog-cloudwatch",
+    "name": "async-aws/monolog-cloud-watch",
     "type": "library",
     "description": "Monolog integration with CloudWatch logs",
     "keywords": [


### PR DESCRIPTION
I rename it to be consistent with `async-aws/cloud-watch-logs`