### PR TITLE
Allows special char in S3 Bucket and Key

### DIFF
--- a/src/CodeGenerator/src/Generator/InputGenerator.php
+++ b/src/CodeGenerator/src/Generator/InputGenerator.php
@@ -320,11 +320,11 @@ class InputGenerator
 
         $requestUri = null;
         $body['uri'] = $body['uri'] ?? '';
-        $uriStringCode = '"'.$operation->getHttpRequestUri().'"';
+        $uriStringCode = '"' . $operation->getHttpRequestUri() . '"';
         $uriStringCode = \preg_replace('/\{([^\}\+]+)\+\}/', '".str_replace(\'%2F\', \'/\', rawurlencode($uri[\'$1\']))."', $uriStringCode);
         $uriStringCode = \preg_replace('/\{([^\}]+)\}/', '".rawurlencode($uri[\'$1\'])."', $uriStringCode);
         $uriStringCode = \preg_replace('/(^""\.|\.""$|\.""\.)/', '', $uriStringCode);
-        $body['uri'] .= '$uriString = '.$uriStringCode.';';
+        $body['uri'] .= '$uriString = ' . $uriStringCode . ';';
 
         $method = \var_export($operation->getHttpMethod(), true);
 

--- a/src/CodeGenerator/src/Generator/InputGenerator.php
+++ b/src/CodeGenerator/src/Generator/InputGenerator.php
@@ -320,7 +320,11 @@ class InputGenerator
 
         $requestUri = null;
         $body['uri'] = $body['uri'] ?? '';
-        $body['uri'] .= '$uriString = "' . str_replace(['{', '+}', '}'], ['{$uri[\'', '}', '\']}'], $operation->getHttpRequestUri()) . '";';
+        $uriStringCode = '"'.$operation->getHttpRequestUri().'"';
+        $uriStringCode = \preg_replace('/\{([^\}\+]+)\+\}/', '".str_replace(\'%2F\', \'/\', rawurlencode($uri[\'$1\']))."', $uriStringCode);
+        $uriStringCode = \preg_replace('/\{([^\}]+)\}/', '".rawurlencode($uri[\'$1\'])."', $uriStringCode);
+        $uriStringCode = \preg_replace('/(^""\.|\.""$|\.""\.)/', '', $uriStringCode);
+        $body['uri'] .= '$uriString = '.$uriStringCode.';';
 
         $method = \var_export($operation->getHttpMethod(), true);
 

--- a/src/Core/src/Signer/SignerV4.php
+++ b/src/Core/src/Signer/SignerV4.php
@@ -327,7 +327,7 @@ class SignerV4 implements Signer
         return implode('&', $encodedQuery);
     }
 
-    private function buildCanonicalPath(Request $request): string
+    protected function buildCanonicalPath(Request $request): string
     {
         $doubleEncoded = rawurlencode(ltrim($request->getUri(), '/'));
 

--- a/src/Core/src/Signer/SignerV4.php
+++ b/src/Core/src/Signer/SignerV4.php
@@ -102,6 +102,13 @@ class SignerV4 implements Signer
         $request->setBody(StringStream::create($request->getBody()));
     }
 
+    protected function buildCanonicalPath(Request $request): string
+    {
+        $doubleEncoded = rawurlencode(ltrim($request->getUri(), '/'));
+
+        return '/' . str_replace('%2F', '/', $doubleEncoded);
+    }
+
     private function handleSignature(Request $request, Credentials $credentials, \DateTimeImmutable $now, \DateTimeImmutable $expires, bool $isPresign): void
     {
         $this->removePresign($request);
@@ -325,13 +332,6 @@ class SignerV4 implements Signer
         }
 
         return implode('&', $encodedQuery);
-    }
-
-    protected function buildCanonicalPath(Request $request): string
-    {
-        $doubleEncoded = rawurlencode(ltrim($request->getUri(), '/'));
-
-        return '/' . str_replace('%2F', '/', $doubleEncoded);
     }
 
     private function buildStringToSign(\DateTimeImmutable $now, string $credentialString, string $canonicalRequest): string

