### PR TITLE
report AWS deprecation

### DIFF
--- a/src/CodeGenerator/src/Definition/Member.php
+++ b/src/CodeGenerator/src/Definition/Member.php
@@ -41,4 +41,9 @@ class Member
     {
         return $this->data['flattened'] ?? false;
     }
+
+    public function isDeprecated(): ?bool
+    {
+        return $this->data['deprecated'] ?? false;
+    }
 }

--- a/src/CodeGenerator/src/Definition/Operation.php
+++ b/src/CodeGenerator/src/Definition/Operation.php
@@ -124,4 +124,9 @@ class Operation
     {
         return \in_array($this->getHttpMethod(), ['PUT', 'POST']);
     }
+
+    public function isDeprecated(): bool
+    {
+        return $this->data['deprecated'] ?? false;
+    }
 }

--- a/src/CodeGenerator/src/Generator/InputGenerator.php
+++ b/src/CodeGenerator/src/Generator/InputGenerator.php
@@ -190,8 +190,8 @@ class InputGenerator
                     $this->NAME = $value;
                     return $this;
                 ', [
-                    'NAME' => $member->getName(),
-                ]));
+                'NAME' => $member->getName(),
+            ]));
             $setter
                 ->addParameter('value')->setType($returnType)->setNullable($nullable)
             ;

--- a/src/CodeGenerator/src/Generator/InputGenerator.php
+++ b/src/CodeGenerator/src/Generator/InputGenerator.php
@@ -175,12 +175,18 @@ class InputGenerator
 
             $getter = $class->addMethod('get' . \ucfirst($member->getName()))
                 ->setReturnType($returnType)
-                ->setReturnNullable($nullable)
-                ->setBody(strtr('return $this->NAME;', ['NAME' => $member->getName()]));
-
+                ->setReturnNullable($nullable);
             $setter = $class->addMethod('set' . \ucfirst($member->getName()))
