### PR TITLE
Fix code generation #606

### DIFF
--- a/src/CodeGenerator/src/Command/GenerateCommand.php
+++ b/src/CodeGenerator/src/Command/GenerateCommand.php
@@ -283,9 +283,14 @@ class GenerateCommand extends Command
 
     private function fixCs(ClassName $clientClass, SymfonyStyle $io): void
     {
-        $reflection = new \ReflectionClass($clientClass->getFqdn());
-        $srcPath = \dirname($reflection->getFileName());
-        $testPath = realpath($srcPath . '/../tests');
+        $srcPath = \dirname((new \ReflectionClass($clientClass->getFqdn()))->getFileName());
+        $testPath = \substr($srcPath, 0, \strrpos($srcPath, '/src/')) . '/tests';
+        if (!\is_dir($srcPath)) {
+            throw new \InvalidArgumentException(sprintf('The src dir "%s" does not exists', $srcPath));
+        }
+        if (!\is_dir($testPath)) {
+            throw new \InvalidArgumentException(sprintf('The test dir "%s" does not exists', $testPath));
+        }
 
         // assert this
         $baseDir = \dirname($this->manifestFile);


### PR DESCRIPTION
Issue were, the "test" directory of Sts, is not alongside Client's dir, leading to `realpath` returning false and PhpCsFixer fix everything. This were an issue, when Code Generator were re-writing code between PhpCsFix read then write the fixed code.

Timeline were:
- Sts generation finished => start run CS-Fixer for the entiere code base
- CloudFormation dump the operation "XXX"
- PhpCsFixer detect XXX changed and open the file to fix it
- CloudFormation detect XXX is paginated and adds iterator methods
- PhpCsFixer finish processing XXX and write the file (override what has been done by CloudFormation)