### PR TITLE
Ignore expires header for signing requests

### DIFF
--- a/src/Core/src/Signer/SignerV4.php
+++ b/src/Core/src/Signer/SignerV4.php
@@ -24,6 +24,7 @@ class SignerV4 implements Signer
         'content-type' => true,
         'content-length' => true,
         'expect' => true,
+        'expires' => true,
         'max-forwards' => true,
         'pragma' => true,
         'range' => true,


### PR DESCRIPTION
When uploading to S3 with an `Expires` header, it throws an Exception: 

```
AsyncAws\Core\Exception\Http\ClientException: HTTP 403 returned for "https://s3.eu-central-1.amazonaws.com/my-bucket/my-key.txt".
        Code:    SignatureDoesNotMatch
        Message: The request signature we calculated does not match the signature you provided. Check your key and signing method.
        ...
```

This PR fixes that. But I have to be honest, I don't know if it breaks other stuff.

I haven't found an exact documentation which headers should go into `CanonicalHeaders`, so if you know more or have a better way to fix this, feel free to take over or replace this PR by a better one :)