### PR TITLE
Use correct filename in docs for Illuminate Cache

### DIFF
--- a/docs/integration/laravel.md
+++ b/docs/integration/laravel.md
@@ -25,7 +25,7 @@ key will not work.
 ### Configure
 
 ```diff
-# config/filesystems.php
+# config/cache.php
 
  'dynamodb' => [
 -    'driver' => 'dynamodb',


### PR DESCRIPTION
Fix the filename for the config instructions for Illuminate Cache