### PR TITLE
Fix signing of request with Date in header

### DIFF
--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -16,6 +16,10 @@
 - Custom endpoints should not contain `%region%` and `%service` placeholder. They won't be replaced anymore in 2.0
 - Protected methods `getServiceCode`, `getSignatureVersion` and `getSignatureScopeName` of AbstractApi are deprecated and will be removed in 2.0
 
+### Fixed
+
+- Fix signing of requests with a header containing a date (like `expires` in `S3`).
+
 ## 1.1.0
 
 ### Added

--- a/src/Core/src/Signer/SignerV4.php
+++ b/src/Core/src/Signer/SignerV4.php
@@ -267,20 +267,10 @@ class SignerV4 implements Signer
     {
         // Case-insensitively aggregate all of the headers.
         $canonicalHeaders = [];
-        foreach ($request->getHeaders() as $key => $values) {
+        foreach ($request->getHeaders() as $key => $value) {
             $key = strtolower($key);
             if (isset(self::BLACKLIST_HEADERS[$key])) {
                 continue;
-            }
-
-            if (!\is_array($values) && false !== \strpos($values, ',')) {
-                $values = array_map('trim', \explode(',', $values));
-            }
-            if (\is_array($values)) {
-                sort($values);
-                $value = \implode(',', $values);
-            } else {
-                $value = $values;
             }
 
             $canonicalHeaders[$key] = "$key:$value";

--- a/src/Core/tests/Unit/Signer/SignerV4Test.php
+++ b/src/Core/tests/Unit/Signer/SignerV4Test.php
@@ -91,11 +91,6 @@ class SignerV4Test extends TestCase
                 "GET / HTTP/1.1\r\nHost: host.foo.com\r\nx-AMZ-date: 20110909T233600Z\r\nZOO:zoobar\r\n\r\n",
                 "GET / HTTP/1.1\r\nHost: host.foo.com\r\nZOO: zoobar\r\nX-Amz-Date: 20110909T233600Z\r\nAuthorization: AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=host;x-amz-date;zoo, Signature=287deb2c1249c9c415cb4b3ef74404629fcab56a8e9ec568bff88cf093196e8e\r\n\r\n",
             ],
-            // Duplicate header values must be sorted.
-            [
-                "POST / HTTP/1.1\r\nHost: host.foo.com\r\nx-AMZ-date: 20110909T233600Z\r\np: z\r\np: a\r\np: p\r\np: a\r\n\r\n",
-                "POST / HTTP/1.1\r\nHost: host.foo.com\r\np: z, a, p, a\r\nX-Amz-Date: 20110909T233600Z\r\nAuthorization: AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=host;p;x-amz-date, Signature=faca06aa6ae71c0a24116c9a61b01346e6d9d621001bac49d38a6fdb285649ec\r\n\r\n",
-            ],
             // Request with space.
             [
                 "GET /%20/foo HTTP/1.1\r\nHost: host.foo.com\r\n\r\n",
@@ -121,11 +116,6 @@ class SignerV4Test extends TestCase
                 "GET / HTTP/1.1\r\nHost: host.foo.com:443\r\nx-AMZ-date: 20110909T233600Z\r\nZOO:zoobar\r\n\r\n",
                 "GET / HTTP/1.1\r\nHost: host.foo.com:443\r\nZOO: zoobar\r\nX-Amz-Date: 20110909T233600Z\r\nAuthorization: AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=host;x-amz-date;zoo, Signature=69c57723eee136a804b6d4b1fd1b4d45ba059e1f758900a6b1301111e1e8c77e\r\n\r\n",
             ],
-            // HTTPS Duplicate header values must be sorted.
-            [
-                "POST / HTTP/1.1\r\nHost: host.foo.com:443\r\nx-AMZ-date: 20110909T233600Z\r\np: z\r\np: a\r\np: p\r\np: a\r\n\r\n",
-                "POST / HTTP/1.1\r\nHost: host.foo.com:443\r\np: z, a, p, a\r\nX-Amz-Date: 20110909T233600Z\r\nAuthorization: AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=host;p;x-amz-date, Signature=cec423fa9e930519918d3c05982c14ae60b7c5aedd296f2a1322b5831bbaf4ea\r\n\r\n",
-            ],
             // HTTPS Request with space.
             [
                 "GET /%20/foo HTTP/1.1\r\nHost: host.foo.com:443\r\n\r\n",
@@ -141,6 +131,11 @@ class SignerV4Test extends TestCase
                 "POST / HTTP/1.1\r\nHost: host.foo.com:443\r\nContent-Length: 4\r\n\r\nTest",
                 "POST / HTTP/1.1\r\nHost: host.foo.com:443\r\nContent-Length: 4\r\nX-Amz-Date: 20110909T233600Z\r\nAuthorization: AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=host;x-amz-date, Signature=e971be49c79358595ef6214f683ac9c0489d397a5d5d13b361291e751deeca03\r\n\r\nTest",
                 "POST\n/\n\nhost:host.foo.com:443\n\nhost\n532eaabd9574880dbf76b9b8cc00832c20a6ec113d682299550d7a6e0f345e25",
+            ],
+            // DateHeader should be kept
+            [
+                "POST / HTTP/1.1\r\nHost: host.foo.com:443\r\nx-AMZ-date: 20110909T233600Z\r\nExpires: Thu, 21 May 20 20:54:15 +0200\r\n\r\n",
+                "POST / HTTP/1.1\r\nHost: host.foo.com:443\r\nexpires:Thu, 21 May 20 20:54:15 +0200\r\nX-Amz-Date: 20110909T233600Z\r\nAuthorization: AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=expires;host;x-amz-date, Signature=7090e12acc44281b2b46ba195ee1ae09f2e8c81653fcd592abbfbc30e1a5acc6\r\n\r\n",
             ],
         ];
     }


### PR DESCRIPTION
Fixes #634

Issue is about canonicalheader method that try to sort values in headers and belive that `expires:Thu, 21 May 20 20:54:15 +0200` should be canonicalized to `expires:21 May 20 20:54:15 +0200,Thu` 

Given our headers are an array of string and we don't cover array of array, this sort header logic is not used nor needed.