--- a/src/Service/Lambda/CHANGELOG.md
+++ b/src/Service/Lambda/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## NOT RELEASED
+
+### Fixed
+
+- Fixed issue when Layer, Function or Version contained a special char `#`
+
 ## 0.4.2
 
 ### Fixed

--- a/src/Service/Lambda/src/Input/AddLayerVersionPermissionRequest.php
+++ b/src/Service/Lambda/src/Input/AddLayerVersionPermissionRequest.php
@@ -157,7 +157,7 @@ final class AddLayerVersionPermissionRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "VersionNumber" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['VersionNumber'] = $v;
-        $uriString = "/2018-10-31/layers/{$uri['LayerName']}/versions/{$uri['VersionNumber']}/policy";
+        $uriString = '/2018-10-31/layers/' . rawurlencode($uri['LayerName']) . '/versions/' . rawurlencode($uri['VersionNumber']) . '/policy';
 
         // Prepare Body
         $bodyPayload = $this->requestBody();

--- a/src/Service/Lambda/src/Input/InvocationRequest.php
+++ b/src/Service/Lambda/src/Input/InvocationRequest.php
@@ -153,7 +153,7 @@ final class InvocationRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "FunctionName" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['FunctionName'] = $v;
-        $uriString = "/2015-03-31/functions/{$uri['FunctionName']}/invocations";
+        $uriString = '/2015-03-31/functions/' . rawurlencode($uri['FunctionName']) . '/invocations';
 
         // Prepare Body
         $body = $this->Payload ?? '';

--- a/src/Service/Lambda/src/Input/ListLayerVersionsRequest.php
+++ b/src/Service/Lambda/src/Input/ListLayerVersionsRequest.php
@@ -115,7 +115,7 @@ final class ListLayerVersionsRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "LayerName" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['LayerName'] = $v;
-        $uriString = "/2018-10-31/layers/{$uri['LayerName']}/versions";
+        $uriString = '/2018-10-31/layers/' . rawurlencode($uri['LayerName']) . '/versions';
 
         // Prepare Body
         $body = '';

--- a/src/Service/Lambda/src/Input/PublishLayerVersionRequest.php
+++ b/src/Service/Lambda/src/Input/PublishLayerVersionRequest.php
@@ -122,7 +122,7 @@ final class PublishLayerVersionRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "LayerName" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['LayerName'] = $v;
-        $uriString = "/2018-10-31/layers/{$uri['LayerName']}/versions";
+        $uriString = '/2018-10-31/layers/' . rawurlencode($uri['LayerName']) . '/versions';
 
         // Prepare Body
         $bodyPayload = $this->requestBody();

--- a/src/Service/S3/CHANGELOG.md
+++ b/src/Service/S3/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## NOT RELEASED
+
+### Fixed
+
+- Fixed issue when Bucket or Object's Key contained a special char `#`
+
 ## 1.1.0
 
 ### Added

--- a/src/Service/S3/src/Input/AbortMultipartUploadRequest.php
+++ b/src/Service/S3/src/Input/AbortMultipartUploadRequest.php
@@ -121,7 +121,7 @@ final class AbortMultipartUploadRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "Key" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Key'] = $v;
-        $uriString = "/{$uri['Bucket']}/{$uri['Key']}";
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '/' . str_replace('%2F', '/', rawurlencode($uri['Key']));
 
         // Prepare Body
         $body = '';

--- a/src/Service/S3/src/Input/CompleteMultipartUploadRequest.php
+++ b/src/Service/S3/src/Input/CompleteMultipartUploadRequest.php
@@ -136,7 +136,7 @@ final class CompleteMultipartUploadRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "Key" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Key'] = $v;
-        $uriString = "/{$uri['Bucket']}/{$uri['Key']}";
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '/' . str_replace('%2F', '/', rawurlencode($uri['Key']));
 
         // Prepare Body
 

--- a/src/Service/S3/src/Input/CopyObjectRequest.php
+++ b/src/Service/S3/src/Input/CopyObjectRequest.php
@@ -746,7 +746,7 @@ final class CopyObjectRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "Key" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Key'] = $v;
-        $uriString = "/{$uri['Bucket']}/{$uri['Key']}";
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '/' . str_replace('%2F', '/', rawurlencode($uri['Key']));
 
         // Prepare Body
         $body = '';