-                ->setReturnType('self')
-                ->setBody(strtr('
+                ->setReturnType('self');
+
+            $deprecation = '';
+            if ($member->isDeprecated()) {
+                $getter->addComment('@deprecated');
+                $setter->addComment('@deprecated');
+                $deprecation = strtr('@trigger_error(\sprintf(\'The property "NAME" of "%s" is deprecated by AWS.\', __CLASS__), E_USER_DEPRECATED);', ['NAME' => $member->getName()]);
+            }
+            $getter->setBody($deprecation . strtr('return $this->NAME;', ['NAME' => $member->getName()]));
+            $setter->setBody($deprecation . strtr('
                     $this->NAME = $value;
                     return $this;
                 ', [

--- a/src/CodeGenerator/src/Generator/ObjectGenerator.php
+++ b/src/CodeGenerator/src/Generator/ObjectGenerator.php
@@ -246,8 +246,15 @@ class ObjectGenerator
             }
 
             $method = $class->addMethod('get' . \ucfirst($member->getName()))
-                ->setReturnType($returnType)
-                ->setBody(strtr('
+                ->setReturnType($returnType);
+
+            $deprecation = '';
+            if ($member->isDeprecated()) {
+                $method->addComment('@deprecated');
+                $deprecation = strtr('@trigger_error(\sprintf(\'The property "NAME" of "%s" is deprecated by AWS.\', __CLASS__), E_USER_DEPRECATED);', ['NAME' => $member->getName()]);
+            }
+
+            $method->setBody($deprecation . strtr('
                     return $this->NAME;
                 ', [
                     'NAME' => $member->getName(),

--- a/src/CodeGenerator/src/Generator/ObjectGenerator.php
+++ b/src/CodeGenerator/src/Generator/ObjectGenerator.php
@@ -257,8 +257,8 @@ class ObjectGenerator
             $method->setBody($deprecation . strtr('
                     return $this->NAME;
                 ', [
-                    'NAME' => $member->getName(),
-                ]));
+                'NAME' => $member->getName(),
+            ]));
 
             $nullable = $nullable ?? !$member->isRequired();
             if ($parameterType && $parameterType !== $returnType && (empty($memberClassNames) || $memberClassNames[0]->getName() !== $parameterType)) {

--- a/src/CodeGenerator/src/Generator/OperationGenerator.php
+++ b/src/CodeGenerator/src/Generator/OperationGenerator.php
@@ -138,15 +138,21 @@ class OperationGenerator
 
     private function setMethodBody(Method $method, Operation $operation, ClassName $inputClass, ?ClassName $resultClass): void
     {
+        $body = '';
+        if ($operation->isDeprecated()) {
+            $method->addComment('@deprecated');
+            $body .= '@trigger_error(\sprintf(\'The operation "%s" is deprecated by AWS.\', __FUNCTION__), E_USER_DEPRECATED);';
+        }
+
         if ((null !== $pagination = $operation->getPagination()) && !empty($pagination->getOutputToken())) {
-            $body = '
+            $body .= '
                 $input = INPUT_CLASS::create($input);
                 $response = $this->getResponse($input->request(), new RequestContext(["operation" => OPERATION_NAME, "region" => $input->getRegion()]));
 
                 return new RESULT_CLASS($response, $this, $input);
             ';
         } else {
-            $body = '
+            $body .= '
                 $input = INPUT_CLASS::create($input);
                 $response = $this->getResponse($input->request(), new RequestContext(["operation" => OPERATION_NAME, "region" => $input->getRegion()]));
 

--- a/src/CodeGenerator/src/Generator/RequestSerializer/QuerySerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/QuerySerializer.php
@@ -78,9 +78,14 @@ class QuerySerializer implements Serializer
                 $inputElement = '$v';
             }
 
+            $deprecation = '';
+            if ($member->isDeprecated()) {
+                $deprecation = strtr('@trigger_error(\sprintf(\'The property "NAME" of "%s" is deprecated by AWS.\', __CLASS__), E_USER_DEPRECATED);', ['NAME' => $member->getName()]);
+            }
+
             return strtr($body, [
                 'PROPERTY' => $member->getName(),
-                'MEMBER_CODE' => $this->dumpArrayElement($name = $this->getName($member), $inputElement, $name, $shape),
+                'MEMBER_CODE' => $deprecation . $this->dumpArrayElement($name = $this->getName($member), $inputElement, $name, $shape),
             ]);
         }, $shape->getMembers()));
 

--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestJsonSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestJsonSerializer.php
@@ -75,9 +75,14 @@ class RestJsonSerializer implements Serializer
                 $inputElement = '$v';
             }
 
+            $deprecation = '';
+            if ($member->isDeprecated()) {
+                $deprecation = strtr('@trigger_error(\sprintf(\'The property "NAME" of "%s" is deprecated by AWS.\', __CLASS__), E_USER_DEPRECATED);', ['NAME' => $member->getName()]);
+            }
+
             return strtr($body, [
                 'PROPERTY' => $member->getName(),
-                'MEMBER_CODE' => $this->dumpArrayElement(sprintf('["%s"]', $name = $this->getName($member)), $inputElement, $name, $shape, $member->isRequired()),
+                'MEMBER_CODE' => $deprecation . $this->dumpArrayElement(sprintf('["%s"]', $name = $this->getName($member)), $inputElement, $name, $shape, $member->isRequired()),
             ]);
         }, $shape->getMembers()));
 

--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
@@ -84,9 +84,14 @@ class RestXmlSerializer implements Serializer
                 $inputElement = '$v';
             }
 
+            $deprecation = '';
+            if ($member->isDeprecated()) {
+                $deprecation = strtr('@trigger_error(\sprintf(\'The property "NAME" of "%s" is deprecated by AWS.\', __CLASS__), E_USER_DEPRECATED);', ['NAME' => $member->getName()]);
+            }
+
             return strtr($body, [
                 'PROPERTY' => $member->getName(),
-                'MEMBER_CODE' => $this->dumpXmlShape($member, $member->getShape(), '$node', $inputElement),
+                'MEMBER_CODE' => $deprecation . $this->dumpXmlShape($member, $member->getShape(), '$node', $inputElement),
             ]);
         }, $shape->getMembers()));
 

--- a/src/CodeGenerator/src/Generator/ResultGenerator.php
+++ b/src/CodeGenerator/src/Generator/ResultGenerator.php
@@ -183,8 +183,15 @@ class ResultGenerator
             }
 
             $method = $class->addMethod('get' . \ucfirst($member->getName()))
