### PR TITLE
Remove broken link checker

### DIFF
--- a/docs/clients/index.md
+++ b/docs/clients/index.md
@@ -139,7 +139,7 @@ for more information.
 | [CloudWatchLogs](./cloud-watch-logs.md)     | [async-aws/cloud-watch-logs](https://packagist.org/packages/async-aws/cloud-watch-logs)
 | CodeDeploy                                  | [async-aws/code-deploy](https://packagist.org/packages/async-aws/code-deploy)
 | [CognitoIdentityProvider](./cognito-idp.md) | [async-aws/cognito-identity-provider](https://packagist.org/packages/async-aws/cognito-identity-provider)
-| [DynamoDb]('./dynamodb.md)                  | [async-aws/dynamo-db](https://packagist.org/packages/async-aws/dynamo-db)
+| [DynamoDb](./dynamodb.md)                   | [async-aws/dynamo-db](https://packagist.org/packages/async-aws/dynamo-db)
 | EventBridge                                 | [async-aws/event-bridge](https://packagist.org/packages/async-aws/event-bridge)
 | [Iam](./iam.md)                             | [async-aws/iam](https://packagist.org/packages/async-aws/iam)
 | [Lambda](./lambda.md)                       | [async-aws/lambda](https://packagist.org/packages/async-aws/lambda)

--- a/website/template/netlify.toml
+++ b/website/template/netlify.toml
@@ -5,18 +5,3 @@
     cache-control = '''
     max-age=31449600,
     immutable'''
-
-[[plugins]]
-package = "netlify-plugin-checklinks"
-
-  # https://github.com/munter/netlify-plugin-checklinks
-  [plugins.inputs]
-  entryPoints = [
-    "*.html",
-  ]
-  recursive = true
-  pretty = true
-  skipPatterns = []
-  todoPatterns = []
-  checkExternal = false
-  followSourceMaps = false


### PR DESCRIPTION
I reverted #593 and here is why: 

1. The "build" on Netlify failed with errors. I didt get any email or other notification. 
2. The reason the build failed was because link `https://%service%.%region%.amazonaws.com` is not valid 

However.. it did find a bug. (also in this PR). 


<img width="1208" alt="Screenshot 2020-05-16 at 14 55 34" src="https://user-images.githubusercontent.com/1275206/82120307-558d7580-9785-11ea-981d-1f7c96a46c87.png">