--- a/src/Service/S3/src/Input/CreateBucketRequest.php
+++ b/src/Service/S3/src/Input/CreateBucketRequest.php
@@ -200,7 +200,7 @@ final class CreateBucketRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "Bucket" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Bucket'] = $v;
-        $uriString = "/{$uri['Bucket']}";
+        $uriString = '/' . rawurlencode($uri['Bucket']);
 
         // Prepare Body
 

--- a/src/Service/S3/src/Input/CreateMultipartUploadRequest.php
+++ b/src/Service/S3/src/Input/CreateMultipartUploadRequest.php
@@ -555,7 +555,7 @@ final class CreateMultipartUploadRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "Key" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Key'] = $v;
-        $uriString = "/{$uri['Bucket']}/{$uri['Key']}?uploads";
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '/' . str_replace('%2F', '/', rawurlencode($uri['Key'])) . '?uploads';
 
         // Prepare Body
         $body = '';

--- a/src/Service/S3/src/Input/DeleteObjectRequest.php
+++ b/src/Service/S3/src/Input/DeleteObjectRequest.php
@@ -154,7 +154,7 @@ final class DeleteObjectRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "Key" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Key'] = $v;
-        $uriString = "/{$uri['Bucket']}/{$uri['Key']}";
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '/' . str_replace('%2F', '/', rawurlencode($uri['Key']));
 
         // Prepare Body
         $body = '';

--- a/src/Service/S3/src/Input/DeleteObjectsRequest.php
+++ b/src/Service/S3/src/Input/DeleteObjectsRequest.php
@@ -135,7 +135,7 @@ final class DeleteObjectsRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "Bucket" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Bucket'] = $v;
-        $uriString = "/{$uri['Bucket']}?delete";
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '?delete';
 
         // Prepare Body
 

--- a/src/Service/S3/src/Input/GetObjectAclRequest.php
+++ b/src/Service/S3/src/Input/GetObjectAclRequest.php
@@ -118,7 +118,7 @@ final class GetObjectAclRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "Key" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Key'] = $v;
-        $uriString = "/{$uri['Bucket']}/{$uri['Key']}?acl";
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '/' . str_replace('%2F', '/', rawurlencode($uri['Key'])) . '?acl';
 
         // Prepare Body
         $body = '';

--- a/src/Service/S3/src/Input/GetObjectRequest.php
+++ b/src/Service/S3/src/Input/GetObjectRequest.php
@@ -383,7 +383,7 @@ final class GetObjectRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "Key" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Key'] = $v;
-        $uriString = "/{$uri['Bucket']}/{$uri['Key']}";
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '/' . str_replace('%2F', '/', rawurlencode($uri['Key']));
 
         // Prepare Body
         $body = '';

--- a/src/Service/S3/src/Input/HeadBucketRequest.php
+++ b/src/Service/S3/src/Input/HeadBucketRequest.php
@@ -59,7 +59,7 @@ final class HeadBucketRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "Bucket" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Bucket'] = $v;
-        $uriString = "/{$uri['Bucket']}";
+        $uriString = '/' . rawurlencode($uri['Bucket']);
 
         // Prepare Body
         $body = '';

--- a/src/Service/S3/src/Input/HeadObjectRequest.php
+++ b/src/Service/S3/src/Input/HeadObjectRequest.php
@@ -282,7 +282,7 @@ final class HeadObjectRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "Key" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Key'] = $v;
-        $uriString = "/{$uri['Bucket']}/{$uri['Key']}";
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '/' . str_replace('%2F', '/', rawurlencode($uri['Key']));
 
         // Prepare Body
         $body = '';

--- a/src/Service/S3/src/Input/ListMultipartUploadsRequest.php
+++ b/src/Service/S3/src/Input/ListMultipartUploadsRequest.php
@@ -172,7 +172,7 @@ final class ListMultipartUploadsRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "Bucket" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Bucket'] = $v;
-        $uriString = "/{$uri['Bucket']}?uploads";
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '?uploads';
 
         // Prepare Body
         $body = '';

