### PR TITLE
Change configuration of CloudWatchLogsHandler

### DIFF
--- a/docs/integration/monolog.md
+++ b/docs/integration/monolog.md
@@ -36,11 +36,11 @@ $logger->error('an error occurred');
 The CloudWatchLogsHandler accepts the following parameters:
 
 - `$client`: the CloudWatchLogsClient instance
-- `$config`: handler configuration (see below)
+- `$options`: handler configuration (see below)
 - `$level` (default `Logger::DEBUG`): minimum logging level at which this handler will be triggered (see https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#log-levels)
 - `$bubble`(default `true`): whether the messages that are handled can bubble up the stack or not (see https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#core-concepts)
 
-For the `$config` parameter, the allowed values are:
+For the `$options` parameter, the allowed values are:
 
 - `batchSize` (default `10000`): number of log records that are pushed to CloudWatch in a single call. This number cannot exceed 10,000.
 - `group`: name of the CloudWatch Log Group which was created previously

--- a/docs/integration/monolog.md
+++ b/docs/integration/monolog.md
@@ -33,12 +33,17 @@ $logger->error('an error occurred');
 
 ## Configuration
 
-The CloudWatchLogsHandler accepts the following configuration:
+The CloudWatchLogsHandler accepts the following parameters:
+
+- `$client`: the CloudWatchLogsClient instance
+- `$config`: handler configuration (see below)
+- `$level` (default `Logger::DEBUG`): minimum logging level at which this handler will be triggered (see https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#log-levels)
+- `$bubble`(default `true`): whether the messages that are handled can bubble up the stack or not (see https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#core-concepts)
+
+For the `$config` parameter, the allowed values are:
 
 - `batchSize` (default `10000`): number of log records that are pushed to CloudWatch in a single call. This number cannot exceed 10,000.
-- `bubble` (default `true`): whether the messages that are handled can bubble up the stack or not (see https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#core-concepts).
 - `group`: name of the CloudWatch Log Group which was created previously
-- `level` (default `Logger::DEBUG`): minimum logging level at which this handler will be triggered (see https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#log-levels)
 - `stream`: name of the CloudWatch Log Stream which was created previously
 
 ## Symfony usage

--- a/docs/integration/monolog.md
+++ b/docs/integration/monolog.md
@@ -20,10 +20,11 @@ use AsyncAws\Monolog\CloudWatch\CloudWatchLogsHandler;
 use Monolog\Logger;
 
 $client = new CloudWatchLogsClient();
-$groupName = 'company-website';
-$streamName = 'frontend-api';
 
-$handler = new CloudWatchLogsHandler($client, $groupName, $streamName);
+$handler = new CloudWatchLogsHandler($client, [
+    'group' => 'company-website',
+    'stream' => 'frontend-api',
+]);
 
 $logger = new Logger('logger');
 $logger->pushHandler($handler);
@@ -32,14 +33,13 @@ $logger->error('an error occurred');
 
 ## Configuration
 
-The CloudWatchLogsHandler accepts the following parameters:
+The CloudWatchLogsHandler accepts the following configuration:
 
-- `$client`: the CloudWatchLogsClient instance
-- `$group`: name of the CloudWatch Log Group which was created previously
-- `$stream`: name of the CloudWatch Log Stream which was created previously
-- `$batchSize`: number of log records that are pushed to CloudWatch in a single call. This number cannot exceed 10,000.
-- `$level`: minimum logging level at which this handler will be triggered (see https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#log-levels)
-- `$bubble`: whether the messages that are handled can bubble up the stack or not (see https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#core-concepts)
+- `batchSize` (default `10000`): number of log records that are pushed to CloudWatch in a single call. This number cannot exceed 10,000.
+- `bubble` (default `true`): whether the messages that are handled can bubble up the stack or not (see https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#core-concepts).
+- `group`: name of the CloudWatch Log Group which was created previously
+- `level` (default `Logger::DEBUG`): minimum logging level at which this handler will be triggered (see https://github.com/Seldaek/monolog/blob/master/doc/01-usage.md#log-levels)
+- `stream`: name of the CloudWatch Log Stream which was created previously
 
 ## Symfony usage
 
@@ -55,9 +55,9 @@ services:
         class: AsyncAws\Monolog\CloudWatch\CloudWatchLogsHandler
         arguments:
             - '@async_aws.client.cloud_watch_logs'
-            - company-website
-            - frontend-api
-            # more arguments, see Configuration
+            - group: company-website
+              stream: frontend-api
+              # more parameters, see Configuration
 ```
 
 ```yaml

--- a/src/Integration/Monolog/CloudWatch/CHANGELOG.md
+++ b/src/Integration/Monolog/CloudWatch/CHANGELOG.md
@@ -1,10 +1,10 @@
 # Change Log
 
-## 0.2.0
+## NOT RELEASED
 
 ### Changed
 
-- `CloudWatchLogsHandler` inline arguments deprecated in favor of a `$config` array
+- BC: `CloudWatchLogsHandler` constructor arguments changed
 
 ## 0.1.0
 

--- a/src/Integration/Monolog/CloudWatch/CHANGELOG.md
+++ b/src/Integration/Monolog/CloudWatch/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change Log
 
+## 0.2.0
+
+### Changed
+
+- `CloudWatchLogsHandler` inline arguments deprecated in favor of a `$config` array
+
 ## 0.1.0
 
 First version

--- a/src/Integration/Monolog/CloudWatch/src/CloudWatchLogsHandler.php
+++ b/src/Integration/Monolog/CloudWatch/src/CloudWatchLogsHandler.php
@@ -98,23 +98,9 @@ class CloudWatchLogsHandler extends AbstractProcessingHandler
     public function __construct(
         CloudWatchLogsClient $client,
         $config,
-        /*$stream,
-        $batchSize = 10000,*/
         $level = Logger::DEBUG,
         $bubble = true
     ) {
-        if (!\is_array($config)) {
-            @\trigger_error('Creating CloudWatchLogsHandler with inline config arguments is deprecated', \E_USER_WARNING);
-            $arguments = \func_get_args();
-            $config = [
-                'group' => $arguments[1],
-                'stream' => $arguments[2],
-                'batchSize' => $arguments[3] ?? null,
-            ];
-            $level = $arguments[4] ?? Logger::DEBUG;
-            $bubble = $arguments[5] ?? true;
-        }
-
         $config['batchSize'] = $config['batchSize'] ?? 10000;
 
         if ($config['batchSize'] > 10000) {

--- a/src/Integration/Monolog/CloudWatch/src/CloudWatchLogsHandler.php
+++ b/src/Integration/Monolog/CloudWatch/src/CloudWatchLogsHandler.php
@@ -90,16 +90,18 @@ class CloudWatchLogsHandler extends AbstractProcessingHandler
      *   level?: int,
      *   stream: string,
      * } $config
+     * @param int  $level
+     * @param bool $bubble
      *
      * @throws \InvalidArgumentException
      */
     public function __construct(
         CloudWatchLogsClient $client,
-        $config /*,
-        $stream,
-        $batchSize = 10000,
+        $config,
+        /*$stream,
+        $batchSize = 10000,*/
         $level = Logger::DEBUG,
-        $bubble = true*/
+        $bubble = true
     ) {
         if (!\is_array($config)) {
             @\trigger_error('Creating CloudWatchLogsHandler with inline config arguments is deprecated', \E_USER_WARNING);
@@ -108,9 +110,9 @@ class CloudWatchLogsHandler extends AbstractProcessingHandler
                 'group' => $arguments[1],
                 'stream' => $arguments[2],
                 'batchSize' => $arguments[3] ?? null,
-                'level' => $arguments[4] ?? null,
-                'bubble' => $arguments[5] ?? null,
             ];
+            $level = $arguments[4] ?? Logger::DEBUG;
+            $bubble = $arguments[5] ?? true;
         }
 
         $config['batchSize'] = $config['batchSize'] ?? 10000;
@@ -122,7 +124,7 @@ class CloudWatchLogsHandler extends AbstractProcessingHandler
         $this->client = $client;
         $this->config = $config;
 
-        parent::__construct($config['level'] ?? Logger::DEBUG, $config['bubble'] ?? true);
+        parent::__construct($level, $bubble);
     }
 
     /**

--- a/src/Integration/Monolog/CloudWatch/src/CloudWatchLogsHandler.php
+++ b/src/Integration/Monolog/CloudWatch/src/CloudWatchLogsHandler.php
@@ -85,9 +85,7 @@ class CloudWatchLogsHandler extends AbstractProcessingHandler
      *  The ':' (colon) and '*' (asterisk) characters are not allowed.
      * @param array{
      *   batchSize?: int,
-     *   bubble?: bool,
      *   group: string,
-     *   level?: int,
      *   stream: string,
      * } $options
      * @param int  $level

--- a/src/Integration/Monolog/CloudWatch/tests/CloudWatchLogsHandlerTest.php
+++ b/src/Integration/Monolog/CloudWatch/tests/CloudWatchLogsHandlerTest.php
@@ -42,11 +42,9 @@ class CloudWatchLogsHandlerTest extends TestCase
     {
         $handler = new CloudWatchLogsHandler($this->clientMock, [
             'batchSize' => 1337,
-            'bubble' => false,
             'group' => $this->groupName,
-            'level' => Logger::CRITICAL,
             'stream' => $this->streamName,
-        ]);
+        ], Logger::CRITICAL, false);
 
         self::assertEquals(Logger::CRITICAL, $handler->getLevel());
         self::assertFalse($handler->getBubble());

--- a/src/Integration/Monolog/CloudWatch/tests/CloudWatchLogsHandlerTest.php
+++ b/src/Integration/Monolog/CloudWatch/tests/CloudWatchLogsHandlerTest.php
@@ -54,7 +54,10 @@ class CloudWatchLogsHandlerTest extends TestCase
     {
         $this->mockDescribeLogStreams();
 
-        $handler = new CloudWatchLogsHandler($this->clientMock, $this->groupName, $this->streamName, 10000, Logger::DEBUG, true);
+        $handler = new CloudWatchLogsHandler($this->clientMock, [
+            'group' => $this->groupName,
+            'stream' => $this->streamName,
+        ]);
 
         $reflection = new \ReflectionClass($handler);
         $reflectionMethod = $reflection->getMethod('initialize');
@@ -65,7 +68,7 @@ class CloudWatchLogsHandlerTest extends TestCase
     public function testLimitExceeded()
     {
         $this->expectException(\InvalidArgumentException::class);
-        (new CloudWatchLogsHandler($this->clientMock, 'a', 'b', 10001));
+        $this->getHandler(10001);
     }
 
     public function testSendsOnClose()
@@ -170,7 +173,11 @@ class CloudWatchLogsHandlerTest extends TestCase
 
     private function getHandler($batchSize = 1000): CloudWatchLogsHandler
     {
-        return new CloudWatchLogsHandler($this->clientMock, $this->groupName, $this->streamName, $batchSize);
+        return new CloudWatchLogsHandler($this->clientMock, [
+            'batchSize' => $batchSize,
+            'group' => $this->groupName,
+            'stream' => $this->streamName,
+        ]);
     }
 
     private function getRecord(int $level = Logger::WARNING, string $message = 'test', array $context = []): array

--- a/src/Integration/Monolog/CloudWatch/tests/CloudWatchLogsHandlerTest.php
+++ b/src/Integration/Monolog/CloudWatch/tests/CloudWatchLogsHandlerTest.php
@@ -38,6 +38,20 @@ class CloudWatchLogsHandlerTest extends TestCase
             ->getMock();
     }
 
+    public function testConfig()
+    {
+        $handler = new CloudWatchLogsHandler($this->clientMock, [
+            'batchSize' => 1337,
+            'bubble' => false,
+            'group' => $this->groupName,
+            'level' => Logger::CRITICAL,
+            'stream' => $this->streamName,
+        ]);
+
+        self::assertEquals(Logger::CRITICAL, $handler->getLevel());
+        self::assertFalse($handler->getBubble());
+    }
+
     public function testInitialize()
     {
         $this->mockDescribeLogStreams();


### PR DESCRIPTION
I think it's a bad practice to have inline config arguments in the CloudWatchLogsHandler constructor

this will lead to a very long argument list (see https://github.com/maxbanton/cwh/blob/master/src/Handler/CloudWatch.php#L121) and the need for users to hard-code defaults in instance creation

this PR proposes a signature change with a `$config` array with a BC layer until version 1 is released

this will also greatly simplify the bundle factory, since it will not have to take care of handling defaults