### PR TITLE
Refactor endpoint generation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,6 +2,7 @@
     "variables": {
         "${LATEST}": "3.137.5"
     },
+    "endpoints": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/${LATEST}\/src\/data\/endpoints.json",
     "services": {
         "CloudFormation": {
             "source": "https:\/\/raw.githubusercontent.com\/aws\/aws-sdk-php\/${LATEST}\/src\/data\/cloudformation\/2010-05-15\/api-2.json",

--- a/src/CodeGenerator/src/Command/GenerateCommand.php
+++ b/src/CodeGenerator/src/Command/GenerateCommand.php
@@ -210,14 +210,16 @@ class GenerateCommand extends Command
                 unset($serviceEndpoints[$service['partitionEndpoint']]);
                 unset($serviceEndpoints['_global'][$partition['partition']]['region']);
                 $serviceEndpoints['_global'][$partition['partition']]['regions'] = [];
-                foreach ($partition['regions'] as $region => $_) {
-                    if (isset($serviceEndpoints[$region])) {
-                        continue;
+                if (!($service['isRegionalized'] ?? true)) {
+                    foreach ($partition['regions'] as $region => $_) {
+                        if (isset($serviceEndpoints[$region])) {
+                            continue;
+                        }
+                        if (\in_array($region, $serviceEndpoints['_default'][$partition['partition']]['regions'] ?? [])) {
+                            continue;
+                        }
+                        $serviceEndpoints['_global'][$partition['partition']]['regions'][] = $region;
                     }
-                    if (\in_array($region, $serviceEndpoints['_default'][$partition['partition']]['regions'] ?? [])) {
-                        continue;
-                    }
-                    $serviceEndpoints['_global'][$partition['partition']]['regions'][] = $region;
                 }
             }
         }

--- a/src/CodeGenerator/src/Command/GenerateCommand.php
+++ b/src/CodeGenerator/src/Command/GenerateCommand.php
@@ -67,15 +67,16 @@ class GenerateCommand extends Command
 
         /** @var ConsoleOutputInterface $output */
         $manifest = $this->loadManifest();
+        $endpoints = $this->loadFile($manifest['endpoints'], 'endpoints');
         $serviceNames = $this->getServiceNames($input->getArgument('service'), $input->getOption('all'), $io, $manifest['services']);
         if (\is_int($serviceNames)) {
             return $serviceNames;
         }
 
         if (\count($serviceNames) > 1 && $input->getOption('all') && \extension_loaded('pcntl')) {
-            $manifest = $this->generateServicesParallel($io, $input, $output, $manifest, $serviceNames);
+            $manifest = $this->generateServicesParallel($io, $input, $output, $manifest, $endpoints, $serviceNames);
         } else {
-            $manifest = $this->generateServicesSequential($io, $input, $output, $manifest, $serviceNames);
+            $manifest = $this->generateServicesSequential($io, $input, $output, $manifest, $endpoints, $serviceNames);
         }
 
         if (\is_int($manifest)) {
@@ -88,7 +89,7 @@ class GenerateCommand extends Command
         return 0;
     }
 
-    private function generateServicesParallel(SymfonyStyle $io, InputInterface $input, ConsoleOutputInterface $output, array $manifest, array $serviceNames)
+    private function generateServicesParallel(SymfonyStyle $io, InputInterface $input, ConsoleOutputInterface $output, array $manifest, array $endpoints, array $serviceNames)
     {
         $progress = (new SymfonyStyle($input, $output->section()))->createProgressBar();
         $progress->setFormat(' [%bar%] %message%');
@@ -102,7 +103,7 @@ class GenerateCommand extends Command
                 throw new \RuntimeException('Failed to fork');
             }
             if (!$pid) {
-                $code = $this->generateService($io, $input, $manifest, $serviceName);
+                $code = $this->generateService($io, $input, $manifest, $endpoints, $serviceName);
                 if (\is_int($code)) {
                     die($code);
                 }
@@ -128,7 +129,7 @@ class GenerateCommand extends Command
         return $manifest;
     }
 
-    private function generateServicesSequential(SymfonyStyle $io, InputInterface $input, ConsoleOutputInterface $output, array $manifest, array $serviceNames)
+    private function generateServicesSequential(SymfonyStyle $io, InputInterface $input, ConsoleOutputInterface $output, array $manifest, array $endpoints, array $serviceNames)
     {
         if (\count($serviceNames) > 1) {
             $progress = (new SymfonyStyle($input, $output->section()))->createProgressBar();
@@ -138,7 +139,7 @@ class GenerateCommand extends Command
         }
 
         foreach ($serviceNames as $serviceName) {
-            $manifest = $this->generateService($io, $input, $manifest, $serviceName);
+            $manifest = $this->generateService($io, $input, $manifest, $endpoints, $serviceName);
             if (\is_int($manifest)) {
                 return $manifest;
             }
@@ -157,9 +158,78 @@ class GenerateCommand extends Command
         return $manifest;
     }
 
-    private function generateService(SymfonyStyle $io, InputInterface $input, array $manifest, string $serviceName)
+    private function extractEndpointsForService(array $endpoints, string $prefix): array
+    {
+        $serviceEndpoints = [];
+        foreach ($endpoints['partitions'] as $partition) {
+            $suffix = $partition['dnsSuffix'];
+            $service = $partition['services'][$prefix] ?? [];
+            foreach ($service['endpoints'] ?? [] as $region => $config) {
+                $hostname = $config['hostname'] ?? $service['defaults']['hostname'] ?? $partition['defaults']['hostname'];
+                $protocols = array_merge($config['protocols'] ?? [], $service['defaults']['protocols'] ?? [], $partition['defaults']['protocols'] ?? []);
+                $signRegion = $config['credentialScope']['region'] ?? $service['defaults']['credentialScope']['region'] ?? $partition['defaults']['credentialScope']['region'] ?? $region;
+                $signService = $config['credentialScope']['service'] ?? $service['defaults']['credentialScope']['service'] ?? $partition['defaults']['credentialScope']['service'] ?? $prefix;
+                $signVersions = \array_unique(array_merge($config['signatureVersions'] ?? [], $service['defaults']['signatureVersions'] ?? [], $partition['defaults']['signatureVersions'] ?? []));
+
+                if (empty($config)) {
+                    if (!isset($serviceEndpoints['_default'][$partition['partition']])) {
+                        $endpoint = strtr(sprintf('http%s://%s', \in_array('https', $protocols) ? 's' : '', $hostname), [
+                            '{service}' => $prefix,
+                            '{region}' => '%region%',
+                            '{dnsSuffix}' => $suffix,
+                        ]);
+                        $serviceEndpoints['_default'][$partition['partition']] = [
+                            'endpoint' => $endpoint,
+                            'regions' => [$region],
+                            'signService' => $signService,
+                            'signVersions' => $signVersions,
+                        ];
+                    } else {
+                        $serviceEndpoints['_default'][$partition['partition']]['regions'][] = $region;
+                    }
+                } else {
+                    $endpoint = strtr(sprintf('http%s://%s', \in_array('https', $protocols) ? 's' : '', $hostname), [
+                        '{service}' => $prefix,
+                        '{region}' => $region,
+                        '{dnsSuffix}' => $suffix,
+                    ]);
+
+                    $serviceEndpoints[$region] = [
+                        'endpoint' => $endpoint,
+                        'signRegion' => $signRegion,
+                        'signService' => $signService,
+                        'signVersions' => $signVersions,
+                    ];
+                }
+            }
+            if (isset($service['partitionEndpoint'])) {
+                if (!isset($serviceEndpoints[$service['partitionEndpoint']])) {
+                    throw new \RuntimeException('Missing global region config');
+                }
+                $serviceEndpoints['_global'][$partition['partition']] = $serviceEndpoints[$service['partitionEndpoint']];
+                unset($serviceEndpoints[$service['partitionEndpoint']]);
+                unset($serviceEndpoints['_global'][$partition['partition']]['region']);
+                $serviceEndpoints['_global'][$partition['partition']]['regions'] = [];
+                foreach ($partition['regions'] as $region => $_) {
+                    if (isset($serviceEndpoints[$region])) {
+                        continue;
+                    }
+                    if (\in_array($region, $serviceEndpoints['_default'][$partition['partition']]['regions'] ?? [])) {
+                        continue;
+                    }
+                    $serviceEndpoints['_global'][$partition['partition']]['regions'][] = $region;
+                }
+            }
+        }
+
+        return $serviceEndpoints;
+    }
+
+    private function generateService(SymfonyStyle $io, InputInterface $input, array $manifest, array $endpoints, string $serviceName)
     {
         $definitionArray = $this->loadFile($manifest['services'][$serviceName]['source'], "$serviceName-source");
+        $endpoints = $this->extractEndpointsForService($endpoints, $definitionArray['metadata']['endpointPrefix']);
+
         $documentationArray = $this->loadFile($manifest['services'][$serviceName]['documentation'], "$serviceName-documentation");
         $paginationArray = $this->loadFile($manifest['services'][$serviceName]['pagination'], "$serviceName-pagination");
         $waiterArray = isset($manifest['services'][$serviceName]['waiter']) ? $this->loadFile($manifest['services'][$serviceName]['waiter'], "$serviceName-waiter") : ['waiters' => []];
@@ -171,7 +241,7 @@ class GenerateCommand extends Command
         }
 
         $managedOperations = \array_unique(\array_merge($manifest['services'][$serviceName]['methods'], $operationNames));
-        $definition = new ServiceDefinition($serviceName, $definitionArray, $documentationArray, $paginationArray, $waiterArray, $exampleArray);
+        $definition = new ServiceDefinition($serviceName, $endpoints, $definitionArray, $documentationArray, $paginationArray, $waiterArray, $exampleArray);
         $serviceGenerator = $this->generator->service($manifest['services'][$serviceName]['namespace'] ?? \sprintf('AsyncAws\\%s', $serviceName), $managedOperations);
 
         $clientClass = $serviceGenerator->client()->generate($definition);

--- a/src/CodeGenerator/src/Command/GenerateCommand.php
+++ b/src/CodeGenerator/src/Command/GenerateCommand.php
@@ -166,10 +166,10 @@ class GenerateCommand extends Command
             $service = $partition['services'][$prefix] ?? [];
             foreach ($service['endpoints'] ?? [] as $region => $config) {
                 $hostname = $config['hostname'] ?? $service['defaults']['hostname'] ?? $partition['defaults']['hostname'];
-                $protocols = array_merge($config['protocols'] ?? [], $service['defaults']['protocols'] ?? [], $partition['defaults']['protocols'] ?? []);
+                $protocols = $config['protocols'] ?? $service['defaults']['protocols'] ?? $partition['defaults']['protocols'] ?? [];
                 $signRegion = $config['credentialScope']['region'] ?? $service['defaults']['credentialScope']['region'] ?? $partition['defaults']['credentialScope']['region'] ?? $region;
                 $signService = $config['credentialScope']['service'] ?? $service['defaults']['credentialScope']['service'] ?? $partition['defaults']['credentialScope']['service'] ?? $prefix;
-                $signVersions = \array_unique(array_merge($config['signatureVersions'] ?? [], $service['defaults']['signatureVersions'] ?? [], $partition['defaults']['signatureVersions'] ?? []));
+                $signVersions = \array_unique($config['signatureVersions'] ?? $service['defaults']['signatureVersions'] ?? $partition['defaults']['signatureVersions'] ?? []);
 
                 if (empty($config)) {
                     if (!isset($serviceEndpoints['_default'][$partition['partition']])) {

--- a/src/CodeGenerator/src/Definition/ServiceDefinition.php
+++ b/src/CodeGenerator/src/Definition/ServiceDefinition.php
@@ -13,6 +13,8 @@ class ServiceDefinition
 {
     private $name;
 
+    private $endpoints;
+
     private $definition;
 
     private $documentation;
@@ -23,9 +25,10 @@ class ServiceDefinition
 
     private $example;
 
-    public function __construct(string $name, array $definition, array $documentation, array $pagination, array $waiter, array $example)
+    public function __construct(string $name, array $endpoints, array $definition, array $documentation, array $pagination, array $waiter, array $example)
     {
         $this->name = $name;
+        $this->endpoints = $endpoints;
         $this->definition = $definition;
         $this->documentation = $documentation;
         $this->pagination = $pagination;
@@ -36,6 +39,11 @@ class ServiceDefinition
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function getEndpoints(): array
+    {
+        return $this->endpoints;
     }
 
     public function getOperation(string $name): ?Operation
@@ -83,11 +91,6 @@ class ServiceDefinition
     public function getEndpointPrefix(): string
     {
         return $this->definition['metadata']['endpointPrefix'];
-    }
-
-    public function getGlobalEndpoint(): ?string
-    {
-        return $this->definition['metadata']['globalEndpoint'] ?? null;
     }
 
     public function getTargetPrefix(): string

--- a/src/CodeGenerator/src/Generator/ClientGenerator.php
+++ b/src/CodeGenerator/src/Generator/ClientGenerator.php
@@ -9,6 +9,7 @@ use AsyncAws\CodeGenerator\File\FileWriter;
 use AsyncAws\CodeGenerator\Generator\Naming\ClassName;
 use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
 use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassFactory;
+use AsyncAws\Core\Exception\UnsupportedRegion;
 use Nette\PhpGenerator\ClassType;
 
 /**
@@ -98,7 +99,8 @@ class ClientGenerator
         if (isset($global['aws'])) {
             $body .= $dumpConfig($global['aws']);
         } else {
-            $body .= 'throw new \\InvalidArgumentException(sprintf(\'The region "%s" is not supported by "' . $definition->getName() . '".\', $region));';
+            $namespace->addUse(UnsupportedRegion::class);
+            $body .= 'throw new UnsupportedRegion(sprintf(\'The region "%s" is not supported by "' . $definition->getName() . '".\', $region));';
         }
 
         $class->addMethod('getEndpointMetadata')

--- a/src/CodeGenerator/src/Generator/ClientGenerator.php
+++ b/src/CodeGenerator/src/Generator/ClientGenerator.php
@@ -9,6 +9,7 @@ use AsyncAws\CodeGenerator\File\FileWriter;
 use AsyncAws\CodeGenerator\Generator\Naming\ClassName;
 use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
 use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassFactory;
+use AsyncAws\Core\Configuration;
 use AsyncAws\Core\Exception\UnsupportedRegion;
 use Nette\PhpGenerator\ClassType;
 
@@ -55,7 +56,12 @@ class ClientGenerator
         }
 
         $endpoints = $definition->getEndpoints();
-        $body = 'switch ($region) {' . \PHP_EOL;
+        $body = '';
+        if (!isset($endpoints['_global']['aws'])) {
+            $namespace->addUse(Configuration::class);
+            $body .= 'if ($region === null) { $region = Configuration::DEFAULT_REGION; }' . \PHP_EOL;
+        }
+        $body .= 'switch ($region) {' . \PHP_EOL;
         $dumpConfig = function ($config) {
             sort($config['signVersions']);
 
@@ -113,6 +119,7 @@ class ClientGenerator
             ->setBody($body)
             ->addParameter('region')
                 ->setType('string')
+                ->setNullable(true)
         ;
 
         if (null !== $signatureVersion = $definition->getSignatureVersion()) {

--- a/src/CodeGenerator/src/Generator/ClientGenerator.php
+++ b/src/CodeGenerator/src/Generator/ClientGenerator.php
@@ -79,20 +79,19 @@ class ClientGenerator
         if (!isset($endpoints['_global']['aws'])) {
             $namespace->addUse(Configuration::class);
             $body .= 'if ($region === null) { $region = Configuration::DEFAULT_REGION; }' . \PHP_EOL;
+        } else {
+            if (empty($endpoints['_global']['aws']['signRegion'])) {
+                throw new \RuntimeException('Global endpoint without signRegion is not yet supported');
+            }
+            $body .= 'if ($region === null) { ' . $dumpConfig($endpoints['_global']['aws']) . ' }' . \PHP_EOL;
         }
         $body .= 'switch ($region) {' . \PHP_EOL;
 
         foreach ($endpoints['_global'] ?? [] as $partitionName => $config) {
-            if (empty($config['regions']) && 'aws' !== $partitionName) {
+            if (empty($config['regions'])) {
                 continue;
             }
             sort($config['regions']);
-            if ('aws' === $partitionName) {
-                if (empty($config['signRegion'])) {
-                    throw new \RuntimeException('Global endpoint without signRegion is not yet supported');
-                }
-                $body .= '    case null:' . \PHP_EOL;
-            }
             foreach ($config['regions'] as $region) {
                 $body .= sprintf('    case %s:' . \PHP_EOL, \var_export($region, true));
             }

--- a/src/CodeGenerator/src/Generator/ClientGenerator.php
+++ b/src/CodeGenerator/src/Generator/ClientGenerator.php
@@ -107,7 +107,6 @@ class ClientGenerator
             ->setBody($body)
             ->addParameter('region')
                 ->setType('string')
-                ->setNullable(true)
         ;
 
         if (null !== $signatureVersion = $definition->getSignatureVersion()) {

--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Support for EventBridge in `AwsClientFactory`
 - Support for IAM in `AwsClientFactory`
+- Support for global and regional endpoints
 
 ## 1.1.0
 

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -146,12 +146,15 @@ abstract class AbstractApi
     /**
      * This method is a BC layer for client that does not require core:^1.2.
      *
-     * @return array{endpoint: string, signRegion: string, signService: string, signVersions: list<string>}
+     * @return array{endpoint: string, signRegion: string, signService: string, signVersions: string[]}
      */
     protected function getEndpointMetadata(string $region): array
     {
+        /** @var string $endpoint */
+        $endpoint = $this->configuration->get('endpoint');
+
         return [
-            'endpoint' => $this->configuration->get('endpoint'),
+            'endpoint' => $endpoint,
             'signRegion' => $region,
             'signService' => $this->getSignatureScopeName(),
             'signVersions' => [$this->getSignatureVersion()],
@@ -166,7 +169,9 @@ abstract class AbstractApi
      */
     private function getEndpoint(string $uri, array $query, ?string $region): string
     {
-        $metadata = $this->getEndpointMetadata($region = $this->configuration->get('region'));
+        /** @var string $region */
+        $region = $region ?? $this->configuration->get('region');
+        $metadata = $this->getEndpointMetadata($region);
         if (!$this->configuration->isDefault('endpoint')) {
             $endpoint = $this->configuration->get('endpoint');
         } else {
@@ -189,8 +194,8 @@ abstract class AbstractApi
 
     private function getSigner(?string $region)
     {
-        $region = $region ?? $this->configuration->get(Configuration::OPTION_REGION);
         /** @var string $region */
+        $region = $region ?? $this->configuration->get(Configuration::OPTION_REGION);
         if (!isset($this->signers[$region])) {
             $metadata = $this->getEndpointMetadata($region);
             $factories = $this->getSignerFactories();

--- a/src/Core/src/Configuration.php
+++ b/src/Core/src/Configuration.php
@@ -14,6 +14,8 @@ use AsyncAws\Core\Exception\InvalidArgument;
  */
 final class Configuration
 {
+    public const DEFAULT_REGION = 'us-east-1';
+
     public const OPTION_REGION = 'region';
     public const OPTION_PROFILE = 'profile';
     public const OPTION_ACCESS_KEY_ID = 'accessKeyId';
@@ -62,7 +64,7 @@ final class Configuration
     ];
 
     private const DEFAULT_OPTIONS = [
-        self::OPTION_REGION => 'us-east-1',
+        self::OPTION_REGION => self::DEFAULT_REGION,
         self::OPTION_PROFILE => 'default',
         self::OPTION_SHARED_CREDENTIALS_FILE => '~/.aws/credentials',
         self::OPTION_SHARED_CONFIG_FILE => '~/.aws/config',
@@ -71,6 +73,8 @@ final class Configuration
     ];
 
     private $data = [];
+
+    private $userData = [];
 
     public static function create(array $options)
     {
@@ -98,6 +102,9 @@ final class Configuration
             }
         }
 
+        $configuration = new Configuration();
+        $configuration->userData = \array_fill_keys(\array_keys($options), true);
+
         foreach (self::DEFAULT_OPTIONS as $optionTrigger => $defaultValue) {
             if (isset($options[$optionTrigger])) {
                 continue;
@@ -106,7 +113,6 @@ final class Configuration
             $options[$optionTrigger] = $defaultValue;
         }
 
-        $configuration = new Configuration();
         $configuration->data = $options;
 
         return $configuration;
@@ -136,6 +142,6 @@ final class Configuration
             throw new InvalidArgument(\sprintf('Invalid option "%s" passed to "%s::%s". ', $name, __CLASS__, __METHOD__));
         }
 
-        return isset($this->data[$name], self::DEFAULT_OPTIONS[$name]) && $this->data[$name] === self::DEFAULT_OPTIONS[$name];
+        return empty($this->userData[$name]);
     }
 }

--- a/src/Core/src/Exception/UnsupportedRegion.php
+++ b/src/Core/src/Exception/UnsupportedRegion.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core\Exception;
+
+class UnsupportedRegion extends InvalidArgument
+{
+}

--- a/src/Core/src/Sts/StsClient.php
+++ b/src/Core/src/Sts/StsClient.php
@@ -89,7 +89,7 @@ class StsClient extends AbstractApi
         return new GetCallerIdentityResponse($response);
     }
 
-    protected function getEndpointMetadata(string $region): array
+    protected function getEndpointMetadata(?string $region): array
     {
         switch ($region) {
             case 'af-south-1':

--- a/src/Core/src/Sts/StsClient.php
+++ b/src/Core/src/Sts/StsClient.php
@@ -89,9 +89,121 @@ class StsClient extends AbstractApi
         return new GetCallerIdentityResponse($response);
     }
 
-    protected function getEndpointPattern(?string $region): string
+    protected function getEndpointMetadata(string $region): array
     {
-        return $region ? parent::getEndpointPattern($region) : 'https://sts.amazonaws.com';
+        switch ($region) {
+            case 'af-south-1':
+            case 'ap-east-1':
+            case 'ap-northeast-1':
+            case 'ap-northeast-2':
+            case 'ap-south-1':
+            case 'ap-southeast-1':
+            case 'ap-southeast-2':
+            case 'ca-central-1':
+            case 'eu-central-1':
+            case 'eu-north-1':
+            case 'eu-south-1':
+            case 'eu-west-1':
+            case 'eu-west-2':
+            case 'eu-west-3':
+            case 'me-south-1':
+            case 'sa-east-1':
+            case 'us-east-1':
+            case 'us-east-2':
+            case 'us-west-1':
+            case 'us-west-2':
+                return [
+                    'endpoint' => 'https://sts.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'sts',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'cn-north-1':
+            case 'cn-northwest-1':
+                return [
+                    'endpoint' => 'https://sts.%region%.amazonaws.com.cn',
+                    'signRegion' => $region,
+                    'signService' => 'sts',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-east-1':
+            case 'us-gov-west-1':
+                return [
+                    'endpoint' => 'https://sts.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'sts',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-iso-east-1':
+                return [
+                    'endpoint' => 'https://sts.%region%.c2s.ic.gov',
+                    'signRegion' => $region,
+                    'signService' => 'sts',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-isob-east-1':
+                return [
+                    'endpoint' => 'https://sts.%region%.sc2s.sgov.gov',
+                    'signRegion' => $region,
+                    'signService' => 'sts',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-east-1-fips':
+                return [
+                    'endpoint' => 'https://sts-fips.us-east-1.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 'sts',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-east-2-fips':
+                return [
+                    'endpoint' => 'https://sts-fips.us-east-2.amazonaws.com',
+                    'signRegion' => 'us-east-2',
+                    'signService' => 'sts',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-west-1-fips':
+                return [
+                    'endpoint' => 'https://sts-fips.us-west-1.amazonaws.com',
+                    'signRegion' => 'us-west-1',
+                    'signService' => 'sts',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-west-2-fips':
+                return [
+                    'endpoint' => 'https://sts-fips.us-west-2.amazonaws.com',
+                    'signRegion' => 'us-west-2',
+                    'signService' => 'sts',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+        }
+
+        return [
+            'endpoint' => 'https://sts.amazonaws.com',
+            'signRegion' => 'us-east-1',
+            'signService' => 'sts',
+            'signVersions' => [
+                0 => 'v4',
+            ],
+        ];
     }
 
     protected function getServiceCode(): string

--- a/src/Core/src/Sts/StsClient.php
+++ b/src/Core/src/Sts/StsClient.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\Core\Sts;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Sts\Input\AssumeRoleRequest;
 use AsyncAws\Core\Sts\Input\AssumeRoleWithWebIdentityRequest;
@@ -92,6 +93,15 @@ class StsClient extends AbstractApi
     protected function getEndpointMetadata(?string $region): array
     {
         switch ($region) {
+            case null:
+                return [
+                    'endpoint' => 'https://sts.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 'sts',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
             case 'af-south-1':
             case 'ap-east-1':
             case 'ap-northeast-1':
@@ -196,14 +206,7 @@ class StsClient extends AbstractApi
                 ];
         }
 
-        return [
-            'endpoint' => 'https://sts.amazonaws.com',
-            'signRegion' => 'us-east-1',
-            'signService' => 'sts',
-            'signVersions' => [
-                0 => 'v4',
-            ],
-        ];
+        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "Sts".', $region));
     }
 
     protected function getServiceCode(): string

--- a/src/Core/src/Sts/StsClient.php
+++ b/src/Core/src/Sts/StsClient.php
@@ -102,6 +102,7 @@ class StsClient extends AbstractApi
                 ],
             ];
         }
+
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Core/src/Sts/StsClient.php
+++ b/src/Core/src/Sts/StsClient.php
@@ -92,16 +92,17 @@ class StsClient extends AbstractApi
 
     protected function getEndpointMetadata(?string $region): array
     {
+        if (null === $region) {
+            return [
+                'endpoint' => 'https://sts.amazonaws.com',
+                'signRegion' => 'us-east-1',
+                'signService' => 'sts',
+                'signVersions' => [
+                    0 => 'v4',
+                ],
+            ];
+        }
         switch ($region) {
-            case null:
-                return [
-                    'endpoint' => 'https://sts.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'sts',
-                    'signVersions' => [
-                        0 => 'v4',
-                    ],
-                ];
             case 'af-south-1':
             case 'ap-east-1':
             case 'ap-northeast-1':

--- a/src/Service/CloudFormation/src/CloudFormationClient.php
+++ b/src/Service/CloudFormation/src/CloudFormationClient.php
@@ -58,6 +58,116 @@ class CloudFormationClient extends AbstractApi
         return new DescribeStacksOutput($response, $this, $input);
     }
 
+    protected function getEndpointMetadata(string $region): array
+    {
+        switch ($region) {
+            case 'af-south-1':
+            case 'ap-east-1':
+            case 'ap-northeast-1':
+            case 'ap-northeast-2':
+            case 'ap-south-1':
+            case 'ap-southeast-1':
+            case 'ap-southeast-2':
+            case 'ca-central-1':
+            case 'eu-central-1':
+            case 'eu-north-1':
+            case 'eu-south-1':
+            case 'eu-west-1':
+            case 'eu-west-2':
+            case 'eu-west-3':
+            case 'me-south-1':
+            case 'sa-east-1':
+            case 'us-east-1':
+            case 'us-east-2':
+            case 'us-west-1':
+            case 'us-west-2':
+                return [
+                    'endpoint' => 'https://cloudformation.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'cloudformation',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'cn-north-1':
+            case 'cn-northwest-1':
+                return [
+                    'endpoint' => 'https://cloudformation.%region%.amazonaws.com.cn',
+                    'signRegion' => $region,
+                    'signService' => 'cloudformation',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-east-1':
+            case 'us-gov-west-1':
+                return [
+                    'endpoint' => 'https://cloudformation.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'cloudformation',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-iso-east-1':
+                return [
+                    'endpoint' => 'https://cloudformation.%region%.c2s.ic.gov',
+                    'signRegion' => $region,
+                    'signService' => 'cloudformation',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-isob-east-1':
+                return [
+                    'endpoint' => 'https://cloudformation.%region%.sc2s.sgov.gov',
+                    'signRegion' => $region,
+                    'signService' => 'cloudformation',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-east-1-fips':
+                return [
+                    'endpoint' => 'https://cloudformation-fips.us-east-1.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 'cloudformation',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-east-2-fips':
+                return [
+                    'endpoint' => 'https://cloudformation-fips.us-east-2.amazonaws.com',
+                    'signRegion' => 'us-east-2',
+                    'signService' => 'cloudformation',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-west-1-fips':
+                return [
+                    'endpoint' => 'https://cloudformation-fips.us-west-1.amazonaws.com',
+                    'signRegion' => 'us-west-1',
+                    'signService' => 'cloudformation',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-west-2-fips':
+                return [
+                    'endpoint' => 'https://cloudformation-fips.us-west-2.amazonaws.com',
+                    'signRegion' => 'us-west-2',
+                    'signService' => 'cloudformation',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+        }
+
+        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "CloudFormation".', $region));
+    }
+
     protected function getServiceCode(): string
     {
         return 'cloudformation';

--- a/src/Service/CloudFormation/src/CloudFormationClient.php
+++ b/src/Service/CloudFormation/src/CloudFormationClient.php
@@ -9,6 +9,7 @@ use AsyncAws\CloudFormation\Result\DescribeStacksOutput;
 use AsyncAws\CloudFormation\ValueObject\Stack;
 use AsyncAws\CloudFormation\ValueObject\StackEvent;
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 
 class CloudFormationClient extends AbstractApi
@@ -165,7 +166,7 @@ class CloudFormationClient extends AbstractApi
                 ];
         }
 
-        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "CloudFormation".', $region));
+        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "CloudFormation".', $region));
     }
 
     protected function getServiceCode(): string

--- a/src/Service/CloudFormation/src/CloudFormationClient.php
+++ b/src/Service/CloudFormation/src/CloudFormationClient.php
@@ -65,6 +65,7 @@ class CloudFormationClient extends AbstractApi
         if (null === $region) {
             $region = Configuration::DEFAULT_REGION;
         }
+
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/CloudFormation/src/CloudFormationClient.php
+++ b/src/Service/CloudFormation/src/CloudFormationClient.php
@@ -9,6 +9,7 @@ use AsyncAws\CloudFormation\Result\DescribeStacksOutput;
 use AsyncAws\CloudFormation\ValueObject\Stack;
 use AsyncAws\CloudFormation\ValueObject\StackEvent;
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Configuration;
 use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 
@@ -59,8 +60,11 @@ class CloudFormationClient extends AbstractApi
         return new DescribeStacksOutput($response, $this, $input);
     }
 
-    protected function getEndpointMetadata(string $region): array
+    protected function getEndpointMetadata(?string $region): array
     {
+        if (null === $region) {
+            $region = Configuration::DEFAULT_REGION;
+        }
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
+++ b/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
@@ -66,6 +66,7 @@ class CloudWatchLogsClient extends AbstractApi
         if (null === $region) {
             $region = Configuration::DEFAULT_REGION;
         }
+
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
+++ b/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
@@ -8,6 +8,7 @@ use AsyncAws\CloudWatchLogs\Result\DescribeLogStreamsResponse;
 use AsyncAws\CloudWatchLogs\Result\PutLogEventsResponse;
 use AsyncAws\CloudWatchLogs\ValueObject\LogStream;
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Configuration;
 use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 
@@ -60,8 +61,11 @@ class CloudWatchLogsClient extends AbstractApi
         return new PutLogEventsResponse($response);
     }
 
-    protected function getEndpointMetadata(string $region): array
+    protected function getEndpointMetadata(?string $region): array
     {
+        if (null === $region) {
+            $region = Configuration::DEFAULT_REGION;
+        }
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
+++ b/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
@@ -8,6 +8,7 @@ use AsyncAws\CloudWatchLogs\Result\DescribeLogStreamsResponse;
 use AsyncAws\CloudWatchLogs\Result\PutLogEventsResponse;
 use AsyncAws\CloudWatchLogs\ValueObject\LogStream;
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 
 class CloudWatchLogsClient extends AbstractApi
@@ -130,7 +131,7 @@ class CloudWatchLogsClient extends AbstractApi
                 ];
         }
 
-        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "CloudWatchLogs".', $region));
+        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "CloudWatchLogs".', $region));
     }
 
     protected function getServiceCode(): string

--- a/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
+++ b/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
@@ -59,6 +59,80 @@ class CloudWatchLogsClient extends AbstractApi
         return new PutLogEventsResponse($response);
     }
 
+    protected function getEndpointMetadata(string $region): array
+    {
+        switch ($region) {
+            case 'af-south-1':
+            case 'ap-east-1':
+            case 'ap-northeast-1':
+            case 'ap-northeast-2':
+            case 'ap-south-1':
+            case 'ap-southeast-1':
+            case 'ap-southeast-2':
+            case 'ca-central-1':
+            case 'eu-central-1':
+            case 'eu-north-1':
+            case 'eu-south-1':
+            case 'eu-west-1':
+            case 'eu-west-2':
+            case 'eu-west-3':
+            case 'me-south-1':
+            case 'sa-east-1':
+            case 'us-east-1':
+            case 'us-east-2':
+            case 'us-west-1':
+            case 'us-west-2':
+                return [
+                    'endpoint' => 'https://logs.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'logs',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'cn-north-1':
+            case 'cn-northwest-1':
+                return [
+                    'endpoint' => 'https://logs.%region%.amazonaws.com.cn',
+                    'signRegion' => $region,
+                    'signService' => 'logs',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-east-1':
+            case 'us-gov-west-1':
+                return [
+                    'endpoint' => 'https://logs.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'logs',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-iso-east-1':
+                return [
+                    'endpoint' => 'https://logs.%region%.c2s.ic.gov',
+                    'signRegion' => $region,
+                    'signService' => 'logs',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-isob-east-1':
+                return [
+                    'endpoint' => 'https://logs.%region%.sc2s.sgov.gov',
+                    'signRegion' => $region,
+                    'signService' => 'logs',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+        }
+
+        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "CloudWatchLogs".', $region));
+    }
+
     protected function getServiceCode(): string
     {
         return 'logs';

--- a/src/Service/CodeDeploy/src/CodeDeployClient.php
+++ b/src/Service/CodeDeploy/src/CodeDeployClient.php
@@ -5,6 +5,7 @@ namespace AsyncAws\CodeDeploy;
 use AsyncAws\CodeDeploy\Input\PutLifecycleEventHookExecutionStatusInput;
 use AsyncAws\CodeDeploy\Result\PutLifecycleEventHookExecutionStatusOutput;
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 
 class CodeDeployClient extends AbstractApi
@@ -146,7 +147,7 @@ class CodeDeployClient extends AbstractApi
                 ];
         }
 
-        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "CodeDeploy".', $region));
+        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "CodeDeploy".', $region));
     }
 
     protected function getServiceCode(): string

--- a/src/Service/CodeDeploy/src/CodeDeployClient.php
+++ b/src/Service/CodeDeploy/src/CodeDeployClient.php
@@ -30,6 +30,125 @@ class CodeDeployClient extends AbstractApi
         return new PutLifecycleEventHookExecutionStatusOutput($response);
     }
 
+    protected function getEndpointMetadata(string $region): array
+    {
+        switch ($region) {
+            case 'af-south-1':
+            case 'ap-east-1':
+            case 'ap-northeast-1':
+            case 'ap-northeast-2':
+            case 'ap-south-1':
+            case 'ap-southeast-1':
+            case 'ap-southeast-2':
+            case 'ca-central-1':
+            case 'eu-central-1':
+            case 'eu-north-1':
+            case 'eu-south-1':
+            case 'eu-west-1':
+            case 'eu-west-2':
+            case 'eu-west-3':
+            case 'me-south-1':
+            case 'sa-east-1':
+            case 'us-east-1':
+            case 'us-east-2':
+            case 'us-west-1':
+            case 'us-west-2':
+                return [
+                    'endpoint' => 'https://codedeploy.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'codedeploy',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'cn-north-1':
+            case 'cn-northwest-1':
+                return [
+                    'endpoint' => 'https://codedeploy.%region%.amazonaws.com.cn',
+                    'signRegion' => $region,
+                    'signService' => 'codedeploy',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-east-1':
+            case 'us-gov-west-1':
+                return [
+                    'endpoint' => 'https://codedeploy.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'codedeploy',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-iso-east-1':
+                return [
+                    'endpoint' => 'https://codedeploy.%region%.c2s.ic.gov',
+                    'signRegion' => $region,
+                    'signService' => 'codedeploy',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-east-1-fips':
+                return [
+                    'endpoint' => 'https://codedeploy-fips.us-east-1.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 'codedeploy',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-east-2-fips':
+                return [
+                    'endpoint' => 'https://codedeploy-fips.us-east-2.amazonaws.com',
+                    'signRegion' => 'us-east-2',
+                    'signService' => 'codedeploy',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-east-1-fips':
+                return [
+                    'endpoint' => 'https://codedeploy-fips.us-gov-east-1.amazonaws.com',
+                    'signRegion' => 'us-gov-east-1',
+                    'signService' => 'codedeploy',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-west-1-fips':
+                return [
+                    'endpoint' => 'https://codedeploy-fips.us-gov-west-1.amazonaws.com',
+                    'signRegion' => 'us-gov-west-1',
+                    'signService' => 'codedeploy',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-west-1-fips':
+                return [
+                    'endpoint' => 'https://codedeploy-fips.us-west-1.amazonaws.com',
+                    'signRegion' => 'us-west-1',
+                    'signService' => 'codedeploy',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-west-2-fips':
+                return [
+                    'endpoint' => 'https://codedeploy-fips.us-west-2.amazonaws.com',
+                    'signRegion' => 'us-west-2',
+                    'signService' => 'codedeploy',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+        }
+
+        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "CodeDeploy".', $region));
+    }
+
     protected function getServiceCode(): string
     {
         return 'codedeploy';

--- a/src/Service/CodeDeploy/src/CodeDeployClient.php
+++ b/src/Service/CodeDeploy/src/CodeDeployClient.php
@@ -37,6 +37,7 @@ class CodeDeployClient extends AbstractApi
         if (null === $region) {
             $region = Configuration::DEFAULT_REGION;
         }
+
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/CodeDeploy/src/CodeDeployClient.php
+++ b/src/Service/CodeDeploy/src/CodeDeployClient.php
@@ -5,6 +5,7 @@ namespace AsyncAws\CodeDeploy;
 use AsyncAws\CodeDeploy\Input\PutLifecycleEventHookExecutionStatusInput;
 use AsyncAws\CodeDeploy\Result\PutLifecycleEventHookExecutionStatusOutput;
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Configuration;
 use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 
@@ -31,8 +32,11 @@ class CodeDeployClient extends AbstractApi
         return new PutLifecycleEventHookExecutionStatusOutput($response);
     }
 
-    protected function getEndpointMetadata(string $region): array
+    protected function getEndpointMetadata(?string $region): array
     {
+        if (null === $region) {
+            $region = Configuration::DEFAULT_REGION;
+        }
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
+++ b/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
@@ -21,6 +21,7 @@ use AsyncAws\CognitoIdentityProvider\Result\SetUserMFAPreferenceResponse;
 use AsyncAws\CognitoIdentityProvider\Result\VerifySoftwareTokenResponse;
 use AsyncAws\CognitoIdentityProvider\ValueObject\UserType;
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
 
@@ -272,7 +273,7 @@ class CognitoIdentityProviderClient extends AbstractApi
                 ];
         }
 
-        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "CognitoIdentityProvider".', $region));
+        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "CognitoIdentityProvider".', $region));
     }
 
     protected function getServiceCode(): string

--- a/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
+++ b/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
@@ -220,6 +220,61 @@ class CognitoIdentityProviderClient extends AbstractApi
         return new VerifySoftwareTokenResponse($response);
     }
 
+    protected function getEndpointMetadata(string $region): array
+    {
+        switch ($region) {
+            case 'ap-northeast-1':
+            case 'ap-northeast-2':
+            case 'ap-south-1':
+            case 'ap-southeast-1':
+            case 'ap-southeast-2':
+            case 'ca-central-1':
+            case 'eu-central-1':
+            case 'eu-west-1':
+            case 'eu-west-2':
+            case 'us-east-1':
+            case 'us-east-2':
+            case 'us-west-2':
+                return [
+                    'endpoint' => 'https://cognito-idp.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'cognito-idp',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-east-1':
+                return [
+                    'endpoint' => 'https://cognito-idp-fips.us-east-1.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 'cognito-idp',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-east-2':
+                return [
+                    'endpoint' => 'https://cognito-idp-fips.us-east-2.amazonaws.com',
+                    'signRegion' => 'us-east-2',
+                    'signService' => 'cognito-idp',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-west-2':
+                return [
+                    'endpoint' => 'https://cognito-idp-fips.us-west-2.amazonaws.com',
+                    'signRegion' => 'us-west-2',
+                    'signService' => 'cognito-idp',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+        }
+
+        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "CognitoIdentityProvider".', $region));
+    }
+
     protected function getServiceCode(): string
     {
         return 'cognito-idp';

--- a/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
+++ b/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
@@ -227,6 +227,7 @@ class CognitoIdentityProviderClient extends AbstractApi
         if (null === $region) {
             $region = Configuration::DEFAULT_REGION;
         }
+
         switch ($region) {
             case 'ap-northeast-1':
             case 'ap-northeast-2':

--- a/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
+++ b/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
@@ -21,6 +21,7 @@ use AsyncAws\CognitoIdentityProvider\Result\SetUserMFAPreferenceResponse;
 use AsyncAws\CognitoIdentityProvider\Result\VerifySoftwareTokenResponse;
 use AsyncAws\CognitoIdentityProvider\ValueObject\UserType;
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Configuration;
 use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
@@ -221,8 +222,11 @@ class CognitoIdentityProviderClient extends AbstractApi
         return new VerifySoftwareTokenResponse($response);
     }
 
-    protected function getEndpointMetadata(string $region): array
+    protected function getEndpointMetadata(?string $region): array
     {
+        if (null === $region) {
+            $region = Configuration::DEFAULT_REGION;
+        }
         switch ($region) {
             case 'ap-northeast-1':
             case 'ap-northeast-2':

--- a/src/Service/DynamoDb/src/DynamoDbClient.php
+++ b/src/Service/DynamoDb/src/DynamoDbClient.php
@@ -381,6 +381,7 @@ class DynamoDbClient extends AbstractApi
         if (null === $region) {
             $region = Configuration::DEFAULT_REGION;
         }
+
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/DynamoDb/src/DynamoDbClient.php
+++ b/src/Service/DynamoDb/src/DynamoDbClient.php
@@ -374,6 +374,152 @@ class DynamoDbClient extends AbstractApi
         return new UpdateTableOutput($response);
     }
 
+    protected function getEndpointMetadata(string $region): array
+    {
+        switch ($region) {
+            case 'af-south-1':
+            case 'ap-east-1':
+            case 'ap-northeast-1':
+            case 'ap-northeast-2':
+            case 'ap-south-1':
+            case 'ap-southeast-1':
+            case 'ap-southeast-2':
+            case 'ca-central-1':
+            case 'eu-central-1':
+            case 'eu-north-1':
+            case 'eu-south-1':
+            case 'eu-west-1':
+            case 'eu-west-2':
+            case 'eu-west-3':
+            case 'me-south-1':
+            case 'sa-east-1':
+            case 'us-east-1':
+            case 'us-east-2':
+            case 'us-west-1':
+            case 'us-west-2':
+                return [
+                    'endpoint' => 'https://dynamodb.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'dynamodb',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'cn-north-1':
+            case 'cn-northwest-1':
+                return [
+                    'endpoint' => 'https://dynamodb.%region%.amazonaws.com.cn',
+                    'signRegion' => $region,
+                    'signService' => 'dynamodb',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-east-1':
+            case 'us-gov-west-1':
+                return [
+                    'endpoint' => 'https://dynamodb.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'dynamodb',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-isob-east-1':
+                return [
+                    'endpoint' => 'https://dynamodb.%region%.sc2s.sgov.gov',
+                    'signRegion' => $region,
+                    'signService' => 'dynamodb',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'ca-central-1-fips':
+                return [
+                    'endpoint' => 'https://dynamodb-fips.ca-central-1.amazonaws.com',
+                    'signRegion' => 'ca-central-1',
+                    'signService' => 'dynamodb',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'local':
+                return [
+                    'endpoint' => 'http://localhost:8000',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 'dynamodb',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-east-1-fips':
+                return [
+                    'endpoint' => 'https://dynamodb-fips.us-east-1.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 'dynamodb',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-east-2-fips':
+                return [
+                    'endpoint' => 'https://dynamodb-fips.us-east-2.amazonaws.com',
+                    'signRegion' => 'us-east-2',
+                    'signService' => 'dynamodb',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-east-1-fips':
+                return [
+                    'endpoint' => 'https://dynamodb.us-gov-east-1.amazonaws.com',
+                    'signRegion' => 'us-gov-east-1',
+                    'signService' => 'dynamodb',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-west-1-fips':
+                return [
+                    'endpoint' => 'https://dynamodb.us-gov-west-1.amazonaws.com',
+                    'signRegion' => 'us-gov-west-1',
+                    'signService' => 'dynamodb',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-iso-east-1':
+                return [
+                    'endpoint' => 'https://dynamodb.us-iso-east-1.c2s.ic.gov',
+                    'signRegion' => 'us-iso-east-1',
+                    'signService' => 'dynamodb',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-west-1-fips':
+                return [
+                    'endpoint' => 'https://dynamodb-fips.us-west-1.amazonaws.com',
+                    'signRegion' => 'us-west-1',
+                    'signService' => 'dynamodb',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-west-2-fips':
+                return [
+                    'endpoint' => 'https://dynamodb-fips.us-west-2.amazonaws.com',
+                    'signRegion' => 'us-west-2',
+                    'signService' => 'dynamodb',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+        }
+
+        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "DynamoDb".', $region));
+    }
+
     protected function getServiceCode(): string
     {
         return 'dynamodb';

--- a/src/Service/DynamoDb/src/DynamoDbClient.php
+++ b/src/Service/DynamoDb/src/DynamoDbClient.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\DynamoDb;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Configuration;
 use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\DynamoDb\Input\CreateTableInput;
@@ -375,8 +376,11 @@ class DynamoDbClient extends AbstractApi
         return new UpdateTableOutput($response);
     }
 
-    protected function getEndpointMetadata(string $region): array
+    protected function getEndpointMetadata(?string $region): array
     {
+        if (null === $region) {
+            $region = Configuration::DEFAULT_REGION;
+        }
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/DynamoDb/src/DynamoDbClient.php
+++ b/src/Service/DynamoDb/src/DynamoDbClient.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\DynamoDb;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\DynamoDb\Input\CreateTableInput;
 use AsyncAws\DynamoDb\Input\DeleteItemInput;
@@ -517,7 +518,7 @@ class DynamoDbClient extends AbstractApi
                 ];
         }
 
-        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "DynamoDb".', $region));
+        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "DynamoDb".', $region));
     }
 
     protected function getServiceCode(): string

--- a/src/Service/EventBridge/src/EventBridgeClient.php
+++ b/src/Service/EventBridge/src/EventBridgeClient.php
@@ -27,6 +27,124 @@ class EventBridgeClient extends AbstractApi
         return new PutEventsResponse($response);
     }
 
+    protected function getEndpointMetadata(string $region): array
+    {
+        switch ($region) {
+            case 'af-south-1':
+            case 'ap-east-1':
+            case 'ap-northeast-1':
+            case 'ap-northeast-2':
+            case 'ap-south-1':
+            case 'ap-southeast-1':
+            case 'ap-southeast-2':
+            case 'ca-central-1':
+            case 'eu-central-1':
+            case 'eu-north-1':
+            case 'eu-south-1':
+            case 'eu-west-1':
+            case 'eu-west-2':
+            case 'eu-west-3':
+            case 'me-south-1':
+            case 'sa-east-1':
+            case 'us-east-1':
+            case 'us-east-2':
+            case 'us-west-1':
+            case 'us-west-2':
+                return [
+                    'endpoint' => 'https://events.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'events',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'cn-north-1':
+            case 'cn-northwest-1':
+                return [
+                    'endpoint' => 'https://events.%region%.amazonaws.com.cn',
+                    'signRegion' => $region,
+                    'signService' => 'events',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-iso-east-1':
+                return [
+                    'endpoint' => 'https://events.%region%.c2s.ic.gov',
+                    'signRegion' => $region,
+                    'signService' => 'events',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-isob-east-1':
+                return [
+                    'endpoint' => 'https://events.%region%.sc2s.sgov.gov',
+                    'signRegion' => $region,
+                    'signService' => 'events',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-east-1':
+                return [
+                    'endpoint' => 'https://events-fips.us-east-1.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 'events',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-east-2':
+                return [
+                    'endpoint' => 'https://events-fips.us-east-2.amazonaws.com',
+                    'signRegion' => 'us-east-2',
+                    'signService' => 'events',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-west-1':
+                return [
+                    'endpoint' => 'https://events-fips.us-west-1.amazonaws.com',
+                    'signRegion' => 'us-west-1',
+                    'signService' => 'events',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-west-2':
+                return [
+                    'endpoint' => 'https://events-fips.us-west-2.amazonaws.com',
+                    'signRegion' => 'us-west-2',
+                    'signService' => 'events',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-east-1':
+                return [
+                    'endpoint' => 'https://events.us-gov-east-1.amazonaws.com',
+                    'signRegion' => 'us-gov-east-1',
+                    'signService' => 'events',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-west-1':
+                return [
+                    'endpoint' => 'https://events.us-gov-west-1.amazonaws.com',
+                    'signRegion' => 'us-gov-west-1',
+                    'signService' => 'events',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+        }
+
+        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "EventBridge".', $region));
+    }
+
     protected function getServiceCode(): string
     {
         return 'events';

--- a/src/Service/EventBridge/src/EventBridgeClient.php
+++ b/src/Service/EventBridge/src/EventBridgeClient.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\EventBridge;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Configuration;
 use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\EventBridge\Input\PutEventsRequest;
@@ -28,8 +29,11 @@ class EventBridgeClient extends AbstractApi
         return new PutEventsResponse($response);
     }
 
-    protected function getEndpointMetadata(string $region): array
+    protected function getEndpointMetadata(?string $region): array
     {
+        if (null === $region) {
+            $region = Configuration::DEFAULT_REGION;
+        }
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/EventBridge/src/EventBridgeClient.php
+++ b/src/Service/EventBridge/src/EventBridgeClient.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\EventBridge;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\EventBridge\Input\PutEventsRequest;
 use AsyncAws\EventBridge\Result\PutEventsResponse;
@@ -142,7 +143,7 @@ class EventBridgeClient extends AbstractApi
                 ];
         }
 
-        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "EventBridge".', $region));
+        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "EventBridge".', $region));
     }
 
     protected function getServiceCode(): string

--- a/src/Service/EventBridge/src/EventBridgeClient.php
+++ b/src/Service/EventBridge/src/EventBridgeClient.php
@@ -34,6 +34,7 @@ class EventBridgeClient extends AbstractApi
         if (null === $region) {
             $region = Configuration::DEFAULT_REGION;
         }
+
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/Iam/src/IamClient.php
+++ b/src/Service/Iam/src/IamClient.php
@@ -132,34 +132,6 @@ class IamClient extends AbstractApi
                         0 => 'v4',
                     ],
                 ];
-            case 'af-south-1':
-            case 'ap-east-1':
-            case 'ap-northeast-1':
-            case 'ap-northeast-2':
-            case 'ap-south-1':
-            case 'ap-southeast-1':
-            case 'ap-southeast-2':
-            case 'ca-central-1':
-            case 'eu-central-1':
-            case 'eu-north-1':
-            case 'eu-south-1':
-            case 'eu-west-1':
-            case 'eu-west-2':
-            case 'eu-west-3':
-            case 'me-south-1':
-            case 'sa-east-1':
-            case 'us-east-1':
-            case 'us-east-2':
-            case 'us-west-1':
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://iam.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'iam',
-                    'signVersions' => [
-                        0 => 'v4',
-                    ],
-                ];
             case 'cn-north-1':
             case 'cn-northwest-1':
                 return [

--- a/src/Service/Iam/src/IamClient.php
+++ b/src/Service/Iam/src/IamClient.php
@@ -120,9 +120,94 @@ class IamClient extends AbstractApi
         return new Result($response);
     }
 
-    protected function getEndpointPattern(?string $region): string
+    protected function getEndpointMetadata(string $region): array
     {
-        return $region ? parent::getEndpointPattern($region) : 'https://iam.amazonaws.com';
+        switch ($region) {
+            case 'iam-fips':
+                return [
+                    'endpoint' => 'https://iam-fips.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 'iam',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'af-south-1':
+            case 'ap-east-1':
+            case 'ap-northeast-1':
+            case 'ap-northeast-2':
+            case 'ap-south-1':
+            case 'ap-southeast-1':
+            case 'ap-southeast-2':
+            case 'ca-central-1':
+            case 'eu-central-1':
+            case 'eu-north-1':
+            case 'eu-south-1':
+            case 'eu-west-1':
+            case 'eu-west-2':
+            case 'eu-west-3':
+            case 'me-south-1':
+            case 'sa-east-1':
+            case 'us-east-1':
+            case 'us-east-2':
+            case 'us-west-1':
+            case 'us-west-2':
+                return [
+                    'endpoint' => 'https://iam.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 'iam',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'cn-north-1':
+            case 'cn-northwest-1':
+                return [
+                    'endpoint' => 'https://iam.cn-north-1.amazonaws.com.cn',
+                    'signRegion' => 'cn-north-1',
+                    'signService' => 'iam',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-east-1':
+            case 'us-gov-west-1':
+                return [
+                    'endpoint' => 'https://iam.us-gov.amazonaws.com',
+                    'signRegion' => 'us-gov-west-1',
+                    'signService' => 'iam',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-iso-east-1':
+                return [
+                    'endpoint' => 'https://iam.us-iso-east-1.c2s.ic.gov',
+                    'signRegion' => 'us-iso-east-1',
+                    'signService' => 'iam',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-isob-east-1':
+                return [
+                    'endpoint' => 'https://iam.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
+                    'signService' => 'iam',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+        }
+
+        return [
+            'endpoint' => 'https://iam.amazonaws.com',
+            'signRegion' => 'us-east-1',
+            'signService' => 'iam',
+            'signVersions' => [
+                0 => 'v4',
+            ],
+        ];
     }
 
     protected function getServiceCode(): string

--- a/src/Service/Iam/src/IamClient.php
+++ b/src/Service/Iam/src/IamClient.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\Iam;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
 use AsyncAws\Iam\Input\CreateUserRequest;
@@ -123,9 +124,29 @@ class IamClient extends AbstractApi
     protected function getEndpointMetadata(?string $region): array
     {
         switch ($region) {
-            case 'iam-fips':
+            case null:
+            case 'af-south-1':
+            case 'ap-east-1':
+            case 'ap-northeast-1':
+            case 'ap-northeast-2':
+            case 'ap-south-1':
+            case 'ap-southeast-1':
+            case 'ap-southeast-2':
+            case 'ca-central-1':
+            case 'eu-central-1':
+            case 'eu-north-1':
+            case 'eu-south-1':
+            case 'eu-west-1':
+            case 'eu-west-2':
+            case 'eu-west-3':
+            case 'me-south-1':
+            case 'sa-east-1':
+            case 'us-east-1':
+            case 'us-east-2':
+            case 'us-west-1':
+            case 'us-west-2':
                 return [
-                    'endpoint' => 'https://iam-fips.amazonaws.com',
+                    'endpoint' => 'https://iam.amazonaws.com',
                     'signRegion' => 'us-east-1',
                     'signService' => 'iam',
                     'signVersions' => [
@@ -170,16 +191,18 @@ class IamClient extends AbstractApi
                         0 => 'v4',
                     ],
                 ];
+            case 'iam-fips':
+                return [
+                    'endpoint' => 'https://iam-fips.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 'iam',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
         }
 
-        return [
-            'endpoint' => 'https://iam.amazonaws.com',
-            'signRegion' => 'us-east-1',
-            'signService' => 'iam',
-            'signVersions' => [
-                0 => 'v4',
-            ],
-        ];
+        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "Iam".', $region));
     }
 
     protected function getServiceCode(): string

--- a/src/Service/Iam/src/IamClient.php
+++ b/src/Service/Iam/src/IamClient.php
@@ -123,8 +123,17 @@ class IamClient extends AbstractApi
 
     protected function getEndpointMetadata(?string $region): array
     {
+        if (null === $region) {
+            return [
+                'endpoint' => 'https://iam.amazonaws.com',
+                'signRegion' => 'us-east-1',
+                'signService' => 'iam',
+                'signVersions' => [
+                    0 => 'v4',
+                ],
+            ];
+        }
         switch ($region) {
-            case null:
             case 'af-south-1':
             case 'ap-east-1':
             case 'ap-northeast-1':

--- a/src/Service/Iam/src/IamClient.php
+++ b/src/Service/Iam/src/IamClient.php
@@ -133,6 +133,7 @@ class IamClient extends AbstractApi
                 ],
             ];
         }
+
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/Iam/src/IamClient.php
+++ b/src/Service/Iam/src/IamClient.php
@@ -120,7 +120,7 @@ class IamClient extends AbstractApi
         return new Result($response);
     }
 
-    protected function getEndpointMetadata(string $region): array
+    protected function getEndpointMetadata(?string $region): array
     {
         switch ($region) {
             case 'iam-fips':

--- a/src/Service/Lambda/src/LambdaClient.php
+++ b/src/Service/Lambda/src/LambdaClient.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\Lambda;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Lambda\Input\AddLayerVersionPermissionRequest;
 use AsyncAws\Lambda\Input\InvocationRequest;
@@ -233,7 +234,7 @@ class LambdaClient extends AbstractApi
                 ];
         }
 
-        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "Lambda".', $region));
+        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "Lambda".', $region));
     }
 
     protected function getServiceCode(): string

--- a/src/Service/Lambda/src/LambdaClient.php
+++ b/src/Service/Lambda/src/LambdaClient.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\Lambda;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Configuration;
 use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Lambda\Input\AddLayerVersionPermissionRequest;
@@ -118,8 +119,11 @@ class LambdaClient extends AbstractApi
         return new PublishLayerVersionResponse($response);
     }
 
-    protected function getEndpointMetadata(string $region): array
+    protected function getEndpointMetadata(?string $region): array
     {
+        if (null === $region) {
+            $region = Configuration::DEFAULT_REGION;
+        }
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/Lambda/src/LambdaClient.php
+++ b/src/Service/Lambda/src/LambdaClient.php
@@ -124,6 +124,7 @@ class LambdaClient extends AbstractApi
         if (null === $region) {
             $region = Configuration::DEFAULT_REGION;
         }
+
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/Lambda/src/LambdaClient.php
+++ b/src/Service/Lambda/src/LambdaClient.php
@@ -117,6 +117,125 @@ class LambdaClient extends AbstractApi
         return new PublishLayerVersionResponse($response);
     }
 
+    protected function getEndpointMetadata(string $region): array
+    {
+        switch ($region) {
+            case 'af-south-1':
+            case 'ap-east-1':
+            case 'ap-northeast-1':
+            case 'ap-northeast-2':
+            case 'ap-south-1':
+            case 'ap-southeast-1':
+            case 'ap-southeast-2':
+            case 'ca-central-1':
+            case 'eu-central-1':
+            case 'eu-north-1':
+            case 'eu-south-1':
+            case 'eu-west-1':
+            case 'eu-west-2':
+            case 'eu-west-3':
+            case 'me-south-1':
+            case 'sa-east-1':
+            case 'us-east-1':
+            case 'us-east-2':
+            case 'us-west-1':
+            case 'us-west-2':
+                return [
+                    'endpoint' => 'https://lambda.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'lambda',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'cn-north-1':
+            case 'cn-northwest-1':
+                return [
+                    'endpoint' => 'https://lambda.%region%.amazonaws.com.cn',
+                    'signRegion' => $region,
+                    'signService' => 'lambda',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-east-1':
+            case 'us-gov-west-1':
+                return [
+                    'endpoint' => 'https://lambda.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'lambda',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-iso-east-1':
+                return [
+                    'endpoint' => 'https://lambda.%region%.c2s.ic.gov',
+                    'signRegion' => $region,
+                    'signService' => 'lambda',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-east-1':
+                return [
+                    'endpoint' => 'https://lambda-fips.us-east-1.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 'lambda',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-east-2':
+                return [
+                    'endpoint' => 'https://lambda-fips.us-east-2.amazonaws.com',
+                    'signRegion' => 'us-east-2',
+                    'signService' => 'lambda',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-gov-east-1':
+                return [
+                    'endpoint' => 'https://lambda-fips.us-gov-east-1.amazonaws.com',
+                    'signRegion' => 'us-gov-east-1',
+                    'signService' => 'lambda',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-gov-west-1':
+                return [
+                    'endpoint' => 'https://lambda-fips.us-gov-west-1.amazonaws.com',
+                    'signRegion' => 'us-gov-west-1',
+                    'signService' => 'lambda',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-west-1':
+                return [
+                    'endpoint' => 'https://lambda-fips.us-west-1.amazonaws.com',
+                    'signRegion' => 'us-west-1',
+                    'signService' => 'lambda',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-west-2':
+                return [
+                    'endpoint' => 'https://lambda-fips.us-west-2.amazonaws.com',
+                    'signRegion' => 'us-west-2',
+                    'signService' => 'lambda',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+        }
+
+        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "Lambda".', $region));
+    }
+
     protected function getServiceCode(): string
     {
         return 'lambda';

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -651,7 +651,7 @@ class S3Client extends AbstractApi
         return new UploadPartOutput($response);
     }
 
-    protected function getEndpointMetadata(string $region): array
+    protected function getEndpointMetadata(?string $region): array
     {
         switch ($region) {
             case 'af-south-1':

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -651,9 +651,188 @@ class S3Client extends AbstractApi
         return new UploadPartOutput($response);
     }
 
-    protected function getEndpointPattern(?string $region): string
+    protected function getEndpointMetadata(string $region): array
     {
-        return $region ? parent::getEndpointPattern($region) : 'https://s3.amazonaws.com';
+        switch ($region) {
+            case 'af-south-1':
+            case 'ap-east-1':
+            case 'ap-northeast-2':
+            case 'ap-south-1':
+            case 'ca-central-1':
+            case 'eu-central-1':
+            case 'eu-north-1':
+            case 'eu-south-1':
+            case 'eu-west-2':
+            case 'eu-west-3':
+            case 'me-south-1':
+            case 'us-east-2':
+                return [
+                    'endpoint' => 'https://s3.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 's3',
+                    'signVersions' => [
+                        0 => 's3v4',
+                    ],
+                ];
+            case 'cn-north-1':
+            case 'cn-northwest-1':
+                return [
+                    'endpoint' => 'https://s3.%region%.amazonaws.com.cn',
+                    'signRegion' => $region,
+                    'signService' => 's3',
+                    'signVersions' => [
+                        0 => 's3v4',
+                    ],
+                ];
+            case 'us-isob-east-1':
+                return [
+                    'endpoint' => 'https://s3.%region%.sc2s.sgov.gov',
+                    'signRegion' => $region,
+                    'signService' => 's3',
+                    'signVersions' => [
+                        0 => 's3v4',
+                    ],
+                ];
+            case 'ap-northeast-1':
+                return [
+                    'endpoint' => 'https://s3.ap-northeast-1.amazonaws.com',
+                    'signRegion' => 'ap-northeast-1',
+                    'signService' => 's3',
+                    'signVersions' => [
+                        0 => 's3',
+                        1 => 's3v4',
+                    ],
+                ];
+            case 'ap-southeast-1':
+                return [
+                    'endpoint' => 'https://s3.ap-southeast-1.amazonaws.com',
+                    'signRegion' => 'ap-southeast-1',
+                    'signService' => 's3',
+                    'signVersions' => [
+                        0 => 's3',
+                        1 => 's3v4',
+                    ],
+                ];
+            case 'ap-southeast-2':
+                return [
+                    'endpoint' => 'https://s3.ap-southeast-2.amazonaws.com',
+                    'signRegion' => 'ap-southeast-2',
+                    'signService' => 's3',
+                    'signVersions' => [
+                        0 => 's3',
+                        1 => 's3v4',
+                    ],
+                ];
+            case 'eu-west-1':
+                return [
+                    'endpoint' => 'https://s3.eu-west-1.amazonaws.com',
+                    'signRegion' => 'eu-west-1',
+                    'signService' => 's3',
+                    'signVersions' => [
+                        0 => 's3',
+                        1 => 's3v4',
+                    ],
+                ];
+            case 'fips-us-gov-west-1':
+                return [
+                    'endpoint' => 'https://s3-fips-us-gov-west-1.amazonaws.com',
+                    'signRegion' => 'us-gov-west-1',
+                    'signService' => 's3',
+                    'signVersions' => [
+                        0 => 's3',
+                        1 => 's3v4',
+                    ],
+                ];
+            case 's3-external-1':
+                return [
+                    'endpoint' => 'https://s3-external-1.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 's3',
+                    'signVersions' => [
+                        0 => 's3',
+                        1 => 's3v4',
+                    ],
+                ];
+            case 'sa-east-1':
+                return [
+                    'endpoint' => 'https://s3.sa-east-1.amazonaws.com',
+                    'signRegion' => 'sa-east-1',
+                    'signService' => 's3',
+                    'signVersions' => [
+                        0 => 's3',
+                        1 => 's3v4',
+                    ],
+                ];
+            case 'us-east-1':
+                return [
+                    'endpoint' => 'https://s3.us-east-1.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 's3',
+                    'signVersions' => [
+                        0 => 's3',
+                        1 => 's3v4',
+                    ],
+                ];
+            case 'us-gov-east-1':
+                return [
+                    'endpoint' => 'https://s3.us-gov-east-1.amazonaws.com',
+                    'signRegion' => 'us-gov-east-1',
+                    'signService' => 's3',
+                    'signVersions' => [
+                        0 => 's3',
+                        1 => 's3v4',
+                    ],
+                ];
+            case 'us-gov-west-1':
+                return [
+                    'endpoint' => 'https://s3.us-gov-west-1.amazonaws.com',
+                    'signRegion' => 'us-gov-west-1',
+                    'signService' => 's3',
+                    'signVersions' => [
+                        0 => 's3',
+                        1 => 's3v4',
+                    ],
+                ];
+            case 'us-iso-east-1':
+                return [
+                    'endpoint' => 'https://s3.us-iso-east-1.c2s.ic.gov',
+                    'signRegion' => 'us-iso-east-1',
+                    'signService' => 's3',
+                    'signVersions' => [
+                        0 => 's3v4',
+                    ],
+                ];
+            case 'us-west-1':
+                return [
+                    'endpoint' => 'https://s3.us-west-1.amazonaws.com',
+                    'signRegion' => 'us-west-1',
+                    'signService' => 's3',
+                    'signVersions' => [
+                        0 => 's3',
+                        1 => 's3v4',
+                    ],
+                ];
+            case 'us-west-2':
+                return [
+                    'endpoint' => 'https://s3.us-west-2.amazonaws.com',
+                    'signRegion' => 'us-west-2',
+                    'signService' => 's3',
+                    'signVersions' => [
+                        0 => 's3',
+                        1 => 's3v4',
+                    ],
+                ];
+        }
+
+        return [
+            'endpoint' => 'https://s3.amazonaws.com',
+            'signRegion' => 'us-east-1',
+            'signService' => 's3',
+            'signVersions' => [
+                0 => 's3',
+                1 => 's3v4',
+            ],
+        ];
     }
 
     protected function getServiceCode(): string

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -665,6 +665,7 @@ class S3Client extends AbstractApi
                 ],
             ];
         }
+
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\S3;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\S3\Input\AbortMultipartUploadRequest;
 use AsyncAws\S3\Input\CompleteMultipartUploadRequest;
@@ -654,6 +655,16 @@ class S3Client extends AbstractApi
     protected function getEndpointMetadata(?string $region): array
     {
         switch ($region) {
+            case null:
+                return [
+                    'endpoint' => 'https://s3.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 's3',
+                    'signVersions' => [
+                        0 => 's3',
+                        1 => 's3v4',
+                    ],
+                ];
             case 'af-south-1':
             case 'ap-east-1':
             case 'ap-northeast-2':
@@ -824,15 +835,7 @@ class S3Client extends AbstractApi
                 ];
         }
 
-        return [
-            'endpoint' => 'https://s3.amazonaws.com',
-            'signRegion' => 'us-east-1',
-            'signService' => 's3',
-            'signVersions' => [
-                0 => 's3',
-                1 => 's3v4',
-            ],
-        ];
+        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "S3".', $region));
     }
 
     protected function getServiceCode(): string

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -654,17 +654,18 @@ class S3Client extends AbstractApi
 
     protected function getEndpointMetadata(?string $region): array
     {
+        if (null === $region) {
+            return [
+                'endpoint' => 'https://s3.amazonaws.com',
+                'signRegion' => 'us-east-1',
+                'signService' => 's3',
+                'signVersions' => [
+                    0 => 's3v4',
+                    1 => 's3',
+                ],
+            ];
+        }
         switch ($region) {
-            case null:
-                return [
-                    'endpoint' => 'https://s3.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 's3',
-                    'signVersions' => [
-                        0 => 's3v4',
-                        1 => 's3',
-                    ],
-                ];
             case 'af-south-1':
             case 'ap-east-1':
             case 'ap-northeast-2':

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -661,8 +661,8 @@ class S3Client extends AbstractApi
                     'signRegion' => 'us-east-1',
                     'signService' => 's3',
                     'signVersions' => [
-                        0 => 's3',
-                        1 => 's3v4',
+                        0 => 's3v4',
+                        1 => 's3',
                     ],
                 ];
             case 'af-south-1':
@@ -710,8 +710,8 @@ class S3Client extends AbstractApi
                     'signRegion' => 'ap-northeast-1',
                     'signService' => 's3',
                     'signVersions' => [
-                        0 => 's3',
-                        1 => 's3v4',
+                        0 => 's3v4',
+                        1 => 's3',
                     ],
                 ];
             case 'ap-southeast-1':
@@ -720,8 +720,8 @@ class S3Client extends AbstractApi
                     'signRegion' => 'ap-southeast-1',
                     'signService' => 's3',
                     'signVersions' => [
-                        0 => 's3',
-                        1 => 's3v4',
+                        0 => 's3v4',
+                        1 => 's3',
                     ],
                 ];
             case 'ap-southeast-2':
@@ -730,8 +730,8 @@ class S3Client extends AbstractApi
                     'signRegion' => 'ap-southeast-2',
                     'signService' => 's3',
                     'signVersions' => [
-                        0 => 's3',
-                        1 => 's3v4',
+                        0 => 's3v4',
+                        1 => 's3',
                     ],
                 ];
             case 'eu-west-1':
@@ -740,8 +740,8 @@ class S3Client extends AbstractApi
                     'signRegion' => 'eu-west-1',
                     'signService' => 's3',
                     'signVersions' => [
-                        0 => 's3',
-                        1 => 's3v4',
+                        0 => 's3v4',
+                        1 => 's3',
                     ],
                 ];
             case 'fips-us-gov-west-1':
@@ -750,8 +750,8 @@ class S3Client extends AbstractApi
                     'signRegion' => 'us-gov-west-1',
                     'signService' => 's3',
                     'signVersions' => [
-                        0 => 's3',
-                        1 => 's3v4',
+                        0 => 's3v4',
+                        1 => 's3',
                     ],
                 ];
             case 's3-external-1':
@@ -760,8 +760,8 @@ class S3Client extends AbstractApi
                     'signRegion' => 'us-east-1',
                     'signService' => 's3',
                     'signVersions' => [
-                        0 => 's3',
-                        1 => 's3v4',
+                        0 => 's3v4',
+                        1 => 's3',
                     ],
                 ];
             case 'sa-east-1':
@@ -770,8 +770,8 @@ class S3Client extends AbstractApi
                     'signRegion' => 'sa-east-1',
                     'signService' => 's3',
                     'signVersions' => [
-                        0 => 's3',
-                        1 => 's3v4',
+                        0 => 's3v4',
+                        1 => 's3',
                     ],
                 ];
             case 'us-east-1':
@@ -780,8 +780,8 @@ class S3Client extends AbstractApi
                     'signRegion' => 'us-east-1',
                     'signService' => 's3',
                     'signVersions' => [
-                        0 => 's3',
-                        1 => 's3v4',
+                        0 => 's3v4',
+                        1 => 's3',
                     ],
                 ];
             case 'us-gov-east-1':
@@ -790,8 +790,8 @@ class S3Client extends AbstractApi
                     'signRegion' => 'us-gov-east-1',
                     'signService' => 's3',
                     'signVersions' => [
-                        0 => 's3',
-                        1 => 's3v4',
+                        0 => 's3v4',
+                        1 => 's3',
                     ],
                 ];
             case 'us-gov-west-1':
@@ -800,8 +800,8 @@ class S3Client extends AbstractApi
                     'signRegion' => 'us-gov-west-1',
                     'signService' => 's3',
                     'signVersions' => [
-                        0 => 's3',
-                        1 => 's3v4',
+                        0 => 's3v4',
+                        1 => 's3',
                     ],
                 ];
             case 'us-iso-east-1':
@@ -819,8 +819,8 @@ class S3Client extends AbstractApi
                     'signRegion' => 'us-west-1',
                     'signService' => 's3',
                     'signVersions' => [
-                        0 => 's3',
-                        1 => 's3v4',
+                        0 => 's3v4',
+                        1 => 's3',
                     ],
                 ];
             case 'us-west-2':
@@ -829,8 +829,8 @@ class S3Client extends AbstractApi
                     'signRegion' => 'us-west-2',
                     'signService' => 's3',
                     'signVersions' => [
-                        0 => 's3',
-                        1 => 's3v4',
+                        0 => 's3v4',
+                        1 => 's3',
                     ],
                 ];
         }
@@ -860,6 +860,9 @@ class S3Client extends AbstractApi
     {
         return [
             's3' => static function (string $service, string $region) {
+                return new SignerV4ForS3($service, $region);
+            },
+            's3v4' => static function (string $service, string $region) {
                 return new SignerV4ForS3($service, $region);
             },
         ] + parent::getSignerFactories();

--- a/src/Service/Ses/src/SesClient.php
+++ b/src/Service/Ses/src/SesClient.php
@@ -33,6 +33,46 @@ class SesClient extends AbstractApi
         return new SendEmailResponse($response);
     }
 
+    protected function getEndpointMetadata(string $region): array
+    {
+        switch ($region) {
+            case 'ap-south-1':
+            case 'ap-southeast-2':
+            case 'eu-central-1':
+            case 'eu-west-1':
+            case 'us-east-1':
+            case 'us-west-2':
+                return [
+                    'endpoint' => 'https://email.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'email',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-west-1':
+                return [
+                    'endpoint' => 'https://email.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'email',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-gov-west-1':
+                return [
+                    'endpoint' => 'https://email-fips.us-gov-west-1.amazonaws.com',
+                    'signRegion' => 'us-gov-west-1',
+                    'signService' => 'email',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+        }
+
+        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "Ses".', $region));
+    }
+
     protected function getServiceCode(): string
     {
         return 'email';

--- a/src/Service/Ses/src/SesClient.php
+++ b/src/Service/Ses/src/SesClient.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\Ses;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Ses\Input\SendEmailRequest;
 use AsyncAws\Ses\Result\SendEmailResponse;
@@ -70,7 +71,7 @@ class SesClient extends AbstractApi
                 ];
         }
 
-        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "Ses".', $region));
+        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "Ses".', $region));
     }
 
     protected function getServiceCode(): string

--- a/src/Service/Ses/src/SesClient.php
+++ b/src/Service/Ses/src/SesClient.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\Ses;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Configuration;
 use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Ses\Input\SendEmailRequest;
@@ -34,8 +35,11 @@ class SesClient extends AbstractApi
         return new SendEmailResponse($response);
     }
 
-    protected function getEndpointMetadata(string $region): array
+    protected function getEndpointMetadata(?string $region): array
     {
+        if (null === $region) {
+            $region = Configuration::DEFAULT_REGION;
+        }
         switch ($region) {
             case 'ap-south-1':
             case 'ap-southeast-2':

--- a/src/Service/Ses/src/SesClient.php
+++ b/src/Service/Ses/src/SesClient.php
@@ -40,6 +40,7 @@ class SesClient extends AbstractApi
         if (null === $region) {
             $region = Configuration::DEFAULT_REGION;
         }
+
         switch ($region) {
             case 'ap-south-1':
             case 'ap-southeast-2':

--- a/src/Service/Sns/src/SnsClient.php
+++ b/src/Service/Sns/src/SnsClient.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\Sns;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
 use AsyncAws\Sns\Input\CreateTopicInput;
@@ -269,7 +270,7 @@ class SnsClient extends AbstractApi
                 ];
         }
 
-        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "Sns".', $region));
+        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "Sns".', $region));
     }
 
     protected function getServiceCode(): string

--- a/src/Service/Sns/src/SnsClient.php
+++ b/src/Service/Sns/src/SnsClient.php
@@ -154,6 +154,124 @@ class SnsClient extends AbstractApi
         return new Result($response);
     }
 
+    protected function getEndpointMetadata(string $region): array
+    {
+        switch ($region) {
+            case 'af-south-1':
+            case 'ap-east-1':
+            case 'ap-northeast-1':
+            case 'ap-northeast-2':
+            case 'ap-south-1':
+            case 'ap-southeast-1':
+            case 'ap-southeast-2':
+            case 'ca-central-1':
+            case 'eu-central-1':
+            case 'eu-north-1':
+            case 'eu-south-1':
+            case 'eu-west-1':
+            case 'eu-west-2':
+            case 'eu-west-3':
+            case 'me-south-1':
+            case 'sa-east-1':
+            case 'us-east-1':
+            case 'us-east-2':
+            case 'us-west-1':
+            case 'us-west-2':
+                return [
+                    'endpoint' => 'https://sns.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'sns',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'cn-north-1':
+            case 'cn-northwest-1':
+                return [
+                    'endpoint' => 'https://sns.%region%.amazonaws.com.cn',
+                    'signRegion' => $region,
+                    'signService' => 'sns',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-east-1':
+                return [
+                    'endpoint' => 'https://sns.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'sns',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-isob-east-1':
+                return [
+                    'endpoint' => 'https://sns.%region%.sc2s.sgov.gov',
+                    'signRegion' => $region,
+                    'signService' => 'sns',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-east-1':
+                return [
+                    'endpoint' => 'https://sns-fips.us-east-1.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 'sns',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-east-2':
+                return [
+                    'endpoint' => 'https://sns-fips.us-east-2.amazonaws.com',
+                    'signRegion' => 'us-east-2',
+                    'signService' => 'sns',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-west-1':
+                return [
+                    'endpoint' => 'https://sns-fips.us-west-1.amazonaws.com',
+                    'signRegion' => 'us-west-1',
+                    'signService' => 'sns',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-west-2':
+                return [
+                    'endpoint' => 'https://sns-fips.us-west-2.amazonaws.com',
+                    'signRegion' => 'us-west-2',
+                    'signService' => 'sns',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-west-1':
+                return [
+                    'endpoint' => 'https://sns.us-gov-west-1.amazonaws.com',
+                    'signRegion' => 'us-gov-west-1',
+                    'signService' => 'sns',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-iso-east-1':
+                return [
+                    'endpoint' => 'https://sns.us-iso-east-1.c2s.ic.gov',
+                    'signRegion' => 'us-iso-east-1',
+                    'signService' => 'sns',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+        }
+
+        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "Sns".', $region));
+    }
+
     protected function getServiceCode(): string
     {
         return 'sns';

--- a/src/Service/Sns/src/SnsClient.php
+++ b/src/Service/Sns/src/SnsClient.php
@@ -161,6 +161,7 @@ class SnsClient extends AbstractApi
         if (null === $region) {
             $region = Configuration::DEFAULT_REGION;
         }
+
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/Sns/src/SnsClient.php
+++ b/src/Service/Sns/src/SnsClient.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\Sns;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Configuration;
 use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
@@ -155,8 +156,11 @@ class SnsClient extends AbstractApi
         return new Result($response);
     }
 
-    protected function getEndpointMetadata(string $region): array
+    protected function getEndpointMetadata(?string $region): array
     {
+        if (null === $region) {
+            $region = Configuration::DEFAULT_REGION;
+        }
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/Sqs/src/SqsClient.php
+++ b/src/Service/Sqs/src/SqsClient.php
@@ -257,6 +257,132 @@ class SqsClient extends AbstractApi
         return new SendMessageResult($response);
     }
 
+    protected function getEndpointMetadata(string $region): array
+    {
+        switch ($region) {
+            case 'af-south-1':
+            case 'ap-east-1':
+            case 'ap-northeast-1':
+            case 'ap-northeast-2':
+            case 'ap-south-1':
+            case 'ap-southeast-1':
+            case 'ap-southeast-2':
+            case 'ca-central-1':
+            case 'eu-central-1':
+            case 'eu-north-1':
+            case 'eu-south-1':
+            case 'eu-west-1':
+            case 'eu-west-2':
+            case 'eu-west-3':
+            case 'me-south-1':
+            case 'sa-east-1':
+            case 'us-east-2':
+            case 'us-west-1':
+            case 'us-west-2':
+                return [
+                    'endpoint' => 'https://sqs.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'sqs',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'cn-north-1':
+            case 'cn-northwest-1':
+                return [
+                    'endpoint' => 'https://sqs.%region%.amazonaws.com.cn',
+                    'signRegion' => $region,
+                    'signService' => 'sqs',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-east-1':
+                return [
+                    'endpoint' => 'https://sqs.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'sqs',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-isob-east-1':
+                return [
+                    'endpoint' => 'https://sqs.%region%.sc2s.sgov.gov',
+                    'signRegion' => $region,
+                    'signService' => 'sqs',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-east-1':
+                return [
+                    'endpoint' => 'https://sqs-fips.us-east-1.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 'sqs',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-east-2':
+                return [
+                    'endpoint' => 'https://sqs-fips.us-east-2.amazonaws.com',
+                    'signRegion' => 'us-east-2',
+                    'signService' => 'sqs',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-west-1':
+                return [
+                    'endpoint' => 'https://sqs-fips.us-west-1.amazonaws.com',
+                    'signRegion' => 'us-west-1',
+                    'signService' => 'sqs',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-west-2':
+                return [
+                    'endpoint' => 'https://sqs-fips.us-west-2.amazonaws.com',
+                    'signRegion' => 'us-west-2',
+                    'signService' => 'sqs',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-east-1':
+                return [
+                    'endpoint' => 'https://sqs.us-east-1.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 'sqs',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-west-1':
+                return [
+                    'endpoint' => 'https://sqs.us-gov-west-1.amazonaws.com',
+                    'signRegion' => 'us-gov-west-1',
+                    'signService' => 'sqs',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-iso-east-1':
+                return [
+                    'endpoint' => 'https://sqs.us-iso-east-1.c2s.ic.gov',
+                    'signRegion' => 'us-iso-east-1',
+                    'signService' => 'sqs',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+        }
+
+        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "Sqs".', $region));
+    }
+
     protected function getServiceCode(): string
     {
         return 'sqs';

--- a/src/Service/Sqs/src/SqsClient.php
+++ b/src/Service/Sqs/src/SqsClient.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\Sqs;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Configuration;
 use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
@@ -258,8 +259,11 @@ class SqsClient extends AbstractApi
         return new SendMessageResult($response);
     }
 
-    protected function getEndpointMetadata(string $region): array
+    protected function getEndpointMetadata(?string $region): array
     {
+        if (null === $region) {
+            $region = Configuration::DEFAULT_REGION;
+        }
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/Sqs/src/SqsClient.php
+++ b/src/Service/Sqs/src/SqsClient.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\Sqs;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
 use AsyncAws\Sqs\Input\ChangeMessageVisibilityRequest;
@@ -380,7 +381,7 @@ class SqsClient extends AbstractApi
                 ];
         }
 
-        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "Sqs".', $region));
+        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "Sqs".', $region));
     }
 
     protected function getServiceCode(): string

--- a/src/Service/Sqs/src/SqsClient.php
+++ b/src/Service/Sqs/src/SqsClient.php
@@ -264,6 +264,7 @@ class SqsClient extends AbstractApi
         if (null === $region) {
             $region = Configuration::DEFAULT_REGION;
         }
+
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/Ssm/src/SsmClient.php
+++ b/src/Service/Ssm/src/SsmClient.php
@@ -135,6 +135,7 @@ class SsmClient extends AbstractApi
         if (null === $region) {
             $region = Configuration::DEFAULT_REGION;
         }
+
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/Ssm/src/SsmClient.php
+++ b/src/Service/Ssm/src/SsmClient.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\Ssm;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Ssm\Input\DeleteParameterRequest;
 use AsyncAws\Ssm\Input\GetParameterRequest;
@@ -262,7 +263,7 @@ class SsmClient extends AbstractApi
                 ];
         }
 
-        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "Ssm".', $region));
+        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "Ssm".', $region));
     }
 
     protected function getServiceCode(): string

--- a/src/Service/Ssm/src/SsmClient.php
+++ b/src/Service/Ssm/src/SsmClient.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\Ssm;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\Configuration;
 use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Ssm\Input\DeleteParameterRequest;
@@ -129,8 +130,11 @@ class SsmClient extends AbstractApi
         return new PutParameterResult($response);
     }
 
-    protected function getEndpointMetadata(string $region): array
+    protected function getEndpointMetadata(?string $region): array
     {
+        if (null === $region) {
+            $region = Configuration::DEFAULT_REGION;
+        }
         switch ($region) {
             case 'af-south-1':
             case 'ap-east-1':

--- a/src/Service/Ssm/src/SsmClient.php
+++ b/src/Service/Ssm/src/SsmClient.php
@@ -128,6 +128,143 @@ class SsmClient extends AbstractApi
         return new PutParameterResult($response);
     }
 
+    protected function getEndpointMetadata(string $region): array
+    {
+        switch ($region) {
+            case 'af-south-1':
+            case 'ap-east-1':
+            case 'ap-northeast-1':
+            case 'ap-northeast-2':
+            case 'ap-south-1':
+            case 'ap-southeast-1':
+            case 'ap-southeast-2':
+            case 'ca-central-1':
+            case 'eu-central-1':
+            case 'eu-north-1':
+            case 'eu-south-1':
+            case 'eu-west-1':
+            case 'eu-west-2':
+            case 'eu-west-3':
+            case 'me-south-1':
+            case 'sa-east-1':
+            case 'us-east-1':
+            case 'us-east-2':
+            case 'us-west-1':
+            case 'us-west-2':
+                return [
+                    'endpoint' => 'https://ssm.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'ssm',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'cn-north-1':
+            case 'cn-northwest-1':
+                return [
+                    'endpoint' => 'https://ssm.%region%.amazonaws.com.cn',
+                    'signRegion' => $region,
+                    'signService' => 'ssm',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-gov-east-1':
+            case 'us-gov-west-1':
+                return [
+                    'endpoint' => 'https://ssm.%region%.amazonaws.com',
+                    'signRegion' => $region,
+                    'signService' => 'ssm',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'us-isob-east-1':
+                return [
+                    'endpoint' => 'https://ssm.%region%.sc2s.sgov.gov',
+                    'signRegion' => $region,
+                    'signService' => 'ssm',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-east-1':
+                return [
+                    'endpoint' => 'https://ssm-fips.us-east-1.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 'ssm',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-east-2':
+                return [
+                    'endpoint' => 'https://ssm-fips.us-east-2.amazonaws.com',
+                    'signRegion' => 'us-east-2',
+                    'signService' => 'ssm',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-west-1':
+                return [
+                    'endpoint' => 'https://ssm-fips.us-west-1.amazonaws.com',
+                    'signRegion' => 'us-west-1',
+                    'signService' => 'ssm',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'fips-us-west-2':
+                return [
+                    'endpoint' => 'https://ssm-fips.us-west-2.amazonaws.com',
+                    'signRegion' => 'us-west-2',
+                    'signService' => 'ssm',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'ssm-facade-fips-us-east-1':
+                return [
+                    'endpoint' => 'https://ssm-facade-fips.us-east-1.amazonaws.com',
+                    'signRegion' => 'us-east-1',
+                    'signService' => 'ssm',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'ssm-facade-fips-us-east-2':
+                return [
+                    'endpoint' => 'https://ssm-facade-fips.us-east-2.amazonaws.com',
+                    'signRegion' => 'us-east-2',
+                    'signService' => 'ssm',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'ssm-facade-fips-us-west-1':
+                return [
+                    'endpoint' => 'https://ssm-facade-fips.us-west-1.amazonaws.com',
+                    'signRegion' => 'us-west-1',
+                    'signService' => 'ssm',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+            case 'ssm-facade-fips-us-west-2':
+                return [
+                    'endpoint' => 'https://ssm-facade-fips.us-west-2.amazonaws.com',
+                    'signRegion' => 'us-west-2',
+                    'signService' => 'ssm',
+                    'signVersions' => [
+                        0 => 'v4',
+                    ],
+                ];
+        }
+
+        throw new \InvalidArgumentException(sprintf('The region "%s" is not supported by "Ssm".', $region));
+    }
+
     protected function getServiceCode(): string
     {
         return 'ssm';


### PR DESCRIPTION
The current implementation of IAM is ~wrong: AWS does not provide regional endpoint.
After digging in AWS SDK metadata, I found that all endpoint are listed in an endpoints.json file

And this file contains also advance metadata that are leveraged in this PR to:
- handle more region (-fips, -gov, -iso, -china)
- handle signature dedicated to region (S3 for eu-west-1)
- handle region not available for the given service
- fix the issue when configuring a region with a global client (ie. `new IamClient(['region' => 'eu-west-1'])`)

I think we should merge this PR before releasing a new version of Core, Iam or S3 (that use the removed `getEndpointPattern` method)