--- a/src/Service/S3/src/Input/ListObjectsV2Request.php
+++ b/src/Service/S3/src/Input/ListObjectsV2Request.php
@@ -212,7 +212,7 @@ final class ListObjectsV2Request extends Input
             throw new InvalidArgument(sprintf('Missing parameter "Bucket" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Bucket'] = $v;
-        $uriString = "/{$uri['Bucket']}?list-type=2";
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '?list-type=2';
 
         // Prepare Body
         $body = '';

--- a/src/Service/S3/src/Input/ListPartsRequest.php
+++ b/src/Service/S3/src/Input/ListPartsRequest.php
@@ -155,7 +155,7 @@ final class ListPartsRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "Key" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Key'] = $v;
-        $uriString = "/{$uri['Bucket']}/{$uri['Key']}";
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '/' . str_replace('%2F', '/', rawurlencode($uri['Key']));
 
         // Prepare Body
         $body = '';

--- a/src/Service/S3/src/Input/PutObjectAclRequest.php
+++ b/src/Service/S3/src/Input/PutObjectAclRequest.php
@@ -265,7 +265,7 @@ final class PutObjectAclRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "Key" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Key'] = $v;
-        $uriString = "/{$uri['Bucket']}/{$uri['Key']}?acl";
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '/' . str_replace('%2F', '/', rawurlencode($uri['Key'])) . '?acl';
 
         // Prepare Body
 

--- a/src/Service/S3/src/Input/PutObjectRequest.php
+++ b/src/Service/S3/src/Input/PutObjectRequest.php
@@ -633,7 +633,7 @@ final class PutObjectRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "Key" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Key'] = $v;
-        $uriString = "/{$uri['Bucket']}/{$uri['Key']}";
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '/' . str_replace('%2F', '/', rawurlencode($uri['Key']));
 
         // Prepare Body
         $body = $this->Body ?? '';

--- a/src/Service/S3/src/Input/UploadPartRequest.php
+++ b/src/Service/S3/src/Input/UploadPartRequest.php
@@ -248,7 +248,7 @@ final class UploadPartRequest extends Input
             throw new InvalidArgument(sprintf('Missing parameter "Key" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Key'] = $v;
-        $uriString = "/{$uri['Bucket']}/{$uri['Key']}";
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '/' . str_replace('%2F', '/', rawurlencode($uri['Key']));
 
         // Prepare Body
         $body = $this->Body ?? '';

--- a/src/Service/S3/src/Signer/SignerV4ForS3.php
+++ b/src/Service/S3/src/Signer/SignerV4ForS3.php
@@ -60,6 +60,14 @@ class SignerV4ForS3 extends SignerV4
         return parent::buildBodyDigest($request, $isPresign);
     }
 
+    /**
+     * Amazon S3 does not double-encode the path component in the canonical request
+     */
+    protected function buildCanonicalPath(Request $request): string
+    {
+        return '/' . ltrim($request->getUri(), '/');
+    }
+
     protected function convertBodyToStream(SigningContext $context): void
     {
         $request = $context->getRequest();

--- a/src/Service/S3/src/Signer/SignerV4ForS3.php
+++ b/src/Service/S3/src/Signer/SignerV4ForS3.php
@@ -61,7 +61,7 @@ class SignerV4ForS3 extends SignerV4
     }
 
     /**
-     * Amazon S3 does not double-encode the path component in the canonical request
+     * Amazon S3 does not double-encode the path component in the canonical request.
      */
     protected function buildCanonicalPath(Request $request): string
     {

--- a/src/Service/S3/tests/Integration/S3ClientTest.php
+++ b/src/Service/S3/tests/Integration/S3ClientTest.php
@@ -636,16 +636,16 @@ class S3ClientTest extends TestCase
 
         $result = $client->listObjectsV2([
             'Bucket' => 'foo#pound',
-            'Delimiter' => '/'
+            'Delimiter' => '/',
         ]);
-        $this->assertEquals(['bar#pound/'], array_map(function(CommonPrefix $prefix) {return $prefix->getPrefix();}, \iterator_to_array($result->getCommonPrefixes())));
+        self::assertEquals(['bar#pound/'], array_map(function (CommonPrefix $prefix) {return $prefix->getPrefix(); }, \iterator_to_array($result->getCommonPrefixes())));
 
         $result = $client->listObjectsV2([
             'Bucket' => 'foo#pound',
-            'Prefix' => 'bar#pound/'
+            'Prefix' => 'bar#pound/',
         ]);
 
-        $this->assertEquals(['bar#pound/baz#pound'], array_map(function(AwsObject $prefix) {return $prefix->getKey();}, \iterator_to_array($result->getContents())));
+        self::assertEquals(['bar#pound/baz#pound'], array_map(function (AwsObject $prefix) {return $prefix->getKey(); }, \iterator_to_array($result->getContents())));
     }
 
     private function getClient(): S3Client

--- a/src/Service/S3/tests/Integration/S3ClientTest.php
+++ b/src/Service/S3/tests/Integration/S3ClientTest.php
@@ -614,6 +614,40 @@ class S3ClientTest extends TestCase
         self::assertEquals(200, $result->info()['status']);
     }
 
