### PR TITLE
Make sure passing "null" to the configuration does not have any effect

### DIFF
--- a/src/Core/src/Configuration.php
+++ b/src/Core/src/Configuration.php
@@ -103,7 +103,12 @@ final class Configuration
         }
 
         $configuration = new Configuration();
-        $configuration->userData = \array_fill_keys(\array_keys($options), true);
+        $configuration->userData = [];
+        foreach ($options as $key => $value) {
+            if (null !== $value) {
+                $configuration->userData[$key] = true;
+            }
+        }
 
         foreach (self::DEFAULT_OPTIONS as $optionTrigger => $defaultValue) {
             if (isset($options[$optionTrigger])) {

--- a/src/Core/tests/Unit/ConfigurationTest.php
+++ b/src/Core/tests/Unit/ConfigurationTest.php
@@ -38,6 +38,29 @@ class ConfigurationTest extends TestCase
         self::assertFalse($config->isDefault('region'));
     }
 
+    /**
+     * Make sure passing "null" is the same as no passing anything.
+     */
+    public function testIsDefaultWhenPassingNull()
+    {
+        $config = Configuration::create([
+            'region' => null,
+            'accessKeyId' => null,
+            'accessKeySecret' => null,
+        ]);
+
+        self::assertFalse($config->has('accessKeyId'));
+        self::assertFalse($config->has('accessKeySecret'));
+
+        self::assertTrue($config->isDefault('region'));
+        self::assertTrue($config->isDefault('accessKeyId'));
+        self::assertTrue($config->isDefault('accessKeySecret'));
+
+        self::assertEquals(Configuration::DEFAULT_REGION, $config->get('region'));
+        self::assertNull($config->get('accessKeyId'));
+        self::assertNull($config->get('accessKeySecret'));
+    }
+
     public function provideConfiguration(): iterable
     {
         yield 'simple config' => [['endpoint' => 'foo'], [], ['endpoint' => 'foo']];


### PR DESCRIPTION
This PR does not change anything*. It just adds a test so we dont change this behavior in the future. 

*We do change an edge case. For values without default you could have 
```php
$conf = Configuration::create();
$conf->get('accessKeyId') === null;
// Assert "null" is the default value

$conf = Configuration::create(['accessKeyId'=>null]);
$conf->isDefault('accessKeyId') === false; // Strange...
$conf->has('accessKeyId') === false;
$conf->get('accessKeyId') === null;
```

With this PR, we will acknowledge that `null` is default of `accessKeyId`. 

-------------

This PR allows us to write Symfony config like this. Because `default::ENV_VAR` will return `null` if `ENV_VAR` is not defined. 

```yaml
async_aws:
    config:
        region: '%env(default::AWS_REGION)%'
        accessKeyId: '%env(default::AWS_ACCESS_KEY_ID)%'
        accessKeySecret: '%env(default::AWS_SECRET_ACCESS_KEY)%'
        sessionToken: '%env(default::AWS_SESSION_TOKEN)%'
```
