### PR TITLE
Fix SES signature

### DIFF
--- a/src/CodeGenerator/generate.php
+++ b/src/CodeGenerator/generate.php
@@ -6,9 +6,9 @@ use Symfony\Component\Console\Application;
 
 $application = new Application('AsyncAws', '0.1.0');
 
-$src = $_SERVER['ASYNC_AWS_GENERATE_SRC'] ?: __DIR__ . '/src';
-$cache = $_SERVER['ASYNC_AWS_GENERATE_CACHE'] ?: __DIR__ . '/.async-aws.cache';
-$manifest = $_SERVER['ASYNC_AWS_GENERATE_MANIFEST'] ?: __DIR__ . '/manifest.json';
+$src = $_SERVER['ASYNC_AWS_GENERATE_SRC'] ?? __DIR__ . '/src';
+$cache = $_SERVER['ASYNC_AWS_GENERATE_CACHE'] ?? __DIR__ . '/.async-aws.cache';
+$manifest = $_SERVER['ASYNC_AWS_GENERATE_MANIFEST'] ?? __DIR__ . '/manifest.json';
 $command = new GenerateCommand($manifest, $cache, new ApiGenerator($src));
 $application->add($command);
 $application->setDefaultCommand($command->getName(), true);

--- a/src/CodeGenerator/src/Command/GenerateCommand.php
+++ b/src/CodeGenerator/src/Command/GenerateCommand.php
@@ -158,7 +158,7 @@ class GenerateCommand extends Command
         return $manifest;
     }
 
-    private function extractEndpointsForService(array $endpoints, string $prefix): array
+    private function extractEndpointsForService(array $endpoints, string $prefix, string $signingServiceFallback, string $signingVersionFallback): array
     {
         $serviceEndpoints = [];
         foreach ($endpoints['partitions'] as $partition) {
@@ -168,8 +168,8 @@ class GenerateCommand extends Command
                 $hostname = $config['hostname'] ?? $service['defaults']['hostname'] ?? $partition['defaults']['hostname'];
                 $protocols = $config['protocols'] ?? $service['defaults']['protocols'] ?? $partition['defaults']['protocols'] ?? [];
                 $signRegion = $config['credentialScope']['region'] ?? $service['defaults']['credentialScope']['region'] ?? $partition['defaults']['credentialScope']['region'] ?? $region;
-                $signService = $config['credentialScope']['service'] ?? $service['defaults']['credentialScope']['service'] ?? $partition['defaults']['credentialScope']['service'] ?? $prefix;
-                $signVersions = \array_unique($config['signatureVersions'] ?? $service['defaults']['signatureVersions'] ?? $partition['defaults']['signatureVersions'] ?? []);
+                $signService = $config['credentialScope']['service'] ?? $service['defaults']['credentialScope']['service'] ?? $partition['defaults']['credentialScope']['service'] ?? $signingServiceFallback;
+                $signVersions = \array_unique($config['signatureVersions'] ?? $service['defaults']['signatureVersions'] ?? $partition['defaults']['signatureVersions'] ?? [$signingVersionFallback]);
 
                 if (empty($config)) {
                     if (!isset($serviceEndpoints['_default'][$partition['partition']])) {
@@ -230,7 +230,7 @@ class GenerateCommand extends Command
     private function generateService(SymfonyStyle $io, InputInterface $input, array $manifest, array $endpoints, string $serviceName)
     {
         $definitionArray = $this->loadFile($manifest['services'][$serviceName]['source'], "$serviceName-source");
-        $endpoints = $this->extractEndpointsForService($endpoints, $definitionArray['metadata']['endpointPrefix']);
+        $endpoints = $this->extractEndpointsForService($endpoints, $definitionArray['metadata']['endpointPrefix'], $definitionArray['metadata']['signingName'] ?? $definitionArray['metadata']['endpointPrefix'], $definitionArray['metadata']['signatureVersion']);
 
         $documentationArray = $this->loadFile($manifest['services'][$serviceName]['documentation'], "$serviceName-documentation");
         $paginationArray = $this->loadFile($manifest['services'][$serviceName]['pagination'], "$serviceName-pagination");

--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## NOT RELEASED
 
-### Fixed
-
-- Fix invalid signature in SES client because of wrong Scoped Service.
-
 ## 1.2.0
 
 ### Added

--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Fixed
+
+- Fix invalid signature in SES client because of wrong Scoped Service.
+
 ## 1.2.0
 
 ### Added

--- a/src/Service/Ses/CHANGELOG.md
+++ b/src/Service/Ses/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## NOT RELEASED
 
+## 1.1.1
+
+### Fixed
+
+- Fix invalid signature in SES client because of wrong Scoped Service.
+
 ## 1.1.0
 
 ### Deprecation

--- a/src/Service/Ses/src/SesClient.php
+++ b/src/Service/Ses/src/SesClient.php
@@ -51,21 +51,21 @@ class SesClient extends AbstractApi
                 return [
                     'endpoint' => "https://email.$region.amazonaws.com",
                     'signRegion' => $region,
-                    'signService' => 'email',
+                    'signService' => 'ses',
                     'signVersions' => ['v4'],
                 ];
             case 'us-gov-west-1':
                 return [
                     'endpoint' => "https://email.$region.amazonaws.com",
                     'signRegion' => $region,
-                    'signService' => 'email',
+                    'signService' => 'ses',
                     'signVersions' => ['v4'],
                 ];
             case 'fips-us-gov-west-1':
                 return [
                     'endpoint' => 'https://email-fips.us-gov-west-1.amazonaws.com',
                     'signRegion' => 'us-gov-west-1',
-                    'signService' => 'email',
+                    'signService' => 'ses',
                     'signVersions' => ['v4'],
                 ];
         }


### PR DESCRIPTION
When `endpoints.json` does not provide a ScopedService, we fallback to the `api2.json` metadata