+    public function testKeyWithSpecialChars(): void
+    {
+        $client = $this->getClient();
+
+        $client->CreateBucket(['Bucket' => 'foo#pound'])->resolve();
+
+        $result = $client->PutObject([
+            'Body' => 'content',
+            'Bucket' => 'foo#pound',
+            'Key' => 'bar#pound/baz#pound',
+        ]);
+
+        self::assertEquals('"9a0364b9e99bb480dd25e1f0284c8555"', $result->getETag());
+
+        $result = $client->GetObject([
+            'Bucket' => 'foo#pound',
+            'Key' => 'bar#pound/baz#pound',
+        ]);
+        self::assertEquals('content', $result->getBody()->getContentAsString());
+
+        $result = $client->listObjectsV2([
+            'Bucket' => 'foo#pound',
+            'Delimiter' => '/'
+        ]);
+        $this->assertEquals(['bar#pound/'], array_map(function(CommonPrefix $prefix) {return $prefix->getPrefix();}, \iterator_to_array($result->getCommonPrefixes())));
+
+        $result = $client->listObjectsV2([
+            'Bucket' => 'foo#pound',
+            'Prefix' => 'bar#pound/'
+        ]);
+
+        $this->assertEquals(['bar#pound/baz#pound'], array_map(function(AwsObject $prefix) {return $prefix->getKey();}, \iterator_to_array($result->getContents())));
+    }
+
     private function getClient(): S3Client
     {
         return new S3Client([

--- a/src/Service/S3/tests/Unit/Input/GetObjectRequestTest.php
+++ b/src/Service/S3/tests/Unit/Input/GetObjectRequestTest.php
@@ -25,4 +25,36 @@ class GetObjectRequestTest extends TestCase
 
         self::assertRequestEqualsHttpRequest($expected, $input->request());
     }
+
+    public function testRequestWithSpecialChar(): void
+    {
+        $input = new GetObjectRequest([
+            'Bucket' => 'my-bucket',
+            'Key' => 'foo-with#pound.jpg',
+            'VersionId' => 'abc123',
+        ]);
+
+        $expected = '
+            GET /my-bucket/foo-with%23pound.jpg?versionId=abc123 HTTP/1.0
+            Content-Type: application/xml
+        ';
+
+        self::assertRequestEqualsHttpRequest($expected, $input->request());
+    }
+
+    public function testRequestDoesNotEscapeSlash(): void
+    {
+        $input = new GetObjectRequest([
+            'Bucket' => 'my-bucket',
+            'Key' => 'foo/bar.jpg',
+            'VersionId' => 'abc123',
+        ]);
+
+        $expected = '
+            GET /my-bucket/foo/bar.jpg?versionId=abc123 HTTP/1.0
+            Content-Type: application/xml
+        ';
+
+        self::assertRequestEqualsHttpRequest($expected, $input->request());
+    }
 }


### PR DESCRIPTION
This PR fixes #614 

2 issues:
- When building the URI, the Input's property should be url_encoded.
- The S3 signer should not encode the path in canonicalisation (see https://github.com/aws/aws-sdk-php/blob/master/src/Signature/S3SignatureV4.php#L60-L66)