### PR TITLE
Suppress one more "BC warning" about TestCase

### DIFF
--- a/src/Core/.github/workflows/bc.entrypoint
+++ b/src/Core/.github/workflows/bc.entrypoint
@@ -26,7 +26,7 @@ STATED_BREAKS=`echo "$OUTPUT" | tail -n 1 | awk -F' ' '{ print $1 }'`
 # THEN
 #   exit 1
 
-if [ $BC_BREAKS -gt 0 ] || [ $STATED_BREAKS -gt 7 ]; then
+if [ $BC_BREAKS -gt 0 ] || [ $STATED_BREAKS -gt 8 ]; then
     echo "EXIT 1"
     exit 1
 fi


### PR DESCRIPTION
The latest [Roave BC check](https://github.com/Roave/BackwardCompatibilityCheck) will find one more row saying: 

> [BC] SKIPPED: Roave\BetterReflection\Reflection\ReflectionClass "PHPUnit\Framework\TestCase" could not be found in the located source

I tested with the same core package and two different versions of Roave BC Check.  