-                ->setReturnType($returnType)
-                ->setBody(strtr('
+                ->setReturnType($returnType);
+
+            $deprecation = '';
+            if ($member->isDeprecated()) {
+                $method->addComment('@deprecated');
+                $deprecation = strtr('@trigger_error(\sprintf(\'The property "NAME" of "%s" is deprecated by AWS.\', __CLASS__), E_USER_DEPRECATED);', ['NAME' => $member->getName()]);
+            }
+
+            $method->setBody($deprecation . strtr('
                     $this->initialize();
 
                     return $this->NAME;

--- a/src/CodeGenerator/src/Generator/ResultGenerator.php
+++ b/src/CodeGenerator/src/Generator/ResultGenerator.php
@@ -196,8 +196,8 @@ class ResultGenerator
 
                     return $this->NAME;
                 ', [
-                    'NAME' => $member->getName(),
-                ]));
+                'NAME' => $member->getName(),
+            ]));
 
             $nullable = $nullable ?? !$member->isRequired();
             if ($parameterType && $parameterType !== $returnType && (empty($memberClassNames) || $memberClassNames[0]->getName() !== $parameterType)) {

--- a/src/Service/CloudWatchLogs/src/ValueObject/LogStream.php
+++ b/src/Service/CloudWatchLogs/src/ValueObject/LogStream.php
@@ -105,8 +105,13 @@ final class LogStream
         return $this->logStreamName;
     }
 
+    /**
+     * @deprecated
+     */
     public function getStoredBytes(): ?string
     {
+        @trigger_error(\sprintf('The property "storedBytes" of "%s" is deprecated by AWS.', __CLASS__), \E_USER_DEPRECATED);
+
         return $this->storedBytes;
     }
 

--- a/src/Service/CloudWatchLogs/tests/Unit/Result/DescribeLogStreamsResponseTest.php
+++ b/src/Service/CloudWatchLogs/tests/Unit/Result/DescribeLogStreamsResponseTest.php
@@ -47,7 +47,6 @@ class DescribeLogStreamsResponseTest extends TestCase
         $logStreams = iterator_to_array($result->getLogStreams(true));
 
         self::assertCount(2, $logStreams);
-        self::assertSame('0', $logStreams[0]->getStoredBytes());
         self::assertSame('arn:aws:logs:us-east-1:123456789012:log-group:my-log-group-1:log-stream:my-log-stream-1', $logStreams[0]->getArn());
         self::assertSame('1393545600000', $logStreams[0]->getCreationTime());
         self::assertSame('1393545600000', $logStreams[0]->getFirstEventTimestamp());
@@ -55,5 +54,36 @@ class DescribeLogStreamsResponseTest extends TestCase
         self::assertSame('1393589200000', $logStreams[0]->getLastIngestionTime());
         self::assertSame('my-log-stream-1', $logStreams[0]->getLogStreamName());
         self::assertSame('88602967394531410094953670125156212707622379445839968487', $logStreams[0]->getUploadSequenceToken());
+    }
+
+    /**
+     * @group legacy
+     * @expectedDeprecation The property "storedBytes" of "%s" is deprecated by AWS.
+     */
+    public function testDescribeLogStreamsResponseDeprecatedAttribute(): void
+    {
+        // see https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogStreams.html
+        $response = new SimpleMockedResponse('{
+            "logStreams": [
+                {
+                    "storedBytes": 0,
+                    "arn": "arn:aws:logs:us-east-1:123456789012:log-group:my-log-group-1:log-stream:my-log-stream-1",
+                    "creationTime": 1393545600000,
+                    "firstEventTimestamp": 1393545600000,
+                    "lastEventTimestamp": 1393567800000,
+                    "lastIngestionTime": 1393589200000,
+                    "logStreamName": "my-log-stream-1",
+                    "uploadSequenceToken": "88602967394531410094953670125156212707622379445839968487"
+                }
+            ]
+        }');
+
+        $client = new MockHttpClient($response);
+        $result = new DescribeLogStreamsResponse(new Response($client->request('POST', 'http://localhost'), $client, new NullLogger()));
+
+        /** @var LogStream[] $logStreams */
+        $logStreams = iterator_to_array($result->getLogStreams(true));
+
+        self::assertSame('0', $logStreams[0]->getStoredBytes());
     }
 }


### PR DESCRIPTION
Report deprecation for:
* operation: when user call `$client->operation()`
* input: when user call getter/setter, and when request is built
* result: when user call getter


note: can not trigger deprecation on constructors because ValueObject are also used by result, and `initialize`  will trigger the deprecation.

note: I didn't use `symfony/deprecation-contracts` because, the signature of the \trigger_deprecation` does not fit with our needs (no specific package nor version.)