### PR TITLE
Remove reference $fn in PopulateResult

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,6 +20,4 @@ parameters:
         - '#Negated boolean expression is always false\.#'
         - '#^PHPDoc tag @param has invalid value#'
         - '#^Parameter \#1 \$input of class AsyncAws\\[^\\]+\\ValueObject\\[^ ]+ constructor expects (array\(\)\|)?array\([^\)]+\), array\([^\)]+\) given\.#'
-        - '#should return iterable<array[^>]+>> but empty return statement found\.$#'
-        - '#should return iterable<[^>]+> but empty return statement found\.$#'
         - '#Method AsyncAws\\[^:]+::[^(]+\(\) should return array<[^>]+> but returns array<int(\|string)?, string>\.$#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -22,3 +22,4 @@ parameters:
         - '#^Parameter \#1 \$input of class AsyncAws\\[^\\]+\\ValueObject\\[^ ]+ constructor expects (array\(\)\|)?array\([^\)]+\), array\([^\)]+\) given\.#'
         - '#should return iterable<array[^>]+>> but empty return statement found\.$#'
         - '#should return iterable<[^>]+> but empty return statement found\.$#'
+        - '#Method AsyncAws\\[^:]+::[^(]+\(\) should return array<[^>]+> but returns array<int(\|string)?, string>\.$#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -20,5 +20,5 @@ parameters:
         - '#Negated boolean expression is always false\.#'
         - '#^PHPDoc tag @param has invalid value#'
         - '#^Parameter \#1 \$input of class AsyncAws\\[^\\]+\\ValueObject\\[^ ]+ constructor expects (array\(\)\|)?array\([^\)]+\), array\([^\)]+\) given\.#'
-        - '#^Offset ''(list|map)[^'']+'' does not exist on array#'
-        - '#^Anonymous function has an unused use \$fn.#'
+        - '#should return iterable<array[^>]+>> but empty return statement found\.$#'
+        - '#should return iterable<[^>]+> but empty return statement found\.$#'

--- a/psalm.baseline
+++ b/psalm.baseline
@@ -56,6 +56,9 @@
   <file src="src/Service/DynamoDb/src/Result/DescribeTableOutput.php">
     <InvalidArgument occurrences="6"/>
   </file>
+  <file src="src/Service/DynamoDb/src/Result/GetItemOutput.php">
+    <InvalidArgument occurrences="1"/>
+  </file>
   <file src="src/Service/DynamoDb/src/Result/PutItemOutput.php">
     <InvalidArgument occurrences="2"/>
   </file>

--- a/psalm.baseline
+++ b/psalm.baseline
@@ -35,70 +35,16 @@
       <code>scalarNode</code>
     </PossiblyUndefinedMethod>
   </file>
-  <file src="src/Service/CloudFormation/src/Result/DescribeStacksOutput.php">
-    <InvalidArgument occurrences="2"/>
-  </file>
-  <file src="src/Service/CloudFront/src/Result/CreateInvalidationResult.php">
-    <InvalidArgument occurrences="1"/>
-  </file>
-  <file src="src/Service/CognitoIdentityProvider/src/Result/AdminCreateUserResponse.php">
-    <InvalidArgument occurrences="1"/>
-  </file>
-  <file src="src/Service/CognitoIdentityProvider/src/Result/ListUsersResponse.php">
-    <InvalidArgument occurrences="1"/>
-  </file>
-  <file src="src/Service/DynamoDb/src/Result/BatchGetItemOutput.php">
-    <InvalidArgument occurrences="1"/>
-  </file>
-  <file src="src/Service/DynamoDb/src/Result/CreateTableOutput.php">
-    <InvalidArgument occurrences="6"/>
-  </file>
-  <file src="src/Service/DynamoDb/src/Result/DeleteItemOutput.php">
-    <InvalidArgument occurrences="2"/>
-  </file>
-  <file src="src/Service/DynamoDb/src/Result/DeleteTableOutput.php">
-    <InvalidArgument occurrences="6"/>
-  </file>
-  <file src="src/Service/DynamoDb/src/Result/DescribeTableOutput.php">
-    <InvalidArgument occurrences="6"/>
-  </file>
-  <file src="src/Service/DynamoDb/src/Result/GetItemOutput.php">
-    <InvalidArgument occurrences="1"/>
-  </file>
-  <file src="src/Service/DynamoDb/src/Result/PutItemOutput.php">
-    <InvalidArgument occurrences="2"/>
-  </file>
-  <file src="src/Service/DynamoDb/src/Result/QueryOutput.php">
-    <InvalidArgument occurrences="1"/>
-  </file>
-  <file src="src/Service/DynamoDb/src/Result/ScanOutput.php">
-    <InvalidArgument occurrences="1"/>
-  </file>
-  <file src="src/Service/DynamoDb/src/Result/UpdateItemOutput.php">
-    <InvalidArgument occurrences="2"/>
-  </file>
-  <file src="src/Service/DynamoDb/src/Result/UpdateTableOutput.php">
-    <InvalidArgument occurrences="6"/>
-  </file>
-  <file src="src/Service/Iam/src/Result/CreateUserResponse.php">
-    <InvalidArgument occurrences="1"/>
-  </file>
-  <file src="src/Service/Iam/src/Result/GetUserResponse.php">
-    <InvalidArgument occurrences="1"/>
-  </file>
-  <file src="src/Service/Iam/src/Result/ListUsersResponse.php">
-    <InvalidArgument occurrences="1"/>
+  <file src="src/Service/Lambda/src/Result/PublishLayerVersionResponse.php">
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MoreSpecificReturnType occurrences="1"/>
   </file>
   <file src="src/Service/Lambda/src/Result/ListLayerVersionsResponse.php">
-    <InvalidArgument occurrences="1"/>
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MoreSpecificReturnType occurrences="1"/>
   </file>
-  <file src="src/Service/RdsDataService/src/Result/BatchExecuteStatementResponse.php">
-    <InvalidArgument occurrences="3"/>
-  </file>
-  <file src="src/Service/RdsDataService/src/Result/ExecuteStatementResponse.php">
-    <InvalidArgument occurrences="2"/>
-  </file>
-  <file src="src/Service/Sqs/src/Result/ReceiveMessageResult.php">
-    <InvalidArgument occurrences="2"/>
+  <file src="src/Service/CloudFormation/src/Result/DescribeStacksOutput.php">
+    <LessSpecificReturnStatement occurrences="1"/>
+    <MoreSpecificReturnType occurrences="1"/>
   </file>
 </files>

--- a/psalm.baseline
+++ b/psalm.baseline
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.11.5@3c60609c218d4d4b3b257728b8089094e5c6c6c2">
+<files psalm-version="dev-master@91e76f7173238bc59194f51d0bb08f61b0d17f98">
   <file src="src/Integration/Laravel/Cache/src/ServiceProvider.php">
     <UndefinedInterfaceMethod occurrences="1">
       <code>$this-&gt;app</code>
@@ -34,6 +34,12 @@
     <PossiblyUndefinedMethod occurrences="1">
       <code>scalarNode</code>
     </PossiblyUndefinedMethod>
+  </file>
+  <file src="src/Service/CloudFormation/src/Result/DescribeStacksOutput.php">
+    <InvalidArgument occurrences="2"/>
+  </file>
+  <file src="src/Service/CloudFront/src/Result/CreateInvalidationResult.php">
+    <InvalidArgument occurrences="1"/>
   </file>
   <file src="src/Service/CognitoIdentityProvider/src/Result/AdminCreateUserResponse.php">
     <InvalidArgument occurrences="1"/>
@@ -74,6 +80,15 @@
   <file src="src/Service/DynamoDb/src/Result/UpdateTableOutput.php">
     <InvalidArgument occurrences="6"/>
   </file>
+  <file src="src/Service/Iam/src/Result/CreateUserResponse.php">
+    <InvalidArgument occurrences="1"/>
+  </file>
+  <file src="src/Service/Iam/src/Result/GetUserResponse.php">
+    <InvalidArgument occurrences="1"/>
+  </file>
+  <file src="src/Service/Iam/src/Result/ListUsersResponse.php">
+    <InvalidArgument occurrences="1"/>
+  </file>
   <file src="src/Service/Lambda/src/Result/ListLayerVersionsResponse.php">
     <InvalidArgument occurrences="1"/>
   </file>
@@ -84,6 +99,6 @@
     <InvalidArgument occurrences="2"/>
   </file>
   <file src="src/Service/Sqs/src/Result/ReceiveMessageResult.php">
-    <InvalidArgument occurrences="1"/>
+    <InvalidArgument occurrences="2"/>
   </file>
 </files>

--- a/src/CodeGenerator/src/Generator/ResponseParser/ParserProvider.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/ParserProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AsyncAws\CodeGenerator\Generator\ResponseParser;
 
 use AsyncAws\CodeGenerator\Definition\ServiceDefinition;
+use AsyncAws\CodeGenerator\Generator\CodeGenerator\TypeGenerator;
 use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
 
 /**
@@ -21,9 +22,15 @@ class ParserProvider
      */
     private $namespaceRegistry;
 
-    public function __construct(NamespaceRegistry $namespaceRegistry)
+    /**
+     * @var TypeGenerator
+     */
+    private $typeGenerator;
+
+    public function __construct(NamespaceRegistry $namespaceRegistry, TypeGenerator $typeGenerator)
     {
         $this->namespaceRegistry = $namespaceRegistry;
+        $this->typeGenerator = $typeGenerator;
     }
 
     public function get(ServiceDefinition $definition): Parser
@@ -31,11 +38,11 @@ class ParserProvider
         switch ($definition->getProtocol()) {
             case 'query':
             case 'rest-xml':
-                return new RestXmlParser($this->namespaceRegistry);
+                return new RestXmlParser($this->namespaceRegistry, $this->typeGenerator);
             case 'rest-json':
-                return new RestJsonParser($this->namespaceRegistry);
+                return new RestJsonParser($this->namespaceRegistry, $this->typeGenerator);
             case 'json':
-                return new JsonRpcParser($this->namespaceRegistry);
+                return new JsonRpcParser($this->namespaceRegistry, $this->typeGenerator);
             default:
                 throw new \LogicException(sprintf('Parser for "%s" is not implemented yet', $definition->getProtocol()));
         }

--- a/src/CodeGenerator/src/Generator/ResponseParser/ParserResult.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/ParserResult.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Generator\ResponseParser;
 
+use Nette\PhpGenerator\Method;
+
 /**
  * @internal
  */
@@ -18,10 +20,16 @@ class ParserResult
      */
     private $usedClasses;
 
-    public function __construct(string $body, array $usedClasses)
+    /**
+     * @var Method[]
+     */
+    private $extraMethods;
+
+    public function __construct(string $body, array $usedClasses = [], array $extraMethods = [])
     {
         $this->body = $body;
         $this->usedClasses = $usedClasses;
+        $this->extraMethods = $extraMethods;
     }
 
     public function getBody(): string
@@ -32,5 +40,10 @@ class ParserResult
     public function getUsedClasses(): array
     {
         return $this->usedClasses;
+    }
+
+    public function getExtraMethods(): array
+    {
+        return $this->extraMethods;
     }
 }

--- a/src/CodeGenerator/src/Generator/ResponseParser/ParserResult.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/ParserResult.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Generator\ResponseParser;
 
+use AsyncAws\CodeGenerator\Generator\Naming\ClassName;
 use Nette\PhpGenerator\Method;
 
 /**
@@ -16,7 +17,7 @@ class ParserResult
     /**
      * Classes to import.
      *
-     * @var array<string>
+     * @var ClassName[]
      */
     private $usedClasses;
 

--- a/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
@@ -11,6 +11,8 @@ use AsyncAws\CodeGenerator\Definition\Shape;
 use AsyncAws\CodeGenerator\Definition\StructureMember;
 use AsyncAws\CodeGenerator\Definition\StructureShape;
 use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
+use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\Method;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
@@ -36,7 +38,7 @@ class RestJsonParser implements Parser
     public function generate(StructureShape $shape): ParserResult
     {
         if (null !== $payloadProperty = $shape->getPayload()) {
-            return new ParserResult(strtr('$this->PROPERTY_NAME = $response->getContent();', ['PROPERTY_NAME' => $payloadProperty]), []);
+            return new ParserResult(strtr('$this->PROPERTY_NAME = $response->getContent();', ['PROPERTY_NAME' => $payloadProperty]));
         }
 
         $properties = [];
@@ -54,20 +56,16 @@ class RestJsonParser implements Parser
         }
 
         if (empty($properties)) {
-            return new ParserResult('', $this->imports);
+            return new ParserResult('');
         }
 
         $body = '$data = $response->toArray();' . "\n";
         if (null !== $wrapper = $shape->getResultWrapper()) {
             $body .= strtr('$data = $data[WRAPPER];' . "\n", ['WRAPPER' => var_export($wrapper, true)]);
         }
-        $functions = array_filter($this->functions, 'is_string');
-        if (!empty($functions)) {
-            $body .= '$fn = [];' . \implode("\n", $functions);
-        }
         $body .= "\n" . implode("\n", $properties);
 
-        return new ParserResult($body, $this->imports);
+        return new ParserResult($body, $this->imports, $this->functions);
     }
 
     protected function parseResponseTimestamp(Shape $shape, string $input, bool $required): string
@@ -204,24 +202,23 @@ class RestJsonParser implements Parser
     private function parseResponseList(ListShape $shape, string $input, bool $required): string
     {
         $shapeMember = $shape->getMember();
-        $keyName = 'list-' . $shape->getName();
-        if (!isset($this->functions[$keyName])) {
+        $functionName = 'populateResult' . \ucfirst($shape->getName());
+        if (!isset($this->functions[$functionName])) {
             // prevent recursion
-            $this->functions[$keyName] = true;
+            $this->functions[$functionName] = true;
 
             if ($shapeMember->getShape() instanceof StructureShape) {
                 $listAccessorRequired = true;
-                $body = '$fn[FUNCTION_KEY] = static function(array $json) use (&$fn): array {
+                $body = '
                     $items = [];
                     foreach (INPUT_PROPERTY as $item) {
                        $items[] = LIST_ACCESSOR;
                     }
 
-                    return $items;
-                };';
+                    return $items;';
             } else {
                 $listAccessorRequired = false;
-                $body = '$fn[FUNCTION_KEY] = static function(array $json) use (&$fn): array {
+                $body = '
                     $items = [];
                     foreach (INPUT_PROPERTY as $item) {
                         $a = LIST_ACCESSOR;
@@ -230,84 +227,71 @@ class RestJsonParser implements Parser
                         }
                     }
 
-                    return $items;
-                };';
+                    return $items;';
             }
 
-            $this->functions[$keyName] = strtr($body, [
-                'FUNCTION_KEY' => \var_export($keyName, true),
+            $this->functions[$functionName] = $this->createPopulateMethod($functionName, strtr($body, [
                 'LIST_ACCESSOR' => $this->parseElement('$item', $shapeMember->getShape(), $listAccessorRequired),
                 'INPUT_PROPERTY' => $shape->isFlattened() ? '$json' : '$json' . ($shapeMember->getLocationName() ? '->' . $shapeMember->getLocationName() : ''),
-            ]);
+            ]));
         }
 
-        return strtr($required ? '$fn[FUNCTION_KEY](INPUT)' : 'empty(INPUT) ? [] : $fn[FUNCTION_KEY](INPUT)', [
+        return strtr($required ? '$this->FUNCTION_NAME(INPUT)' : 'empty(INPUT) ? [] : $this->FUNCTION_NAME(INPUT)', [
             'INPUT' => $input,
-            'FUNCTION_KEY' => \var_export($keyName, true),
+            'FUNCTION_NAME' => $functionName,
         ]);
     }
 
     private function parseResponseMap(MapShape $shape, string $input, bool $required): string
     {
         $shapeValue = $shape->getValue();
-        $keyName = 'map-' . $shape->getName();
-        if (!isset($this->functions[$keyName])) {
+        $functionName = 'populateResult' . \ucfirst($shape->getName());
+        if (!isset($this->functions[$functionName])) {
             // prevent recursion
-            $this->functions[$keyName] = true;
+            $this->functions[$functionName] = true;
 
             if (null === $locationName = $shape->getKey()->getLocationName()) {
                 // We need to use array keys
                 if ($shapeValue->getShape() instanceof StructureShape) {
                     $body = '
-                    /** @return array<string, \FQDN> */
-                    $fn[FUNCTION_KEY] = static function(array $json): array {
                         $items = [];
                         foreach ($json as $name => $value) {
                            $items[(string) $name] = CLASS::create($value);
                         }
 
                         return $items;
-                    };';
+                    ';
 
-                    $classFqdn = $this->namespaceRegistry->getObject($shape->getValue()->getShape())->getFqdn();
-                    $this->functions[$keyName] = strtr($body, [
-                        'FUNCTION_KEY' => \var_export($keyName, true),
+                    $this->functions[$functionName] = $this->createPopulateMethod($functionName, strtr($body, [
                         'CLASS' => $shape->getValue()->getShape()->getName(),
-                        'FQDN' => $classFqdn,
-                    ]);
-                    // add CLASS to imports
-                    $this->imports[] = $classFqdn;
+                    ]));
                 } else {
-                    $body = '(function(array $json) use (&$fn): array {
-                $items = [];
-                foreach ($json as $name => $value) {
-                   $items[(string) $name] = CODE;
-                }
+                    $body = '
+                        $items = [];
+                        foreach ($json as $name => $value) {
+                           $items[(string) $name] = CODE;
+                        }
 
-                return $items;
-            })(INPUT)';
-                    if (!$required) {
-                        $body = 'empty(INPUT) ? [] : ' . $body;
-                    }
+                        return $items;
+                    ';
 
-                    return strtr($body, [
-                        'INPUT' => $input,
+                    $this->functions[$functionName] = $this->createPopulateMethod($functionName, strtr($body, [
                         'CODE' => $this->parseElement('$value', $shapeValue->getShape(), true),
-                    ]);
+                    ]));
                 }
             } else {
                 $inputAccessorName = $this->getInputAccessorName($shapeValue);
                 if ($shapeValue->getShape() instanceof StructureShape) {
-                    $body = '$fn[FUNCTION_KEY] = static function(array $json) use (&$fn): array {
+                    $body = '
                         $items = [];
                         foreach ($json as $item) {
                             $items[$item[MAP_KEY]] = MAP_ACCESSOR;
                         }
 
                         return $items;
-                    };';
+                    ';
                 } else {
-                    $body = '$fn[FUNCTION_KEY] = function(array $json) use (&$fn): array {
+                    $body = '
                         $items = [];
                         foreach ($json as $item) {
                             $a = MAP_ACCESSOR;
@@ -317,20 +301,32 @@ class RestJsonParser implements Parser
                         }
 
                         return $items;
-                    };';
+                    ';
                 }
 
-                $this->functions[$keyName] = strtr($body, [
-                    'FUNCTION_KEY' => \var_export($keyName, true),
+                $this->functions[$functionName] = $this->createPopulateMethod($functionName, strtr($body, [
                     'MAP_KEY' => var_export($locationName, true),
                     'MAP_ACCESSOR' => $this->parseElement(sprintf('$item[\'%s\']', $inputAccessorName), $shapeValue->getShape(), false),
-                ]);
+                ]));
             }
         }
 
-        return strtr($required ? '$fn[FUNCTION_KEY](INPUT)' : 'empty(INPUT) ? [] : $fn[FUNCTION_KEY](INPUT)', [
+        return strtr($required ? '$this->FUNCTION_NAME(INPUT)' : 'empty(INPUT) ? [] : $this->FUNCTION_NAME(INPUT)', [
             'INPUT' => $input,
-            'FUNCTION_KEY' => \var_export($keyName, true),
+            'FUNCTION_NAME' => $functionName,
         ]);
+    }
+
+    private function createPopulateMethod(string $functionName, string $body): Method
+    {
+        $method = new Method($functionName);
+        $method->setVisibility(ClassType::VISIBILITY_PRIVATE)
+            ->setReturnType('array')
+            ->setBody($body)
+            ->addParameter('json')
+            ->setType('array')
+        ;
+
+        return $method;
     }
 }

--- a/src/CodeGenerator/src/Generator/ResponseParser/RestXmlParser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/RestXmlParser.php
@@ -263,33 +263,23 @@ class RestXmlParser implements Parser
         }
 
         $shapeValue = $shape->getValue();
-        if ($shapeValue->getShape() instanceof StructureShape) {
-            $body = '
-                $items = [];
-                foreach ($xml as $item) {
-                    $items[$item->MAP_KEY->__toString()] = MAP_ACCESSOR;
+        $body = '
+            $items = [];
+            foreach ($xml as $item) {
+                if (null === $a = VALUE) {
+                    continue;
                 }
+                $items[$item->MAP_KEY->__toString()] = MAP_ACCESSOR;
+            }
 
-                return $items;
-            ';
-        } else {
-            $body = '
-                $items = [];
-                foreach ($xml as $item) {
-                    $a = MAP_ACCESSOR;
-                    if (null !== $a) {
-                        $items[$item->MAP_KEY->__toString()] = $a;
-                    }
-                }
-
-                return $items;
-            ';
-        }
+            return $items;
+        ';
 
         $functionName = 'populateResult' . \ucfirst($shape->getName());
         $this->functions[$functionName] = $this->createPopulateMethod($functionName, strtr($body, [
             'MAP_KEY' => $locationName,
-            'MAP_ACCESSOR' => $this->parseXmlElement($this->getInputAccessor('$item', $shapeValue), $shapeValue->getShape(), true),
+            'VALUE' => $this->getInputAccessor('$item', $shapeValue),
+            'MAP_ACCESSOR' => $this->parseXmlElement('$a', $shapeValue->getShape(), true),
         ]), $shape);
 
         return strtr($required ? '$this->FUNCTION_NAME(INPUT)' : '!INPUT ? [] : $this->FUNCTION_NAME(INPUT)', [

--- a/src/CodeGenerator/src/Generator/ResponseParser/RestXmlParser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/RestXmlParser.php
@@ -52,7 +52,7 @@ class RestXmlParser implements Parser
         }
 
         if (empty($properties)) {
-            return new ParserResult('', []);
+            return new ParserResult('');
         }
 
         $body = '$data = new \SimpleXMLElement($response->getContent());';
@@ -61,7 +61,7 @@ class RestXmlParser implements Parser
         }
         $body .= "\n" . implode("\n", $properties);
 
-        return new ParserResult($body, []);
+        return new ParserResult($body);
     }
 
     private function getInputAccessor(string $currentInput, Member $member)

--- a/src/CodeGenerator/src/Generator/ResultGenerator.php
+++ b/src/CodeGenerator/src/Generator/ResultGenerator.php
@@ -79,7 +79,7 @@ class ResultGenerator
         $this->fileWriter = $fileWriter;
         $this->typeGenerator = $typeGenerator ?? new TypeGenerator($this->namespaceRegistry);
         $this->enumGenerator = $enumGenerator ?? new EnumGenerator($this->namespaceRegistry, $fileWriter);
-        $this->parserProvider = new ParserProvider($this->namespaceRegistry);
+        $this->parserProvider = new ParserProvider($this->namespaceRegistry, $this->typeGenerator);
         $this->objectGenerator = $objectGenerator;
     }
 
@@ -285,8 +285,8 @@ class ResultGenerator
         } else {
             $parserResult = $this->parserProvider->get($this->operation->getService())->generate($shape);
             $body .= $parserResult->getBody();
-            foreach ($parserResult->getUsedClasses() as $import) {
-                $namespace->addUse($import);
+            foreach ($parserResult->getUsedClasses() as $className) {
+                $namespace->addUse($className->getFqdn());
             }
             $class->setMethods($parserResult->getExtraMethods());
         }

--- a/src/CodeGenerator/src/Generator/ResultGenerator.php
+++ b/src/CodeGenerator/src/Generator/ResultGenerator.php
@@ -288,6 +288,7 @@ class ResultGenerator
             foreach ($parserResult->getUsedClasses() as $import) {
                 $namespace->addUse($import);
             }
+            $class->setMethods($parserResult->getExtraMethods());
         }
 
         $namespace->addUse(Response::class);

--- a/src/Service/CloudFormation/src/Result/DescribeStackEventsOutput.php
+++ b/src/Service/CloudFormation/src/Result/DescribeStackEventsOutput.php
@@ -119,6 +119,9 @@ class DescribeStackEventsOutput extends Result implements \IteratorAggregate
         $this->NextToken = ($v = $data->NextToken) ? (string) $v : null;
     }
 
+    /**
+     * @return StackEvent[]
+     */
     private function populateResultStackEvents(\SimpleXMLElement $xml): array
     {
         $items = [];

--- a/src/Service/CloudFormation/src/Result/DescribeStackEventsOutput.php
+++ b/src/Service/CloudFormation/src/Result/DescribeStackEventsOutput.php
@@ -115,26 +115,29 @@ class DescribeStackEventsOutput extends Result implements \IteratorAggregate
         $data = new \SimpleXMLElement($response->getContent());
         $data = $data->DescribeStackEventsResult;
 
-        $this->StackEvents = !$data->StackEvents ? [] : (function (\SimpleXMLElement $xml): array {
-            $items = [];
-            foreach ($xml->member as $item) {
-                $items[] = new StackEvent([
-                    'StackId' => (string) $item->StackId,
-                    'EventId' => (string) $item->EventId,
-                    'StackName' => (string) $item->StackName,
-                    'LogicalResourceId' => ($v = $item->LogicalResourceId) ? (string) $v : null,
-                    'PhysicalResourceId' => ($v = $item->PhysicalResourceId) ? (string) $v : null,
-                    'ResourceType' => ($v = $item->ResourceType) ? (string) $v : null,
-                    'Timestamp' => new \DateTimeImmutable((string) $item->Timestamp),
-                    'ResourceStatus' => ($v = $item->ResourceStatus) ? (string) $v : null,
-                    'ResourceStatusReason' => ($v = $item->ResourceStatusReason) ? (string) $v : null,
-                    'ResourceProperties' => ($v = $item->ResourceProperties) ? (string) $v : null,
-                    'ClientRequestToken' => ($v = $item->ClientRequestToken) ? (string) $v : null,
-                ]);
-            }
-
-            return $items;
-        })($data->StackEvents);
+        $this->StackEvents = !$data->StackEvents ? [] : $this->populateResultStackEvents($data->StackEvents);
         $this->NextToken = ($v = $data->NextToken) ? (string) $v : null;
+    }
+
+    private function populateResultStackEvents(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml->member as $item) {
+            $items[] = new StackEvent([
+                'StackId' => (string) $item->StackId,
+                'EventId' => (string) $item->EventId,
+                'StackName' => (string) $item->StackName,
+                'LogicalResourceId' => ($v = $item->LogicalResourceId) ? (string) $v : null,
+                'PhysicalResourceId' => ($v = $item->PhysicalResourceId) ? (string) $v : null,
+                'ResourceType' => ($v = $item->ResourceType) ? (string) $v : null,
+                'Timestamp' => new \DateTimeImmutable((string) $item->Timestamp),
+                'ResourceStatus' => ($v = $item->ResourceStatus) ? (string) $v : null,
+                'ResourceStatusReason' => ($v = $item->ResourceStatusReason) ? (string) $v : null,
+                'ResourceProperties' => ($v = $item->ResourceProperties) ? (string) $v : null,
+                'ClientRequestToken' => ($v = $item->ClientRequestToken) ? (string) $v : null,
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/CloudFormation/src/Result/DescribeStacksOutput.php
+++ b/src/Service/CloudFormation/src/Result/DescribeStacksOutput.php
@@ -121,107 +121,128 @@ class DescribeStacksOutput extends Result implements \IteratorAggregate
         $data = new \SimpleXMLElement($response->getContent());
         $data = $data->DescribeStacksResult;
 
-        $this->Stacks = !$data->Stacks ? [] : (function (\SimpleXMLElement $xml): array {
-            $items = [];
-            foreach ($xml->member as $item) {
-                $items[] = new Stack([
-                    'StackId' => ($v = $item->StackId) ? (string) $v : null,
-                    'StackName' => (string) $item->StackName,
-                    'ChangeSetId' => ($v = $item->ChangeSetId) ? (string) $v : null,
-                    'Description' => ($v = $item->Description) ? (string) $v : null,
-                    'Parameters' => !$item->Parameters ? [] : (function (\SimpleXMLElement $xml): array {
-                        $items = [];
-                        foreach ($xml->member as $item) {
-                            $items[] = new Parameter([
-                                'ParameterKey' => ($v = $item->ParameterKey) ? (string) $v : null,
-                                'ParameterValue' => ($v = $item->ParameterValue) ? (string) $v : null,
-                                'UsePreviousValue' => ($v = $item->UsePreviousValue) ? filter_var((string) $v, \FILTER_VALIDATE_BOOLEAN) : null,
-                                'ResolvedValue' => ($v = $item->ResolvedValue) ? (string) $v : null,
-                            ]);
-                        }
-
-                        return $items;
-                    })($item->Parameters),
-                    'CreationTime' => new \DateTimeImmutable((string) $item->CreationTime),
-                    'DeletionTime' => ($v = $item->DeletionTime) ? new \DateTimeImmutable((string) $v) : null,
-                    'LastUpdatedTime' => ($v = $item->LastUpdatedTime) ? new \DateTimeImmutable((string) $v) : null,
-                    'RollbackConfiguration' => !$item->RollbackConfiguration ? null : new RollbackConfiguration([
-                        'RollbackTriggers' => !$item->RollbackConfiguration->RollbackTriggers ? [] : (function (\SimpleXMLElement $xml): array {
-                            $items = [];
-                            foreach ($xml->member as $item) {
-                                $items[] = new RollbackTrigger([
-                                    'Arn' => (string) $item->Arn,
-                                    'Type' => (string) $item->Type,
-                                ]);
-                            }
-
-                            return $items;
-                        })($item->RollbackConfiguration->RollbackTriggers),
-                        'MonitoringTimeInMinutes' => ($v = $item->RollbackConfiguration->MonitoringTimeInMinutes) ? (int) (string) $v : null,
-                    ]),
-                    'StackStatus' => (string) $item->StackStatus,
-                    'StackStatusReason' => ($v = $item->StackStatusReason) ? (string) $v : null,
-                    'DisableRollback' => ($v = $item->DisableRollback) ? filter_var((string) $v, \FILTER_VALIDATE_BOOLEAN) : null,
-                    'NotificationARNs' => !$item->NotificationARNs ? [] : (function (\SimpleXMLElement $xml): array {
-                        $items = [];
-                        foreach ($xml->member as $item) {
-                            $a = ($v = $item) ? (string) $v : null;
-                            if (null !== $a) {
-                                $items[] = $a;
-                            }
-                        }
-
-                        return $items;
-                    })($item->NotificationARNs),
-                    'TimeoutInMinutes' => ($v = $item->TimeoutInMinutes) ? (int) (string) $v : null,
-                    'Capabilities' => !$item->Capabilities ? [] : (function (\SimpleXMLElement $xml): array {
-                        $items = [];
-                        foreach ($xml->member as $item) {
-                            $a = ($v = $item) ? (string) $v : null;
-                            if (null !== $a) {
-                                $items[] = $a;
-                            }
-                        }
-
-                        return $items;
-                    })($item->Capabilities),
-                    'Outputs' => !$item->Outputs ? [] : (function (\SimpleXMLElement $xml): array {
-                        $items = [];
-                        foreach ($xml->member as $item) {
-                            $items[] = new Output([
-                                'OutputKey' => ($v = $item->OutputKey) ? (string) $v : null,
-                                'OutputValue' => ($v = $item->OutputValue) ? (string) $v : null,
-                                'Description' => ($v = $item->Description) ? (string) $v : null,
-                                'ExportName' => ($v = $item->ExportName) ? (string) $v : null,
-                            ]);
-                        }
-
-                        return $items;
-                    })($item->Outputs),
-                    'RoleARN' => ($v = $item->RoleARN) ? (string) $v : null,
-                    'Tags' => !$item->Tags ? [] : (function (\SimpleXMLElement $xml): array {
-                        $items = [];
-                        foreach ($xml->member as $item) {
-                            $items[] = new Tag([
-                                'Key' => (string) $item->Key,
-                                'Value' => (string) $item->Value,
-                            ]);
-                        }
-
-                        return $items;
-                    })($item->Tags),
-                    'EnableTerminationProtection' => ($v = $item->EnableTerminationProtection) ? filter_var((string) $v, \FILTER_VALIDATE_BOOLEAN) : null,
-                    'ParentId' => ($v = $item->ParentId) ? (string) $v : null,
-                    'RootId' => ($v = $item->RootId) ? (string) $v : null,
-                    'DriftInformation' => !$item->DriftInformation ? null : new StackDriftInformation([
-                        'StackDriftStatus' => (string) $item->DriftInformation->StackDriftStatus,
-                        'LastCheckTimestamp' => ($v = $item->DriftInformation->LastCheckTimestamp) ? new \DateTimeImmutable((string) $v) : null,
-                    ]),
-                ]);
-            }
-
-            return $items;
-        })($data->Stacks);
+        $this->Stacks = !$data->Stacks ? [] : $this->populateResultStacks($data->Stacks);
         $this->NextToken = ($v = $data->NextToken) ? (string) $v : null;
+    }
+
+    private function populateResultCapabilities(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml->member as $item) {
+            $a = ($v = $item) ? (string) $v : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultNotificationARNs(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml->member as $item) {
+            $a = ($v = $item) ? (string) $v : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultOutputs(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml->member as $item) {
+            $items[] = new Output([
+                'OutputKey' => ($v = $item->OutputKey) ? (string) $v : null,
+                'OutputValue' => ($v = $item->OutputValue) ? (string) $v : null,
+                'Description' => ($v = $item->Description) ? (string) $v : null,
+                'ExportName' => ($v = $item->ExportName) ? (string) $v : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultParameters(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml->member as $item) {
+            $items[] = new Parameter([
+                'ParameterKey' => ($v = $item->ParameterKey) ? (string) $v : null,
+                'ParameterValue' => ($v = $item->ParameterValue) ? (string) $v : null,
+                'UsePreviousValue' => ($v = $item->UsePreviousValue) ? filter_var((string) $v, \FILTER_VALIDATE_BOOLEAN) : null,
+                'ResolvedValue' => ($v = $item->ResolvedValue) ? (string) $v : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultRollbackTriggers(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml->member as $item) {
+            $items[] = new RollbackTrigger([
+                'Arn' => (string) $item->Arn,
+                'Type' => (string) $item->Type,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultStacks(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml->member as $item) {
+            $items[] = new Stack([
+                'StackId' => ($v = $item->StackId) ? (string) $v : null,
+                'StackName' => (string) $item->StackName,
+                'ChangeSetId' => ($v = $item->ChangeSetId) ? (string) $v : null,
+                'Description' => ($v = $item->Description) ? (string) $v : null,
+                'Parameters' => !$item->Parameters ? [] : $this->populateResultParameters($item->Parameters),
+                'CreationTime' => new \DateTimeImmutable((string) $item->CreationTime),
+                'DeletionTime' => ($v = $item->DeletionTime) ? new \DateTimeImmutable((string) $v) : null,
+                'LastUpdatedTime' => ($v = $item->LastUpdatedTime) ? new \DateTimeImmutable((string) $v) : null,
+                'RollbackConfiguration' => !$item->RollbackConfiguration ? null : new RollbackConfiguration([
+                    'RollbackTriggers' => !$item->RollbackConfiguration->RollbackTriggers ? [] : $this->populateResultRollbackTriggers($item->RollbackConfiguration->RollbackTriggers),
+                    'MonitoringTimeInMinutes' => ($v = $item->RollbackConfiguration->MonitoringTimeInMinutes) ? (int) (string) $v : null,
+                ]),
+                'StackStatus' => (string) $item->StackStatus,
+                'StackStatusReason' => ($v = $item->StackStatusReason) ? (string) $v : null,
+                'DisableRollback' => ($v = $item->DisableRollback) ? filter_var((string) $v, \FILTER_VALIDATE_BOOLEAN) : null,
+                'NotificationARNs' => !$item->NotificationARNs ? [] : $this->populateResultNotificationARNs($item->NotificationARNs),
+                'TimeoutInMinutes' => ($v = $item->TimeoutInMinutes) ? (int) (string) $v : null,
+                'Capabilities' => !$item->Capabilities ? [] : $this->populateResultCapabilities($item->Capabilities),
+                'Outputs' => !$item->Outputs ? [] : $this->populateResultOutputs($item->Outputs),
+                'RoleARN' => ($v = $item->RoleARN) ? (string) $v : null,
+                'Tags' => !$item->Tags ? [] : $this->populateResultTags($item->Tags),
+                'EnableTerminationProtection' => ($v = $item->EnableTerminationProtection) ? filter_var((string) $v, \FILTER_VALIDATE_BOOLEAN) : null,
+                'ParentId' => ($v = $item->ParentId) ? (string) $v : null,
+                'RootId' => ($v = $item->RootId) ? (string) $v : null,
+                'DriftInformation' => !$item->DriftInformation ? null : new StackDriftInformation([
+                    'StackDriftStatus' => (string) $item->DriftInformation->StackDriftStatus,
+                    'LastCheckTimestamp' => ($v = $item->DriftInformation->LastCheckTimestamp) ? new \DateTimeImmutable((string) $v) : null,
+                ]),
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultTags(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml->member as $item) {
+            $items[] = new Tag([
+                'Key' => (string) $item->Key,
+                'Value' => (string) $item->Value,
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/CloudFormation/src/Result/DescribeStacksOutput.php
+++ b/src/Service/CloudFormation/src/Result/DescribeStacksOutput.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\CloudFormation\Result;
 
 use AsyncAws\CloudFormation\CloudFormationClient;
+use AsyncAws\CloudFormation\Enum\Capability;
 use AsyncAws\CloudFormation\Input\DescribeStacksInput;
 use AsyncAws\CloudFormation\ValueObject\Output;
 use AsyncAws\CloudFormation\ValueObject\Parameter;
@@ -125,6 +126,9 @@ class DescribeStacksOutput extends Result implements \IteratorAggregate
         $this->NextToken = ($v = $data->NextToken) ? (string) $v : null;
     }
 
+    /**
+     * @return list<Capability::*>
+     */
     private function populateResultCapabilities(\SimpleXMLElement $xml): array
     {
         $items = [];
@@ -138,6 +142,9 @@ class DescribeStacksOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return string[]
+     */
     private function populateResultNotificationARNs(\SimpleXMLElement $xml): array
     {
         $items = [];
@@ -151,6 +158,9 @@ class DescribeStacksOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return Output[]
+     */
     private function populateResultOutputs(\SimpleXMLElement $xml): array
     {
         $items = [];
@@ -166,6 +176,9 @@ class DescribeStacksOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return Parameter[]
+     */
     private function populateResultParameters(\SimpleXMLElement $xml): array
     {
         $items = [];
@@ -181,6 +194,9 @@ class DescribeStacksOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return RollbackTrigger[]
+     */
     private function populateResultRollbackTriggers(\SimpleXMLElement $xml): array
     {
         $items = [];
@@ -194,6 +210,9 @@ class DescribeStacksOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return Stack[]
+     */
     private function populateResultStacks(\SimpleXMLElement $xml): array
     {
         $items = [];
@@ -233,6 +252,9 @@ class DescribeStacksOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return Tag[]
+     */
     private function populateResultTags(\SimpleXMLElement $xml): array
     {
         $items = [];

--- a/src/Service/CloudFront/src/Result/CreateInvalidationResult.php
+++ b/src/Service/CloudFront/src/Result/CreateInvalidationResult.php
@@ -55,6 +55,9 @@ class CreateInvalidationResult extends Result
         ]);
     }
 
+    /**
+     * @return string[]
+     */
     private function populateResultPathList(\SimpleXMLElement $xml): array
     {
         $items = [];

--- a/src/Service/CloudFront/src/Result/CreateInvalidationResult.php
+++ b/src/Service/CloudFront/src/Result/CreateInvalidationResult.php
@@ -48,20 +48,23 @@ class CreateInvalidationResult extends Result
             'InvalidationBatch' => new InvalidationBatch([
                 'Paths' => new Paths([
                     'Quantity' => (int) (string) $data->InvalidationBatch->Paths->Quantity,
-                    'Items' => !$data->InvalidationBatch->Paths->Items ? [] : (function (\SimpleXMLElement $xml): array {
-                        $items = [];
-                        foreach ($xml->Path as $item) {
-                            $a = ($v = $item) ? (string) $v : null;
-                            if (null !== $a) {
-                                $items[] = $a;
-                            }
-                        }
-
-                        return $items;
-                    })($data->InvalidationBatch->Paths->Items),
+                    'Items' => !$data->InvalidationBatch->Paths->Items ? [] : $this->populateResultPathList($data->InvalidationBatch->Paths->Items),
                 ]),
                 'CallerReference' => (string) $data->InvalidationBatch->CallerReference,
             ]),
         ]);
+    }
+
+    private function populateResultPathList(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml->Path as $item) {
+            $a = ($v = $item) ? (string) $v : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
     }
 }

--- a/src/Service/CloudWatchLogs/src/Result/DescribeLogStreamsResponse.php
+++ b/src/Service/CloudWatchLogs/src/Result/DescribeLogStreamsResponse.php
@@ -109,25 +109,27 @@ class DescribeLogStreamsResponse extends Result implements \IteratorAggregate
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-LogStreams'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new LogStream([
-                    'logStreamName' => isset($item['logStreamName']) ? (string) $item['logStreamName'] : null,
-                    'creationTime' => isset($item['creationTime']) ? (string) $item['creationTime'] : null,
-                    'firstEventTimestamp' => isset($item['firstEventTimestamp']) ? (string) $item['firstEventTimestamp'] : null,
-                    'lastEventTimestamp' => isset($item['lastEventTimestamp']) ? (string) $item['lastEventTimestamp'] : null,
-                    'lastIngestionTime' => isset($item['lastIngestionTime']) ? (string) $item['lastIngestionTime'] : null,
-                    'uploadSequenceToken' => isset($item['uploadSequenceToken']) ? (string) $item['uploadSequenceToken'] : null,
-                    'arn' => isset($item['arn']) ? (string) $item['arn'] : null,
-                    'storedBytes' => isset($item['storedBytes']) ? (string) $item['storedBytes'] : null,
-                ]);
-            }
 
-            return $items;
-        };
-        $this->logStreams = empty($data['logStreams']) ? [] : $fn['list-LogStreams']($data['logStreams']);
+        $this->logStreams = empty($data['logStreams']) ? [] : $this->populateResultLogStreams($data['logStreams']);
         $this->nextToken = isset($data['nextToken']) ? (string) $data['nextToken'] : null;
+    }
+
+    private function populateResultLogStreams(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new LogStream([
+                'logStreamName' => isset($item['logStreamName']) ? (string) $item['logStreamName'] : null,
+                'creationTime' => isset($item['creationTime']) ? (string) $item['creationTime'] : null,
+                'firstEventTimestamp' => isset($item['firstEventTimestamp']) ? (string) $item['firstEventTimestamp'] : null,
+                'lastEventTimestamp' => isset($item['lastEventTimestamp']) ? (string) $item['lastEventTimestamp'] : null,
+                'lastIngestionTime' => isset($item['lastIngestionTime']) ? (string) $item['lastIngestionTime'] : null,
+                'uploadSequenceToken' => isset($item['uploadSequenceToken']) ? (string) $item['uploadSequenceToken'] : null,
+                'arn' => isset($item['arn']) ? (string) $item['arn'] : null,
+                'storedBytes' => isset($item['storedBytes']) ? (string) $item['storedBytes'] : null,
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/CloudWatchLogs/src/Result/DescribeLogStreamsResponse.php
+++ b/src/Service/CloudWatchLogs/src/Result/DescribeLogStreamsResponse.php
@@ -114,6 +114,9 @@ class DescribeLogStreamsResponse extends Result implements \IteratorAggregate
         $this->nextToken = isset($data['nextToken']) ? (string) $data['nextToken'] : null;
     }
 
+    /**
+     * @return LogStream[]
+     */
     private function populateResultLogStreams(array $json): array
     {
         $items = [];

--- a/src/Service/CognitoIdentityProvider/src/Result/AdminCreateUserResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/AdminCreateUserResponse.php
@@ -37,6 +37,9 @@ class AdminCreateUserResponse extends Result
         ]);
     }
 
+    /**
+     * @return AttributeType[]
+     */
     private function populateResultAttributeListType(array $json): array
     {
         $items = [];
@@ -50,6 +53,9 @@ class AdminCreateUserResponse extends Result
         return $items;
     }
 
+    /**
+     * @return MFAOptionType[]
+     */
     private function populateResultMFAOptionListType(array $json): array
     {
         $items = [];

--- a/src/Service/CognitoIdentityProvider/src/Result/AdminCreateUserResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/AdminCreateUserResponse.php
@@ -25,37 +25,41 @@ class AdminCreateUserResponse extends Result
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-AttributeListType'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new AttributeType([
-                    'Name' => (string) $item['Name'],
-                    'Value' => isset($item['Value']) ? (string) $item['Value'] : null,
-                ]);
-            }
 
-            return $items;
-        };
-        $fn['list-MFAOptionListType'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new MFAOptionType([
-                    'DeliveryMedium' => isset($item['DeliveryMedium']) ? (string) $item['DeliveryMedium'] : null,
-                    'AttributeName' => isset($item['AttributeName']) ? (string) $item['AttributeName'] : null,
-                ]);
-            }
-
-            return $items;
-        };
         $this->User = empty($data['User']) ? null : new UserType([
             'Username' => isset($data['User']['Username']) ? (string) $data['User']['Username'] : null,
-            'Attributes' => empty($data['User']['Attributes']) ? [] : $fn['list-AttributeListType']($data['User']['Attributes']),
+            'Attributes' => empty($data['User']['Attributes']) ? [] : $this->populateResultAttributeListType($data['User']['Attributes']),
             'UserCreateDate' => (isset($data['User']['UserCreateDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $data['User']['UserCreateDate'])))) ? $d : null,
             'UserLastModifiedDate' => (isset($data['User']['UserLastModifiedDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $data['User']['UserLastModifiedDate'])))) ? $d : null,
             'Enabled' => isset($data['User']['Enabled']) ? filter_var($data['User']['Enabled'], \FILTER_VALIDATE_BOOLEAN) : null,
             'UserStatus' => isset($data['User']['UserStatus']) ? (string) $data['User']['UserStatus'] : null,
-            'MFAOptions' => empty($data['User']['MFAOptions']) ? [] : $fn['list-MFAOptionListType']($data['User']['MFAOptions']),
+            'MFAOptions' => empty($data['User']['MFAOptions']) ? [] : $this->populateResultMFAOptionListType($data['User']['MFAOptions']),
         ]);
+    }
+
+    private function populateResultAttributeListType(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new AttributeType([
+                'Name' => (string) $item['Name'],
+                'Value' => isset($item['Value']) ? (string) $item['Value'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultMFAOptionListType(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new MFAOptionType([
+                'DeliveryMedium' => isset($item['DeliveryMedium']) ? (string) $item['DeliveryMedium'] : null,
+                'AttributeName' => isset($item['AttributeName']) ? (string) $item['AttributeName'] : null,
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/CognitoIdentityProvider/src/Result/AdminGetUserResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/AdminGetUserResponse.php
@@ -148,6 +148,9 @@ class AdminGetUserResponse extends Result
         $this->UserMFASettingList = empty($data['UserMFASettingList']) ? [] : $this->populateResultUserMFASettingListType($data['UserMFASettingList']);
     }
 
+    /**
+     * @return AttributeType[]
+     */
     private function populateResultAttributeListType(array $json): array
     {
         $items = [];
@@ -161,6 +164,9 @@ class AdminGetUserResponse extends Result
         return $items;
     }
 
+    /**
+     * @return MFAOptionType[]
+     */
     private function populateResultMFAOptionListType(array $json): array
     {
         $items = [];
@@ -174,6 +180,9 @@ class AdminGetUserResponse extends Result
         return $items;
     }
 
+    /**
+     * @return string[]
+     */
     private function populateResultUserMFASettingListType(array $json): array
     {
         $items = [];

--- a/src/Service/CognitoIdentityProvider/src/Result/AdminGetUserResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/AdminGetUserResponse.php
@@ -136,48 +136,54 @@ class AdminGetUserResponse extends Result
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-AttributeListType'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new AttributeType([
-                    'Name' => (string) $item['Name'],
-                    'Value' => isset($item['Value']) ? (string) $item['Value'] : null,
-                ]);
-            }
 
-            return $items;
-        };
-        $fn['list-MFAOptionListType'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new MFAOptionType([
-                    'DeliveryMedium' => isset($item['DeliveryMedium']) ? (string) $item['DeliveryMedium'] : null,
-                    'AttributeName' => isset($item['AttributeName']) ? (string) $item['AttributeName'] : null,
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-UserMFASettingListType'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (string) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
-
-            return $items;
-        };
         $this->Username = (string) $data['Username'];
-        $this->UserAttributes = empty($data['UserAttributes']) ? [] : $fn['list-AttributeListType']($data['UserAttributes']);
+        $this->UserAttributes = empty($data['UserAttributes']) ? [] : $this->populateResultAttributeListType($data['UserAttributes']);
         $this->UserCreateDate = (isset($data['UserCreateDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $data['UserCreateDate'])))) ? $d : null;
         $this->UserLastModifiedDate = (isset($data['UserLastModifiedDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $data['UserLastModifiedDate'])))) ? $d : null;
         $this->Enabled = isset($data['Enabled']) ? filter_var($data['Enabled'], \FILTER_VALIDATE_BOOLEAN) : null;
         $this->UserStatus = isset($data['UserStatus']) ? (string) $data['UserStatus'] : null;
-        $this->MFAOptions = empty($data['MFAOptions']) ? [] : $fn['list-MFAOptionListType']($data['MFAOptions']);
+        $this->MFAOptions = empty($data['MFAOptions']) ? [] : $this->populateResultMFAOptionListType($data['MFAOptions']);
         $this->PreferredMfaSetting = isset($data['PreferredMfaSetting']) ? (string) $data['PreferredMfaSetting'] : null;
-        $this->UserMFASettingList = empty($data['UserMFASettingList']) ? [] : $fn['list-UserMFASettingListType']($data['UserMFASettingList']);
+        $this->UserMFASettingList = empty($data['UserMFASettingList']) ? [] : $this->populateResultUserMFASettingListType($data['UserMFASettingList']);
+    }
+
+    private function populateResultAttributeListType(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new AttributeType([
+                'Name' => (string) $item['Name'],
+                'Value' => isset($item['Value']) ? (string) $item['Value'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultMFAOptionListType(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new MFAOptionType([
+                'DeliveryMedium' => isset($item['DeliveryMedium']) ? (string) $item['DeliveryMedium'] : null,
+                'AttributeName' => isset($item['AttributeName']) ? (string) $item['AttributeName'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultUserMFASettingListType(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (string) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
     }
 }

--- a/src/Service/CognitoIdentityProvider/src/Result/AdminInitiateAuthResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/AdminInitiateAuthResponse.php
@@ -78,14 +78,7 @@ class AdminInitiateAuthResponse extends Result
 
         $this->ChallengeName = isset($data['ChallengeName']) ? (string) $data['ChallengeName'] : null;
         $this->Session = isset($data['Session']) ? (string) $data['Session'] : null;
-        $this->ChallengeParameters = empty($data['ChallengeParameters']) ? [] : (function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = (string) $value;
-            }
-
-            return $items;
-        })($data['ChallengeParameters']);
+        $this->ChallengeParameters = empty($data['ChallengeParameters']) ? [] : $this->populateResultChallengeParametersType($data['ChallengeParameters']);
         $this->AuthenticationResult = empty($data['AuthenticationResult']) ? null : new AuthenticationResultType([
             'AccessToken' => isset($data['AuthenticationResult']['AccessToken']) ? (string) $data['AuthenticationResult']['AccessToken'] : null,
             'ExpiresIn' => isset($data['AuthenticationResult']['ExpiresIn']) ? (int) $data['AuthenticationResult']['ExpiresIn'] : null,
@@ -97,5 +90,15 @@ class AdminInitiateAuthResponse extends Result
                 'DeviceGroupKey' => isset($data['AuthenticationResult']['NewDeviceMetadata']['DeviceGroupKey']) ? (string) $data['AuthenticationResult']['NewDeviceMetadata']['DeviceGroupKey'] : null,
             ]),
         ]);
+    }
+
+    private function populateResultChallengeParametersType(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = (string) $value;
+        }
+
+        return $items;
     }
 }

--- a/src/Service/CognitoIdentityProvider/src/Result/AdminInitiateAuthResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/AdminInitiateAuthResponse.php
@@ -92,6 +92,9 @@ class AdminInitiateAuthResponse extends Result
         ]);
     }
 
+    /**
+     * @return array<string, string>
+     */
     private function populateResultChallengeParametersType(array $json): array
     {
         $items = [];

--- a/src/Service/CognitoIdentityProvider/src/Result/ListUsersResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/ListUsersResponse.php
@@ -120,6 +120,9 @@ class ListUsersResponse extends Result implements \IteratorAggregate
         $this->PaginationToken = isset($data['PaginationToken']) ? (string) $data['PaginationToken'] : null;
     }
 
+    /**
+     * @return AttributeType[]
+     */
     private function populateResultAttributeListType(array $json): array
     {
         $items = [];
@@ -133,6 +136,9 @@ class ListUsersResponse extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return MFAOptionType[]
+     */
     private function populateResultMFAOptionListType(array $json): array
     {
         $items = [];
@@ -146,6 +152,9 @@ class ListUsersResponse extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return UserType[]
+     */
     private function populateResultUsersListType(array $json): array
     {
         $items = [];

--- a/src/Service/CognitoIdentityProvider/src/Result/ListUsersResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/ListUsersResponse.php
@@ -115,46 +115,52 @@ class ListUsersResponse extends Result implements \IteratorAggregate
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-UsersListType'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new UserType([
-                    'Username' => isset($item['Username']) ? (string) $item['Username'] : null,
-                    'Attributes' => empty($item['Attributes']) ? [] : $fn['list-AttributeListType']($item['Attributes']),
-                    'UserCreateDate' => (isset($item['UserCreateDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['UserCreateDate'])))) ? $d : null,
-                    'UserLastModifiedDate' => (isset($item['UserLastModifiedDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['UserLastModifiedDate'])))) ? $d : null,
-                    'Enabled' => isset($item['Enabled']) ? filter_var($item['Enabled'], \FILTER_VALIDATE_BOOLEAN) : null,
-                    'UserStatus' => isset($item['UserStatus']) ? (string) $item['UserStatus'] : null,
-                    'MFAOptions' => empty($item['MFAOptions']) ? [] : $fn['list-MFAOptionListType']($item['MFAOptions']),
-                ]);
-            }
 
-            return $items;
-        };
-        $fn['list-AttributeListType'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new AttributeType([
-                    'Name' => (string) $item['Name'],
-                    'Value' => isset($item['Value']) ? (string) $item['Value'] : null,
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-MFAOptionListType'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new MFAOptionType([
-                    'DeliveryMedium' => isset($item['DeliveryMedium']) ? (string) $item['DeliveryMedium'] : null,
-                    'AttributeName' => isset($item['AttributeName']) ? (string) $item['AttributeName'] : null,
-                ]);
-            }
-
-            return $items;
-        };
-        $this->Users = empty($data['Users']) ? [] : $fn['list-UsersListType']($data['Users']);
+        $this->Users = empty($data['Users']) ? [] : $this->populateResultUsersListType($data['Users']);
         $this->PaginationToken = isset($data['PaginationToken']) ? (string) $data['PaginationToken'] : null;
+    }
+
+    private function populateResultAttributeListType(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new AttributeType([
+                'Name' => (string) $item['Name'],
+                'Value' => isset($item['Value']) ? (string) $item['Value'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultMFAOptionListType(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new MFAOptionType([
+                'DeliveryMedium' => isset($item['DeliveryMedium']) ? (string) $item['DeliveryMedium'] : null,
+                'AttributeName' => isset($item['AttributeName']) ? (string) $item['AttributeName'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultUsersListType(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new UserType([
+                'Username' => isset($item['Username']) ? (string) $item['Username'] : null,
+                'Attributes' => empty($item['Attributes']) ? [] : $this->populateResultAttributeListType($item['Attributes']),
+                'UserCreateDate' => (isset($item['UserCreateDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['UserCreateDate'])))) ? $d : null,
+                'UserLastModifiedDate' => (isset($item['UserLastModifiedDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['UserLastModifiedDate'])))) ? $d : null,
+                'Enabled' => isset($item['Enabled']) ? filter_var($item['Enabled'], \FILTER_VALIDATE_BOOLEAN) : null,
+                'UserStatus' => isset($item['UserStatus']) ? (string) $item['UserStatus'] : null,
+                'MFAOptions' => empty($item['MFAOptions']) ? [] : $this->populateResultMFAOptionListType($item['MFAOptions']),
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/DynamoDb/src/Result/BatchGetItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/BatchGetItemOutput.php
@@ -6,6 +6,7 @@ use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\DynamoDb\DynamoDbClient;
 use AsyncAws\DynamoDb\Input\BatchGetItemInput;
+use AsyncAws\DynamoDb\ValueObject\AttributeValue;
 use AsyncAws\DynamoDb\ValueObject\Capacity;
 use AsyncAws\DynamoDb\ValueObject\ConsumedCapacity;
 use AsyncAws\DynamoDb\ValueObject\KeysAndAttributes;
@@ -141,6 +142,9 @@ class BatchGetItemOutput extends Result implements \IteratorAggregate
         $this->ConsumedCapacity = empty($data['ConsumedCapacity']) ? [] : $this->populateResultConsumedCapacityMultiple($data['ConsumedCapacity']);
     }
 
+    /**
+     * @return array<string, AttributeValue>
+     */
     private function populateResultAttributeMap(array $json): array
     {
         $items = [];
@@ -151,6 +155,9 @@ class BatchGetItemOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return array<string, KeysAndAttributes>
+     */
     private function populateResultBatchGetRequestMap(array $json): array
     {
         $items = [];
@@ -161,6 +168,9 @@ class BatchGetItemOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return array<string, array>
+     */
     private function populateResultBatchGetResponseMap(array $json): array
     {
         $items = [];
@@ -171,6 +181,9 @@ class BatchGetItemOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return ConsumedCapacity[]
+     */
     private function populateResultConsumedCapacityMultiple(array $json): array
     {
         $items = [];
@@ -193,6 +206,9 @@ class BatchGetItemOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return array[]
+     */
     private function populateResultItemList(array $json): array
     {
         $items = [];
@@ -206,6 +222,9 @@ class BatchGetItemOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return array<string, Capacity>
+     */
     private function populateResultSecondaryIndexesCapacityMap(array $json): array
     {
         $items = [];

--- a/src/Service/DynamoDb/src/Result/BatchGetItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/BatchGetItemOutput.php
@@ -6,7 +6,6 @@ use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 use AsyncAws\DynamoDb\DynamoDbClient;
 use AsyncAws\DynamoDb\Input\BatchGetItemInput;
-use AsyncAws\DynamoDb\ValueObject\AttributeValue;
 use AsyncAws\DynamoDb\ValueObject\Capacity;
 use AsyncAws\DynamoDb\ValueObject\ConsumedCapacity;
 use AsyncAws\DynamoDb\ValueObject\KeysAndAttributes;
@@ -136,77 +135,84 @@ class BatchGetItemOutput extends Result implements \IteratorAggregate
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-ItemList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = empty($item) ? [] : $fn['map-AttributeMap']($item);
-                if (null !== $a) {
-                    $items[] = $a;
-                }
+
+        $this->Responses = empty($data['Responses']) ? [] : $this->populateResultBatchGetResponseMap($data['Responses']);
+        $this->UnprocessedKeys = empty($data['UnprocessedKeys']) ? [] : $this->populateResultBatchGetRequestMap($data['UnprocessedKeys']);
+        $this->ConsumedCapacity = empty($data['ConsumedCapacity']) ? [] : $this->populateResultConsumedCapacityMultiple($data['ConsumedCapacity']);
+    }
+
+    private function populateResultAttributeMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = AttributeValue::create($value);
+        }
+
+        return $items;
+    }
+
+    private function populateResultBatchGetRequestMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = KeysAndAttributes::create($value);
+        }
+
+        return $items;
+    }
+
+    private function populateResultBatchGetResponseMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = $this->populateResultItemList($value);
+        }
+
+        return $items;
+    }
+
+    private function populateResultConsumedCapacityMultiple(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new ConsumedCapacity([
+                'TableName' => isset($item['TableName']) ? (string) $item['TableName'] : null,
+                'CapacityUnits' => isset($item['CapacityUnits']) ? (float) $item['CapacityUnits'] : null,
+                'ReadCapacityUnits' => isset($item['ReadCapacityUnits']) ? (float) $item['ReadCapacityUnits'] : null,
+                'WriteCapacityUnits' => isset($item['WriteCapacityUnits']) ? (float) $item['WriteCapacityUnits'] : null,
+                'Table' => empty($item['Table']) ? null : new Capacity([
+                    'ReadCapacityUnits' => isset($item['Table']['ReadCapacityUnits']) ? (float) $item['Table']['ReadCapacityUnits'] : null,
+                    'WriteCapacityUnits' => isset($item['Table']['WriteCapacityUnits']) ? (float) $item['Table']['WriteCapacityUnits'] : null,
+                    'CapacityUnits' => isset($item['Table']['CapacityUnits']) ? (float) $item['Table']['CapacityUnits'] : null,
+                ]),
+                'LocalSecondaryIndexes' => empty($item['LocalSecondaryIndexes']) ? [] : $this->populateResultSecondaryIndexesCapacityMap($item['LocalSecondaryIndexes']),
+                'GlobalSecondaryIndexes' => empty($item['GlobalSecondaryIndexes']) ? [] : $this->populateResultSecondaryIndexesCapacityMap($item['GlobalSecondaryIndexes']),
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultItemList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = empty($item) ? [] : $this->populateResultAttributeMap($item);
+            if (null !== $a) {
+                $items[] = $a;
             }
+        }
 
-            return $items;
-        };
+        return $items;
+    }
 
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue> */
-        $fn['map-AttributeMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = AttributeValue::create($value);
-            }
+    private function populateResultSecondaryIndexesCapacityMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = Capacity::create($value);
+        }
 
-            return $items;
-        };
-
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\KeysAndAttributes> */
-        $fn['map-BatchGetRequestMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = KeysAndAttributes::create($value);
-            }
-
-            return $items;
-        };
-        $fn['list-ConsumedCapacityMultiple'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new ConsumedCapacity([
-                    'TableName' => isset($item['TableName']) ? (string) $item['TableName'] : null,
-                    'CapacityUnits' => isset($item['CapacityUnits']) ? (float) $item['CapacityUnits'] : null,
-                    'ReadCapacityUnits' => isset($item['ReadCapacityUnits']) ? (float) $item['ReadCapacityUnits'] : null,
-                    'WriteCapacityUnits' => isset($item['WriteCapacityUnits']) ? (float) $item['WriteCapacityUnits'] : null,
-                    'Table' => empty($item['Table']) ? null : new Capacity([
-                        'ReadCapacityUnits' => isset($item['Table']['ReadCapacityUnits']) ? (float) $item['Table']['ReadCapacityUnits'] : null,
-                        'WriteCapacityUnits' => isset($item['Table']['WriteCapacityUnits']) ? (float) $item['Table']['WriteCapacityUnits'] : null,
-                        'CapacityUnits' => isset($item['Table']['CapacityUnits']) ? (float) $item['Table']['CapacityUnits'] : null,
-                    ]),
-                    'LocalSecondaryIndexes' => empty($item['LocalSecondaryIndexes']) ? [] : $fn['map-SecondaryIndexesCapacityMap']($item['LocalSecondaryIndexes']),
-                    'GlobalSecondaryIndexes' => empty($item['GlobalSecondaryIndexes']) ? [] : $fn['map-SecondaryIndexesCapacityMap']($item['GlobalSecondaryIndexes']),
-                ]);
-            }
-
-            return $items;
-        };
-
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\Capacity> */
-        $fn['map-SecondaryIndexesCapacityMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = Capacity::create($value);
-            }
-
-            return $items;
-        };
-        $this->Responses = empty($data['Responses']) ? [] : (function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = $fn['list-ItemList']($value);
-            }
-
-            return $items;
-        })($data['Responses']);
-        $this->UnprocessedKeys = empty($data['UnprocessedKeys']) ? [] : $fn['map-BatchGetRequestMap']($data['UnprocessedKeys']);
-        $this->ConsumedCapacity = empty($data['ConsumedCapacity']) ? [] : $fn['list-ConsumedCapacityMultiple']($data['ConsumedCapacity']);
+        return $items;
     }
 }

--- a/src/Service/DynamoDb/src/Result/CreateTableOutput.php
+++ b/src/Service/DynamoDb/src/Result/CreateTableOutput.php
@@ -37,120 +37,11 @@ class CreateTableOutput extends Result
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-AttributeDefinitions'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new AttributeDefinition([
-                    'AttributeName' => (string) $item['AttributeName'],
-                    'AttributeType' => (string) $item['AttributeType'],
-                ]);
-            }
 
-            return $items;
-        };
-        $fn['list-KeySchema'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new KeySchemaElement([
-                    'AttributeName' => (string) $item['AttributeName'],
-                    'KeyType' => (string) $item['KeyType'],
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-LocalSecondaryIndexDescriptionList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new LocalSecondaryIndexDescription([
-                    'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
-                    'KeySchema' => empty($item['KeySchema']) ? [] : $fn['list-KeySchema']($item['KeySchema']),
-                    'Projection' => empty($item['Projection']) ? null : new Projection([
-                        'ProjectionType' => isset($item['Projection']['ProjectionType']) ? (string) $item['Projection']['ProjectionType'] : null,
-                        'NonKeyAttributes' => empty($item['Projection']['NonKeyAttributes']) ? [] : $fn['list-NonKeyAttributeNameList']($item['Projection']['NonKeyAttributes']),
-                    ]),
-                    'IndexSizeBytes' => isset($item['IndexSizeBytes']) ? (string) $item['IndexSizeBytes'] : null,
-                    'ItemCount' => isset($item['ItemCount']) ? (string) $item['ItemCount'] : null,
-                    'IndexArn' => isset($item['IndexArn']) ? (string) $item['IndexArn'] : null,
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-NonKeyAttributeNameList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (string) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
-
-            return $items;
-        };
-        $fn['list-GlobalSecondaryIndexDescriptionList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new GlobalSecondaryIndexDescription([
-                    'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
-                    'KeySchema' => empty($item['KeySchema']) ? [] : $fn['list-KeySchema']($item['KeySchema']),
-                    'Projection' => empty($item['Projection']) ? null : new Projection([
-                        'ProjectionType' => isset($item['Projection']['ProjectionType']) ? (string) $item['Projection']['ProjectionType'] : null,
-                        'NonKeyAttributes' => empty($item['Projection']['NonKeyAttributes']) ? [] : $fn['list-NonKeyAttributeNameList']($item['Projection']['NonKeyAttributes']),
-                    ]),
-                    'IndexStatus' => isset($item['IndexStatus']) ? (string) $item['IndexStatus'] : null,
-                    'Backfilling' => isset($item['Backfilling']) ? filter_var($item['Backfilling'], \FILTER_VALIDATE_BOOLEAN) : null,
-                    'ProvisionedThroughput' => empty($item['ProvisionedThroughput']) ? null : new ProvisionedThroughputDescription([
-                        'LastIncreaseDateTime' => (isset($item['ProvisionedThroughput']['LastIncreaseDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['ProvisionedThroughput']['LastIncreaseDateTime'])))) ? $d : null,
-                        'LastDecreaseDateTime' => (isset($item['ProvisionedThroughput']['LastDecreaseDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['ProvisionedThroughput']['LastDecreaseDateTime'])))) ? $d : null,
-                        'NumberOfDecreasesToday' => isset($item['ProvisionedThroughput']['NumberOfDecreasesToday']) ? (string) $item['ProvisionedThroughput']['NumberOfDecreasesToday'] : null,
-                        'ReadCapacityUnits' => isset($item['ProvisionedThroughput']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughput']['ReadCapacityUnits'] : null,
-                        'WriteCapacityUnits' => isset($item['ProvisionedThroughput']['WriteCapacityUnits']) ? (string) $item['ProvisionedThroughput']['WriteCapacityUnits'] : null,
-                    ]),
-                    'IndexSizeBytes' => isset($item['IndexSizeBytes']) ? (string) $item['IndexSizeBytes'] : null,
-                    'ItemCount' => isset($item['ItemCount']) ? (string) $item['ItemCount'] : null,
-                    'IndexArn' => isset($item['IndexArn']) ? (string) $item['IndexArn'] : null,
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-ReplicaDescriptionList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new ReplicaDescription([
-                    'RegionName' => isset($item['RegionName']) ? (string) $item['RegionName'] : null,
-                    'ReplicaStatus' => isset($item['ReplicaStatus']) ? (string) $item['ReplicaStatus'] : null,
-                    'ReplicaStatusDescription' => isset($item['ReplicaStatusDescription']) ? (string) $item['ReplicaStatusDescription'] : null,
-                    'ReplicaStatusPercentProgress' => isset($item['ReplicaStatusPercentProgress']) ? (string) $item['ReplicaStatusPercentProgress'] : null,
-                    'KMSMasterKeyId' => isset($item['KMSMasterKeyId']) ? (string) $item['KMSMasterKeyId'] : null,
-                    'ProvisionedThroughputOverride' => empty($item['ProvisionedThroughputOverride']) ? null : new ProvisionedThroughputOverride([
-                        'ReadCapacityUnits' => isset($item['ProvisionedThroughputOverride']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughputOverride']['ReadCapacityUnits'] : null,
-                    ]),
-                    'GlobalSecondaryIndexes' => empty($item['GlobalSecondaryIndexes']) ? [] : $fn['list-ReplicaGlobalSecondaryIndexDescriptionList']($item['GlobalSecondaryIndexes']),
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-ReplicaGlobalSecondaryIndexDescriptionList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new ReplicaGlobalSecondaryIndexDescription([
-                    'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
-                    'ProvisionedThroughputOverride' => empty($item['ProvisionedThroughputOverride']) ? null : new ProvisionedThroughputOverride([
-                        'ReadCapacityUnits' => isset($item['ProvisionedThroughputOverride']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughputOverride']['ReadCapacityUnits'] : null,
-                    ]),
-                ]);
-            }
-
-            return $items;
-        };
         $this->TableDescription = empty($data['TableDescription']) ? null : new TableDescription([
-            'AttributeDefinitions' => empty($data['TableDescription']['AttributeDefinitions']) ? [] : $fn['list-AttributeDefinitions']($data['TableDescription']['AttributeDefinitions']),
+            'AttributeDefinitions' => empty($data['TableDescription']['AttributeDefinitions']) ? [] : $this->populateResultAttributeDefinitions($data['TableDescription']['AttributeDefinitions']),
             'TableName' => isset($data['TableDescription']['TableName']) ? (string) $data['TableDescription']['TableName'] : null,
-            'KeySchema' => empty($data['TableDescription']['KeySchema']) ? [] : $fn['list-KeySchema']($data['TableDescription']['KeySchema']),
+            'KeySchema' => empty($data['TableDescription']['KeySchema']) ? [] : $this->populateResultKeySchema($data['TableDescription']['KeySchema']),
             'TableStatus' => isset($data['TableDescription']['TableStatus']) ? (string) $data['TableDescription']['TableStatus'] : null,
             'CreationDateTime' => (isset($data['TableDescription']['CreationDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $data['TableDescription']['CreationDateTime'])))) ? $d : null,
             'ProvisionedThroughput' => empty($data['TableDescription']['ProvisionedThroughput']) ? null : new ProvisionedThroughputDescription([
@@ -168,8 +59,8 @@ class CreateTableOutput extends Result
                 'BillingMode' => isset($data['TableDescription']['BillingModeSummary']['BillingMode']) ? (string) $data['TableDescription']['BillingModeSummary']['BillingMode'] : null,
                 'LastUpdateToPayPerRequestDateTime' => (isset($data['TableDescription']['BillingModeSummary']['LastUpdateToPayPerRequestDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $data['TableDescription']['BillingModeSummary']['LastUpdateToPayPerRequestDateTime'])))) ? $d : null,
             ]),
-            'LocalSecondaryIndexes' => empty($data['TableDescription']['LocalSecondaryIndexes']) ? [] : $fn['list-LocalSecondaryIndexDescriptionList']($data['TableDescription']['LocalSecondaryIndexes']),
-            'GlobalSecondaryIndexes' => empty($data['TableDescription']['GlobalSecondaryIndexes']) ? [] : $fn['list-GlobalSecondaryIndexDescriptionList']($data['TableDescription']['GlobalSecondaryIndexes']),
+            'LocalSecondaryIndexes' => empty($data['TableDescription']['LocalSecondaryIndexes']) ? [] : $this->populateResultLocalSecondaryIndexDescriptionList($data['TableDescription']['LocalSecondaryIndexes']),
+            'GlobalSecondaryIndexes' => empty($data['TableDescription']['GlobalSecondaryIndexes']) ? [] : $this->populateResultGlobalSecondaryIndexDescriptionList($data['TableDescription']['GlobalSecondaryIndexes']),
             'StreamSpecification' => empty($data['TableDescription']['StreamSpecification']) ? null : new StreamSpecification([
                 'StreamEnabled' => filter_var($data['TableDescription']['StreamSpecification']['StreamEnabled'], \FILTER_VALIDATE_BOOLEAN),
                 'StreamViewType' => isset($data['TableDescription']['StreamSpecification']['StreamViewType']) ? (string) $data['TableDescription']['StreamSpecification']['StreamViewType'] : null,
@@ -177,7 +68,7 @@ class CreateTableOutput extends Result
             'LatestStreamLabel' => isset($data['TableDescription']['LatestStreamLabel']) ? (string) $data['TableDescription']['LatestStreamLabel'] : null,
             'LatestStreamArn' => isset($data['TableDescription']['LatestStreamArn']) ? (string) $data['TableDescription']['LatestStreamArn'] : null,
             'GlobalTableVersion' => isset($data['TableDescription']['GlobalTableVersion']) ? (string) $data['TableDescription']['GlobalTableVersion'] : null,
-            'Replicas' => empty($data['TableDescription']['Replicas']) ? [] : $fn['list-ReplicaDescriptionList']($data['TableDescription']['Replicas']),
+            'Replicas' => empty($data['TableDescription']['Replicas']) ? [] : $this->populateResultReplicaDescriptionList($data['TableDescription']['Replicas']),
             'RestoreSummary' => empty($data['TableDescription']['RestoreSummary']) ? null : new RestoreSummary([
                 'SourceBackupArn' => isset($data['TableDescription']['RestoreSummary']['SourceBackupArn']) ? (string) $data['TableDescription']['RestoreSummary']['SourceBackupArn'] : null,
                 'SourceTableArn' => isset($data['TableDescription']['RestoreSummary']['SourceTableArn']) ? (string) $data['TableDescription']['RestoreSummary']['SourceTableArn'] : null,
@@ -196,5 +87,128 @@ class CreateTableOutput extends Result
                 'ArchivalBackupArn' => isset($data['TableDescription']['ArchivalSummary']['ArchivalBackupArn']) ? (string) $data['TableDescription']['ArchivalSummary']['ArchivalBackupArn'] : null,
             ]),
         ]);
+    }
+
+    private function populateResultAttributeDefinitions(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new AttributeDefinition([
+                'AttributeName' => (string) $item['AttributeName'],
+                'AttributeType' => (string) $item['AttributeType'],
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultGlobalSecondaryIndexDescriptionList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new GlobalSecondaryIndexDescription([
+                'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
+                'KeySchema' => empty($item['KeySchema']) ? [] : $this->populateResultKeySchema($item['KeySchema']),
+                'Projection' => empty($item['Projection']) ? null : new Projection([
+                    'ProjectionType' => isset($item['Projection']['ProjectionType']) ? (string) $item['Projection']['ProjectionType'] : null,
+                    'NonKeyAttributes' => empty($item['Projection']['NonKeyAttributes']) ? [] : $this->populateResultNonKeyAttributeNameList($item['Projection']['NonKeyAttributes']),
+                ]),
+                'IndexStatus' => isset($item['IndexStatus']) ? (string) $item['IndexStatus'] : null,
+                'Backfilling' => isset($item['Backfilling']) ? filter_var($item['Backfilling'], \FILTER_VALIDATE_BOOLEAN) : null,
+                'ProvisionedThroughput' => empty($item['ProvisionedThroughput']) ? null : new ProvisionedThroughputDescription([
+                    'LastIncreaseDateTime' => (isset($item['ProvisionedThroughput']['LastIncreaseDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['ProvisionedThroughput']['LastIncreaseDateTime'])))) ? $d : null,
+                    'LastDecreaseDateTime' => (isset($item['ProvisionedThroughput']['LastDecreaseDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['ProvisionedThroughput']['LastDecreaseDateTime'])))) ? $d : null,
+                    'NumberOfDecreasesToday' => isset($item['ProvisionedThroughput']['NumberOfDecreasesToday']) ? (string) $item['ProvisionedThroughput']['NumberOfDecreasesToday'] : null,
+                    'ReadCapacityUnits' => isset($item['ProvisionedThroughput']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughput']['ReadCapacityUnits'] : null,
+                    'WriteCapacityUnits' => isset($item['ProvisionedThroughput']['WriteCapacityUnits']) ? (string) $item['ProvisionedThroughput']['WriteCapacityUnits'] : null,
+                ]),
+                'IndexSizeBytes' => isset($item['IndexSizeBytes']) ? (string) $item['IndexSizeBytes'] : null,
+                'ItemCount' => isset($item['ItemCount']) ? (string) $item['ItemCount'] : null,
+                'IndexArn' => isset($item['IndexArn']) ? (string) $item['IndexArn'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultKeySchema(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new KeySchemaElement([
+                'AttributeName' => (string) $item['AttributeName'],
+                'KeyType' => (string) $item['KeyType'],
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultLocalSecondaryIndexDescriptionList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new LocalSecondaryIndexDescription([
+                'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
+                'KeySchema' => empty($item['KeySchema']) ? [] : $this->populateResultKeySchema($item['KeySchema']),
+                'Projection' => empty($item['Projection']) ? null : new Projection([
+                    'ProjectionType' => isset($item['Projection']['ProjectionType']) ? (string) $item['Projection']['ProjectionType'] : null,
+                    'NonKeyAttributes' => empty($item['Projection']['NonKeyAttributes']) ? [] : $this->populateResultNonKeyAttributeNameList($item['Projection']['NonKeyAttributes']),
+                ]),
+                'IndexSizeBytes' => isset($item['IndexSizeBytes']) ? (string) $item['IndexSizeBytes'] : null,
+                'ItemCount' => isset($item['ItemCount']) ? (string) $item['ItemCount'] : null,
+                'IndexArn' => isset($item['IndexArn']) ? (string) $item['IndexArn'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultNonKeyAttributeNameList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (string) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultReplicaDescriptionList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new ReplicaDescription([
+                'RegionName' => isset($item['RegionName']) ? (string) $item['RegionName'] : null,
+                'ReplicaStatus' => isset($item['ReplicaStatus']) ? (string) $item['ReplicaStatus'] : null,
+                'ReplicaStatusDescription' => isset($item['ReplicaStatusDescription']) ? (string) $item['ReplicaStatusDescription'] : null,
+                'ReplicaStatusPercentProgress' => isset($item['ReplicaStatusPercentProgress']) ? (string) $item['ReplicaStatusPercentProgress'] : null,
+                'KMSMasterKeyId' => isset($item['KMSMasterKeyId']) ? (string) $item['KMSMasterKeyId'] : null,
+                'ProvisionedThroughputOverride' => empty($item['ProvisionedThroughputOverride']) ? null : new ProvisionedThroughputOverride([
+                    'ReadCapacityUnits' => isset($item['ProvisionedThroughputOverride']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughputOverride']['ReadCapacityUnits'] : null,
+                ]),
+                'GlobalSecondaryIndexes' => empty($item['GlobalSecondaryIndexes']) ? [] : $this->populateResultReplicaGlobalSecondaryIndexDescriptionList($item['GlobalSecondaryIndexes']),
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultReplicaGlobalSecondaryIndexDescriptionList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new ReplicaGlobalSecondaryIndexDescription([
+                'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
+                'ProvisionedThroughputOverride' => empty($item['ProvisionedThroughputOverride']) ? null : new ProvisionedThroughputOverride([
+                    'ReadCapacityUnits' => isset($item['ProvisionedThroughputOverride']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughputOverride']['ReadCapacityUnits'] : null,
+                ]),
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/DynamoDb/src/Result/CreateTableOutput.php
+++ b/src/Service/DynamoDb/src/Result/CreateTableOutput.php
@@ -89,6 +89,9 @@ class CreateTableOutput extends Result
         ]);
     }
 
+    /**
+     * @return AttributeDefinition[]
+     */
     private function populateResultAttributeDefinitions(array $json): array
     {
         $items = [];
@@ -102,6 +105,9 @@ class CreateTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return GlobalSecondaryIndexDescription[]
+     */
     private function populateResultGlobalSecondaryIndexDescriptionList(array $json): array
     {
         $items = [];
@@ -131,6 +137,9 @@ class CreateTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return KeySchemaElement[]
+     */
     private function populateResultKeySchema(array $json): array
     {
         $items = [];
@@ -144,6 +153,9 @@ class CreateTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return LocalSecondaryIndexDescription[]
+     */
     private function populateResultLocalSecondaryIndexDescriptionList(array $json): array
     {
         $items = [];
@@ -164,6 +176,9 @@ class CreateTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return string[]
+     */
     private function populateResultNonKeyAttributeNameList(array $json): array
     {
         $items = [];
@@ -177,6 +192,9 @@ class CreateTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return ReplicaDescription[]
+     */
     private function populateResultReplicaDescriptionList(array $json): array
     {
         $items = [];
@@ -197,6 +215,9 @@ class CreateTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return ReplicaGlobalSecondaryIndexDescription[]
+     */
     private function populateResultReplicaGlobalSecondaryIndexDescriptionList(array $json): array
     {
         $items = [];

--- a/src/Service/DynamoDb/src/Result/DeleteItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/DeleteItemOutput.php
@@ -82,6 +82,9 @@ class DeleteItemOutput extends Result
         ]);
     }
 
+    /**
+     * @return array<string, AttributeValue>
+     */
     private function populateResultAttributeMap(array $json): array
     {
         $items = [];
@@ -92,6 +95,9 @@ class DeleteItemOutput extends Result
         return $items;
     }
 
+    /**
+     * @return array<string, AttributeValue>
+     */
     private function populateResultItemCollectionKeyAttributeMap(array $json): array
     {
         $items = [];
@@ -102,6 +108,9 @@ class DeleteItemOutput extends Result
         return $items;
     }
 
+    /**
+     * @return float[]
+     */
     private function populateResultItemCollectionSizeEstimateRange(array $json): array
     {
         $items = [];
@@ -115,6 +124,9 @@ class DeleteItemOutput extends Result
         return $items;
     }
 
+    /**
+     * @return array<string, Capacity>
+     */
     private function populateResultSecondaryIndexesCapacityMap(array $json): array
     {
         $items = [];

--- a/src/Service/DynamoDb/src/Result/DeleteItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/DeleteItemOutput.php
@@ -61,48 +61,8 @@ class DeleteItemOutput extends Result
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue> */
-        $fn['map-AttributeMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = AttributeValue::create($value);
-            }
 
-            return $items;
-        };
-
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\Capacity> */
-        $fn['map-SecondaryIndexesCapacityMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = Capacity::create($value);
-            }
-
-            return $items;
-        };
-
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue> */
-        $fn['map-ItemCollectionKeyAttributeMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = AttributeValue::create($value);
-            }
-
-            return $items;
-        };
-        $fn['list-ItemCollectionSizeEstimateRange'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (float) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
-
-            return $items;
-        };
-        $this->Attributes = empty($data['Attributes']) ? [] : $fn['map-AttributeMap']($data['Attributes']);
+        $this->Attributes = empty($data['Attributes']) ? [] : $this->populateResultAttributeMap($data['Attributes']);
         $this->ConsumedCapacity = empty($data['ConsumedCapacity']) ? null : new ConsumedCapacity([
             'TableName' => isset($data['ConsumedCapacity']['TableName']) ? (string) $data['ConsumedCapacity']['TableName'] : null,
             'CapacityUnits' => isset($data['ConsumedCapacity']['CapacityUnits']) ? (float) $data['ConsumedCapacity']['CapacityUnits'] : null,
@@ -113,12 +73,55 @@ class DeleteItemOutput extends Result
                 'WriteCapacityUnits' => isset($data['ConsumedCapacity']['Table']['WriteCapacityUnits']) ? (float) $data['ConsumedCapacity']['Table']['WriteCapacityUnits'] : null,
                 'CapacityUnits' => isset($data['ConsumedCapacity']['Table']['CapacityUnits']) ? (float) $data['ConsumedCapacity']['Table']['CapacityUnits'] : null,
             ]),
-            'LocalSecondaryIndexes' => empty($data['ConsumedCapacity']['LocalSecondaryIndexes']) ? [] : $fn['map-SecondaryIndexesCapacityMap']($data['ConsumedCapacity']['LocalSecondaryIndexes']),
-            'GlobalSecondaryIndexes' => empty($data['ConsumedCapacity']['GlobalSecondaryIndexes']) ? [] : $fn['map-SecondaryIndexesCapacityMap']($data['ConsumedCapacity']['GlobalSecondaryIndexes']),
+            'LocalSecondaryIndexes' => empty($data['ConsumedCapacity']['LocalSecondaryIndexes']) ? [] : $this->populateResultSecondaryIndexesCapacityMap($data['ConsumedCapacity']['LocalSecondaryIndexes']),
+            'GlobalSecondaryIndexes' => empty($data['ConsumedCapacity']['GlobalSecondaryIndexes']) ? [] : $this->populateResultSecondaryIndexesCapacityMap($data['ConsumedCapacity']['GlobalSecondaryIndexes']),
         ]);
         $this->ItemCollectionMetrics = empty($data['ItemCollectionMetrics']) ? null : new ItemCollectionMetrics([
-            'ItemCollectionKey' => empty($data['ItemCollectionMetrics']['ItemCollectionKey']) ? [] : $fn['map-ItemCollectionKeyAttributeMap']($data['ItemCollectionMetrics']['ItemCollectionKey']),
-            'SizeEstimateRangeGB' => empty($data['ItemCollectionMetrics']['SizeEstimateRangeGB']) ? [] : $fn['list-ItemCollectionSizeEstimateRange']($data['ItemCollectionMetrics']['SizeEstimateRangeGB']),
+            'ItemCollectionKey' => empty($data['ItemCollectionMetrics']['ItemCollectionKey']) ? [] : $this->populateResultItemCollectionKeyAttributeMap($data['ItemCollectionMetrics']['ItemCollectionKey']),
+            'SizeEstimateRangeGB' => empty($data['ItemCollectionMetrics']['SizeEstimateRangeGB']) ? [] : $this->populateResultItemCollectionSizeEstimateRange($data['ItemCollectionMetrics']['SizeEstimateRangeGB']),
         ]);
+    }
+
+    private function populateResultAttributeMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = AttributeValue::create($value);
+        }
+
+        return $items;
+    }
+
+    private function populateResultItemCollectionKeyAttributeMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = AttributeValue::create($value);
+        }
+
+        return $items;
+    }
+
+    private function populateResultItemCollectionSizeEstimateRange(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (float) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultSecondaryIndexesCapacityMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = Capacity::create($value);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/DynamoDb/src/Result/DeleteTableOutput.php
+++ b/src/Service/DynamoDb/src/Result/DeleteTableOutput.php
@@ -37,120 +37,11 @@ class DeleteTableOutput extends Result
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-AttributeDefinitions'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new AttributeDefinition([
-                    'AttributeName' => (string) $item['AttributeName'],
-                    'AttributeType' => (string) $item['AttributeType'],
-                ]);
-            }
 
-            return $items;
-        };
-        $fn['list-KeySchema'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new KeySchemaElement([
-                    'AttributeName' => (string) $item['AttributeName'],
-                    'KeyType' => (string) $item['KeyType'],
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-LocalSecondaryIndexDescriptionList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new LocalSecondaryIndexDescription([
-                    'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
-                    'KeySchema' => empty($item['KeySchema']) ? [] : $fn['list-KeySchema']($item['KeySchema']),
-                    'Projection' => empty($item['Projection']) ? null : new Projection([
-                        'ProjectionType' => isset($item['Projection']['ProjectionType']) ? (string) $item['Projection']['ProjectionType'] : null,
-                        'NonKeyAttributes' => empty($item['Projection']['NonKeyAttributes']) ? [] : $fn['list-NonKeyAttributeNameList']($item['Projection']['NonKeyAttributes']),
-                    ]),
-                    'IndexSizeBytes' => isset($item['IndexSizeBytes']) ? (string) $item['IndexSizeBytes'] : null,
-                    'ItemCount' => isset($item['ItemCount']) ? (string) $item['ItemCount'] : null,
-                    'IndexArn' => isset($item['IndexArn']) ? (string) $item['IndexArn'] : null,
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-NonKeyAttributeNameList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (string) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
-
-            return $items;
-        };
-        $fn['list-GlobalSecondaryIndexDescriptionList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new GlobalSecondaryIndexDescription([
-                    'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
-                    'KeySchema' => empty($item['KeySchema']) ? [] : $fn['list-KeySchema']($item['KeySchema']),
-                    'Projection' => empty($item['Projection']) ? null : new Projection([
-                        'ProjectionType' => isset($item['Projection']['ProjectionType']) ? (string) $item['Projection']['ProjectionType'] : null,
-                        'NonKeyAttributes' => empty($item['Projection']['NonKeyAttributes']) ? [] : $fn['list-NonKeyAttributeNameList']($item['Projection']['NonKeyAttributes']),
-                    ]),
-                    'IndexStatus' => isset($item['IndexStatus']) ? (string) $item['IndexStatus'] : null,
-                    'Backfilling' => isset($item['Backfilling']) ? filter_var($item['Backfilling'], \FILTER_VALIDATE_BOOLEAN) : null,
-                    'ProvisionedThroughput' => empty($item['ProvisionedThroughput']) ? null : new ProvisionedThroughputDescription([
-                        'LastIncreaseDateTime' => (isset($item['ProvisionedThroughput']['LastIncreaseDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['ProvisionedThroughput']['LastIncreaseDateTime'])))) ? $d : null,
-                        'LastDecreaseDateTime' => (isset($item['ProvisionedThroughput']['LastDecreaseDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['ProvisionedThroughput']['LastDecreaseDateTime'])))) ? $d : null,
-                        'NumberOfDecreasesToday' => isset($item['ProvisionedThroughput']['NumberOfDecreasesToday']) ? (string) $item['ProvisionedThroughput']['NumberOfDecreasesToday'] : null,
-                        'ReadCapacityUnits' => isset($item['ProvisionedThroughput']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughput']['ReadCapacityUnits'] : null,
-                        'WriteCapacityUnits' => isset($item['ProvisionedThroughput']['WriteCapacityUnits']) ? (string) $item['ProvisionedThroughput']['WriteCapacityUnits'] : null,
-                    ]),
-                    'IndexSizeBytes' => isset($item['IndexSizeBytes']) ? (string) $item['IndexSizeBytes'] : null,
-                    'ItemCount' => isset($item['ItemCount']) ? (string) $item['ItemCount'] : null,
-                    'IndexArn' => isset($item['IndexArn']) ? (string) $item['IndexArn'] : null,
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-ReplicaDescriptionList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new ReplicaDescription([
-                    'RegionName' => isset($item['RegionName']) ? (string) $item['RegionName'] : null,
-                    'ReplicaStatus' => isset($item['ReplicaStatus']) ? (string) $item['ReplicaStatus'] : null,
-                    'ReplicaStatusDescription' => isset($item['ReplicaStatusDescription']) ? (string) $item['ReplicaStatusDescription'] : null,
-                    'ReplicaStatusPercentProgress' => isset($item['ReplicaStatusPercentProgress']) ? (string) $item['ReplicaStatusPercentProgress'] : null,
-                    'KMSMasterKeyId' => isset($item['KMSMasterKeyId']) ? (string) $item['KMSMasterKeyId'] : null,
-                    'ProvisionedThroughputOverride' => empty($item['ProvisionedThroughputOverride']) ? null : new ProvisionedThroughputOverride([
-                        'ReadCapacityUnits' => isset($item['ProvisionedThroughputOverride']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughputOverride']['ReadCapacityUnits'] : null,
-                    ]),
-                    'GlobalSecondaryIndexes' => empty($item['GlobalSecondaryIndexes']) ? [] : $fn['list-ReplicaGlobalSecondaryIndexDescriptionList']($item['GlobalSecondaryIndexes']),
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-ReplicaGlobalSecondaryIndexDescriptionList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new ReplicaGlobalSecondaryIndexDescription([
-                    'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
-                    'ProvisionedThroughputOverride' => empty($item['ProvisionedThroughputOverride']) ? null : new ProvisionedThroughputOverride([
-                        'ReadCapacityUnits' => isset($item['ProvisionedThroughputOverride']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughputOverride']['ReadCapacityUnits'] : null,
-                    ]),
-                ]);
-            }
-
-            return $items;
-        };
         $this->TableDescription = empty($data['TableDescription']) ? null : new TableDescription([
-            'AttributeDefinitions' => empty($data['TableDescription']['AttributeDefinitions']) ? [] : $fn['list-AttributeDefinitions']($data['TableDescription']['AttributeDefinitions']),
+            'AttributeDefinitions' => empty($data['TableDescription']['AttributeDefinitions']) ? [] : $this->populateResultAttributeDefinitions($data['TableDescription']['AttributeDefinitions']),
             'TableName' => isset($data['TableDescription']['TableName']) ? (string) $data['TableDescription']['TableName'] : null,
-            'KeySchema' => empty($data['TableDescription']['KeySchema']) ? [] : $fn['list-KeySchema']($data['TableDescription']['KeySchema']),
+            'KeySchema' => empty($data['TableDescription']['KeySchema']) ? [] : $this->populateResultKeySchema($data['TableDescription']['KeySchema']),
             'TableStatus' => isset($data['TableDescription']['TableStatus']) ? (string) $data['TableDescription']['TableStatus'] : null,
             'CreationDateTime' => (isset($data['TableDescription']['CreationDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $data['TableDescription']['CreationDateTime'])))) ? $d : null,
             'ProvisionedThroughput' => empty($data['TableDescription']['ProvisionedThroughput']) ? null : new ProvisionedThroughputDescription([
@@ -168,8 +59,8 @@ class DeleteTableOutput extends Result
                 'BillingMode' => isset($data['TableDescription']['BillingModeSummary']['BillingMode']) ? (string) $data['TableDescription']['BillingModeSummary']['BillingMode'] : null,
                 'LastUpdateToPayPerRequestDateTime' => (isset($data['TableDescription']['BillingModeSummary']['LastUpdateToPayPerRequestDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $data['TableDescription']['BillingModeSummary']['LastUpdateToPayPerRequestDateTime'])))) ? $d : null,
             ]),
-            'LocalSecondaryIndexes' => empty($data['TableDescription']['LocalSecondaryIndexes']) ? [] : $fn['list-LocalSecondaryIndexDescriptionList']($data['TableDescription']['LocalSecondaryIndexes']),
-            'GlobalSecondaryIndexes' => empty($data['TableDescription']['GlobalSecondaryIndexes']) ? [] : $fn['list-GlobalSecondaryIndexDescriptionList']($data['TableDescription']['GlobalSecondaryIndexes']),
+            'LocalSecondaryIndexes' => empty($data['TableDescription']['LocalSecondaryIndexes']) ? [] : $this->populateResultLocalSecondaryIndexDescriptionList($data['TableDescription']['LocalSecondaryIndexes']),
+            'GlobalSecondaryIndexes' => empty($data['TableDescription']['GlobalSecondaryIndexes']) ? [] : $this->populateResultGlobalSecondaryIndexDescriptionList($data['TableDescription']['GlobalSecondaryIndexes']),
             'StreamSpecification' => empty($data['TableDescription']['StreamSpecification']) ? null : new StreamSpecification([
                 'StreamEnabled' => filter_var($data['TableDescription']['StreamSpecification']['StreamEnabled'], \FILTER_VALIDATE_BOOLEAN),
                 'StreamViewType' => isset($data['TableDescription']['StreamSpecification']['StreamViewType']) ? (string) $data['TableDescription']['StreamSpecification']['StreamViewType'] : null,
@@ -177,7 +68,7 @@ class DeleteTableOutput extends Result
             'LatestStreamLabel' => isset($data['TableDescription']['LatestStreamLabel']) ? (string) $data['TableDescription']['LatestStreamLabel'] : null,
             'LatestStreamArn' => isset($data['TableDescription']['LatestStreamArn']) ? (string) $data['TableDescription']['LatestStreamArn'] : null,
             'GlobalTableVersion' => isset($data['TableDescription']['GlobalTableVersion']) ? (string) $data['TableDescription']['GlobalTableVersion'] : null,
-            'Replicas' => empty($data['TableDescription']['Replicas']) ? [] : $fn['list-ReplicaDescriptionList']($data['TableDescription']['Replicas']),
+            'Replicas' => empty($data['TableDescription']['Replicas']) ? [] : $this->populateResultReplicaDescriptionList($data['TableDescription']['Replicas']),
             'RestoreSummary' => empty($data['TableDescription']['RestoreSummary']) ? null : new RestoreSummary([
                 'SourceBackupArn' => isset($data['TableDescription']['RestoreSummary']['SourceBackupArn']) ? (string) $data['TableDescription']['RestoreSummary']['SourceBackupArn'] : null,
                 'SourceTableArn' => isset($data['TableDescription']['RestoreSummary']['SourceTableArn']) ? (string) $data['TableDescription']['RestoreSummary']['SourceTableArn'] : null,
@@ -196,5 +87,128 @@ class DeleteTableOutput extends Result
                 'ArchivalBackupArn' => isset($data['TableDescription']['ArchivalSummary']['ArchivalBackupArn']) ? (string) $data['TableDescription']['ArchivalSummary']['ArchivalBackupArn'] : null,
             ]),
         ]);
+    }
+
+    private function populateResultAttributeDefinitions(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new AttributeDefinition([
+                'AttributeName' => (string) $item['AttributeName'],
+                'AttributeType' => (string) $item['AttributeType'],
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultGlobalSecondaryIndexDescriptionList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new GlobalSecondaryIndexDescription([
+                'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
+                'KeySchema' => empty($item['KeySchema']) ? [] : $this->populateResultKeySchema($item['KeySchema']),
+                'Projection' => empty($item['Projection']) ? null : new Projection([
+                    'ProjectionType' => isset($item['Projection']['ProjectionType']) ? (string) $item['Projection']['ProjectionType'] : null,
+                    'NonKeyAttributes' => empty($item['Projection']['NonKeyAttributes']) ? [] : $this->populateResultNonKeyAttributeNameList($item['Projection']['NonKeyAttributes']),
+                ]),
+                'IndexStatus' => isset($item['IndexStatus']) ? (string) $item['IndexStatus'] : null,
+                'Backfilling' => isset($item['Backfilling']) ? filter_var($item['Backfilling'], \FILTER_VALIDATE_BOOLEAN) : null,
+                'ProvisionedThroughput' => empty($item['ProvisionedThroughput']) ? null : new ProvisionedThroughputDescription([
+                    'LastIncreaseDateTime' => (isset($item['ProvisionedThroughput']['LastIncreaseDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['ProvisionedThroughput']['LastIncreaseDateTime'])))) ? $d : null,
+                    'LastDecreaseDateTime' => (isset($item['ProvisionedThroughput']['LastDecreaseDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['ProvisionedThroughput']['LastDecreaseDateTime'])))) ? $d : null,
+                    'NumberOfDecreasesToday' => isset($item['ProvisionedThroughput']['NumberOfDecreasesToday']) ? (string) $item['ProvisionedThroughput']['NumberOfDecreasesToday'] : null,
+                    'ReadCapacityUnits' => isset($item['ProvisionedThroughput']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughput']['ReadCapacityUnits'] : null,
+                    'WriteCapacityUnits' => isset($item['ProvisionedThroughput']['WriteCapacityUnits']) ? (string) $item['ProvisionedThroughput']['WriteCapacityUnits'] : null,
+                ]),
+                'IndexSizeBytes' => isset($item['IndexSizeBytes']) ? (string) $item['IndexSizeBytes'] : null,
+                'ItemCount' => isset($item['ItemCount']) ? (string) $item['ItemCount'] : null,
+                'IndexArn' => isset($item['IndexArn']) ? (string) $item['IndexArn'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultKeySchema(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new KeySchemaElement([
+                'AttributeName' => (string) $item['AttributeName'],
+                'KeyType' => (string) $item['KeyType'],
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultLocalSecondaryIndexDescriptionList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new LocalSecondaryIndexDescription([
+                'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
+                'KeySchema' => empty($item['KeySchema']) ? [] : $this->populateResultKeySchema($item['KeySchema']),
+                'Projection' => empty($item['Projection']) ? null : new Projection([
+                    'ProjectionType' => isset($item['Projection']['ProjectionType']) ? (string) $item['Projection']['ProjectionType'] : null,
+                    'NonKeyAttributes' => empty($item['Projection']['NonKeyAttributes']) ? [] : $this->populateResultNonKeyAttributeNameList($item['Projection']['NonKeyAttributes']),
+                ]),
+                'IndexSizeBytes' => isset($item['IndexSizeBytes']) ? (string) $item['IndexSizeBytes'] : null,
+                'ItemCount' => isset($item['ItemCount']) ? (string) $item['ItemCount'] : null,
+                'IndexArn' => isset($item['IndexArn']) ? (string) $item['IndexArn'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultNonKeyAttributeNameList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (string) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultReplicaDescriptionList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new ReplicaDescription([
+                'RegionName' => isset($item['RegionName']) ? (string) $item['RegionName'] : null,
+                'ReplicaStatus' => isset($item['ReplicaStatus']) ? (string) $item['ReplicaStatus'] : null,
+                'ReplicaStatusDescription' => isset($item['ReplicaStatusDescription']) ? (string) $item['ReplicaStatusDescription'] : null,
+                'ReplicaStatusPercentProgress' => isset($item['ReplicaStatusPercentProgress']) ? (string) $item['ReplicaStatusPercentProgress'] : null,
+                'KMSMasterKeyId' => isset($item['KMSMasterKeyId']) ? (string) $item['KMSMasterKeyId'] : null,
+                'ProvisionedThroughputOverride' => empty($item['ProvisionedThroughputOverride']) ? null : new ProvisionedThroughputOverride([
+                    'ReadCapacityUnits' => isset($item['ProvisionedThroughputOverride']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughputOverride']['ReadCapacityUnits'] : null,
+                ]),
+                'GlobalSecondaryIndexes' => empty($item['GlobalSecondaryIndexes']) ? [] : $this->populateResultReplicaGlobalSecondaryIndexDescriptionList($item['GlobalSecondaryIndexes']),
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultReplicaGlobalSecondaryIndexDescriptionList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new ReplicaGlobalSecondaryIndexDescription([
+                'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
+                'ProvisionedThroughputOverride' => empty($item['ProvisionedThroughputOverride']) ? null : new ProvisionedThroughputOverride([
+                    'ReadCapacityUnits' => isset($item['ProvisionedThroughputOverride']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughputOverride']['ReadCapacityUnits'] : null,
+                ]),
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/DynamoDb/src/Result/DeleteTableOutput.php
+++ b/src/Service/DynamoDb/src/Result/DeleteTableOutput.php
@@ -89,6 +89,9 @@ class DeleteTableOutput extends Result
         ]);
     }
 
+    /**
+     * @return AttributeDefinition[]
+     */
     private function populateResultAttributeDefinitions(array $json): array
     {
         $items = [];
@@ -102,6 +105,9 @@ class DeleteTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return GlobalSecondaryIndexDescription[]
+     */
     private function populateResultGlobalSecondaryIndexDescriptionList(array $json): array
     {
         $items = [];
@@ -131,6 +137,9 @@ class DeleteTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return KeySchemaElement[]
+     */
     private function populateResultKeySchema(array $json): array
     {
         $items = [];
@@ -144,6 +153,9 @@ class DeleteTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return LocalSecondaryIndexDescription[]
+     */
     private function populateResultLocalSecondaryIndexDescriptionList(array $json): array
     {
         $items = [];
@@ -164,6 +176,9 @@ class DeleteTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return string[]
+     */
     private function populateResultNonKeyAttributeNameList(array $json): array
     {
         $items = [];
@@ -177,6 +192,9 @@ class DeleteTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return ReplicaDescription[]
+     */
     private function populateResultReplicaDescriptionList(array $json): array
     {
         $items = [];
@@ -197,6 +215,9 @@ class DeleteTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return ReplicaGlobalSecondaryIndexDescription[]
+     */
     private function populateResultReplicaGlobalSecondaryIndexDescriptionList(array $json): array
     {
         $items = [];

--- a/src/Service/DynamoDb/src/Result/DescribeTableOutput.php
+++ b/src/Service/DynamoDb/src/Result/DescribeTableOutput.php
@@ -37,120 +37,11 @@ class DescribeTableOutput extends Result
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-AttributeDefinitions'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new AttributeDefinition([
-                    'AttributeName' => (string) $item['AttributeName'],
-                    'AttributeType' => (string) $item['AttributeType'],
-                ]);
-            }
 
-            return $items;
-        };
-        $fn['list-KeySchema'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new KeySchemaElement([
-                    'AttributeName' => (string) $item['AttributeName'],
-                    'KeyType' => (string) $item['KeyType'],
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-LocalSecondaryIndexDescriptionList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new LocalSecondaryIndexDescription([
-                    'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
-                    'KeySchema' => empty($item['KeySchema']) ? [] : $fn['list-KeySchema']($item['KeySchema']),
-                    'Projection' => empty($item['Projection']) ? null : new Projection([
-                        'ProjectionType' => isset($item['Projection']['ProjectionType']) ? (string) $item['Projection']['ProjectionType'] : null,
-                        'NonKeyAttributes' => empty($item['Projection']['NonKeyAttributes']) ? [] : $fn['list-NonKeyAttributeNameList']($item['Projection']['NonKeyAttributes']),
-                    ]),
-                    'IndexSizeBytes' => isset($item['IndexSizeBytes']) ? (string) $item['IndexSizeBytes'] : null,
-                    'ItemCount' => isset($item['ItemCount']) ? (string) $item['ItemCount'] : null,
-                    'IndexArn' => isset($item['IndexArn']) ? (string) $item['IndexArn'] : null,
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-NonKeyAttributeNameList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (string) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
-
-            return $items;
-        };
-        $fn['list-GlobalSecondaryIndexDescriptionList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new GlobalSecondaryIndexDescription([
-                    'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
-                    'KeySchema' => empty($item['KeySchema']) ? [] : $fn['list-KeySchema']($item['KeySchema']),
-                    'Projection' => empty($item['Projection']) ? null : new Projection([
-                        'ProjectionType' => isset($item['Projection']['ProjectionType']) ? (string) $item['Projection']['ProjectionType'] : null,
-                        'NonKeyAttributes' => empty($item['Projection']['NonKeyAttributes']) ? [] : $fn['list-NonKeyAttributeNameList']($item['Projection']['NonKeyAttributes']),
-                    ]),
-                    'IndexStatus' => isset($item['IndexStatus']) ? (string) $item['IndexStatus'] : null,
-                    'Backfilling' => isset($item['Backfilling']) ? filter_var($item['Backfilling'], \FILTER_VALIDATE_BOOLEAN) : null,
-                    'ProvisionedThroughput' => empty($item['ProvisionedThroughput']) ? null : new ProvisionedThroughputDescription([
-                        'LastIncreaseDateTime' => (isset($item['ProvisionedThroughput']['LastIncreaseDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['ProvisionedThroughput']['LastIncreaseDateTime'])))) ? $d : null,
-                        'LastDecreaseDateTime' => (isset($item['ProvisionedThroughput']['LastDecreaseDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['ProvisionedThroughput']['LastDecreaseDateTime'])))) ? $d : null,
-                        'NumberOfDecreasesToday' => isset($item['ProvisionedThroughput']['NumberOfDecreasesToday']) ? (string) $item['ProvisionedThroughput']['NumberOfDecreasesToday'] : null,
-                        'ReadCapacityUnits' => isset($item['ProvisionedThroughput']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughput']['ReadCapacityUnits'] : null,
-                        'WriteCapacityUnits' => isset($item['ProvisionedThroughput']['WriteCapacityUnits']) ? (string) $item['ProvisionedThroughput']['WriteCapacityUnits'] : null,
-                    ]),
-                    'IndexSizeBytes' => isset($item['IndexSizeBytes']) ? (string) $item['IndexSizeBytes'] : null,
-                    'ItemCount' => isset($item['ItemCount']) ? (string) $item['ItemCount'] : null,
-                    'IndexArn' => isset($item['IndexArn']) ? (string) $item['IndexArn'] : null,
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-ReplicaDescriptionList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new ReplicaDescription([
-                    'RegionName' => isset($item['RegionName']) ? (string) $item['RegionName'] : null,
-                    'ReplicaStatus' => isset($item['ReplicaStatus']) ? (string) $item['ReplicaStatus'] : null,
-                    'ReplicaStatusDescription' => isset($item['ReplicaStatusDescription']) ? (string) $item['ReplicaStatusDescription'] : null,
-                    'ReplicaStatusPercentProgress' => isset($item['ReplicaStatusPercentProgress']) ? (string) $item['ReplicaStatusPercentProgress'] : null,
-                    'KMSMasterKeyId' => isset($item['KMSMasterKeyId']) ? (string) $item['KMSMasterKeyId'] : null,
-                    'ProvisionedThroughputOverride' => empty($item['ProvisionedThroughputOverride']) ? null : new ProvisionedThroughputOverride([
-                        'ReadCapacityUnits' => isset($item['ProvisionedThroughputOverride']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughputOverride']['ReadCapacityUnits'] : null,
-                    ]),
-                    'GlobalSecondaryIndexes' => empty($item['GlobalSecondaryIndexes']) ? [] : $fn['list-ReplicaGlobalSecondaryIndexDescriptionList']($item['GlobalSecondaryIndexes']),
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-ReplicaGlobalSecondaryIndexDescriptionList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new ReplicaGlobalSecondaryIndexDescription([
-                    'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
-                    'ProvisionedThroughputOverride' => empty($item['ProvisionedThroughputOverride']) ? null : new ProvisionedThroughputOverride([
-                        'ReadCapacityUnits' => isset($item['ProvisionedThroughputOverride']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughputOverride']['ReadCapacityUnits'] : null,
-                    ]),
-                ]);
-            }
-
-            return $items;
-        };
         $this->Table = empty($data['Table']) ? null : new TableDescription([
-            'AttributeDefinitions' => empty($data['Table']['AttributeDefinitions']) ? [] : $fn['list-AttributeDefinitions']($data['Table']['AttributeDefinitions']),
+            'AttributeDefinitions' => empty($data['Table']['AttributeDefinitions']) ? [] : $this->populateResultAttributeDefinitions($data['Table']['AttributeDefinitions']),
             'TableName' => isset($data['Table']['TableName']) ? (string) $data['Table']['TableName'] : null,
-            'KeySchema' => empty($data['Table']['KeySchema']) ? [] : $fn['list-KeySchema']($data['Table']['KeySchema']),
+            'KeySchema' => empty($data['Table']['KeySchema']) ? [] : $this->populateResultKeySchema($data['Table']['KeySchema']),
             'TableStatus' => isset($data['Table']['TableStatus']) ? (string) $data['Table']['TableStatus'] : null,
             'CreationDateTime' => (isset($data['Table']['CreationDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $data['Table']['CreationDateTime'])))) ? $d : null,
             'ProvisionedThroughput' => empty($data['Table']['ProvisionedThroughput']) ? null : new ProvisionedThroughputDescription([
@@ -168,8 +59,8 @@ class DescribeTableOutput extends Result
                 'BillingMode' => isset($data['Table']['BillingModeSummary']['BillingMode']) ? (string) $data['Table']['BillingModeSummary']['BillingMode'] : null,
                 'LastUpdateToPayPerRequestDateTime' => (isset($data['Table']['BillingModeSummary']['LastUpdateToPayPerRequestDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $data['Table']['BillingModeSummary']['LastUpdateToPayPerRequestDateTime'])))) ? $d : null,
             ]),
-            'LocalSecondaryIndexes' => empty($data['Table']['LocalSecondaryIndexes']) ? [] : $fn['list-LocalSecondaryIndexDescriptionList']($data['Table']['LocalSecondaryIndexes']),
-            'GlobalSecondaryIndexes' => empty($data['Table']['GlobalSecondaryIndexes']) ? [] : $fn['list-GlobalSecondaryIndexDescriptionList']($data['Table']['GlobalSecondaryIndexes']),
+            'LocalSecondaryIndexes' => empty($data['Table']['LocalSecondaryIndexes']) ? [] : $this->populateResultLocalSecondaryIndexDescriptionList($data['Table']['LocalSecondaryIndexes']),
+            'GlobalSecondaryIndexes' => empty($data['Table']['GlobalSecondaryIndexes']) ? [] : $this->populateResultGlobalSecondaryIndexDescriptionList($data['Table']['GlobalSecondaryIndexes']),
             'StreamSpecification' => empty($data['Table']['StreamSpecification']) ? null : new StreamSpecification([
                 'StreamEnabled' => filter_var($data['Table']['StreamSpecification']['StreamEnabled'], \FILTER_VALIDATE_BOOLEAN),
                 'StreamViewType' => isset($data['Table']['StreamSpecification']['StreamViewType']) ? (string) $data['Table']['StreamSpecification']['StreamViewType'] : null,
@@ -177,7 +68,7 @@ class DescribeTableOutput extends Result
             'LatestStreamLabel' => isset($data['Table']['LatestStreamLabel']) ? (string) $data['Table']['LatestStreamLabel'] : null,
             'LatestStreamArn' => isset($data['Table']['LatestStreamArn']) ? (string) $data['Table']['LatestStreamArn'] : null,
             'GlobalTableVersion' => isset($data['Table']['GlobalTableVersion']) ? (string) $data['Table']['GlobalTableVersion'] : null,
-            'Replicas' => empty($data['Table']['Replicas']) ? [] : $fn['list-ReplicaDescriptionList']($data['Table']['Replicas']),
+            'Replicas' => empty($data['Table']['Replicas']) ? [] : $this->populateResultReplicaDescriptionList($data['Table']['Replicas']),
             'RestoreSummary' => empty($data['Table']['RestoreSummary']) ? null : new RestoreSummary([
                 'SourceBackupArn' => isset($data['Table']['RestoreSummary']['SourceBackupArn']) ? (string) $data['Table']['RestoreSummary']['SourceBackupArn'] : null,
                 'SourceTableArn' => isset($data['Table']['RestoreSummary']['SourceTableArn']) ? (string) $data['Table']['RestoreSummary']['SourceTableArn'] : null,
@@ -196,5 +87,128 @@ class DescribeTableOutput extends Result
                 'ArchivalBackupArn' => isset($data['Table']['ArchivalSummary']['ArchivalBackupArn']) ? (string) $data['Table']['ArchivalSummary']['ArchivalBackupArn'] : null,
             ]),
         ]);
+    }
+
+    private function populateResultAttributeDefinitions(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new AttributeDefinition([
+                'AttributeName' => (string) $item['AttributeName'],
+                'AttributeType' => (string) $item['AttributeType'],
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultGlobalSecondaryIndexDescriptionList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new GlobalSecondaryIndexDescription([
+                'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
+                'KeySchema' => empty($item['KeySchema']) ? [] : $this->populateResultKeySchema($item['KeySchema']),
+                'Projection' => empty($item['Projection']) ? null : new Projection([
+                    'ProjectionType' => isset($item['Projection']['ProjectionType']) ? (string) $item['Projection']['ProjectionType'] : null,
+                    'NonKeyAttributes' => empty($item['Projection']['NonKeyAttributes']) ? [] : $this->populateResultNonKeyAttributeNameList($item['Projection']['NonKeyAttributes']),
+                ]),
+                'IndexStatus' => isset($item['IndexStatus']) ? (string) $item['IndexStatus'] : null,
+                'Backfilling' => isset($item['Backfilling']) ? filter_var($item['Backfilling'], \FILTER_VALIDATE_BOOLEAN) : null,
+                'ProvisionedThroughput' => empty($item['ProvisionedThroughput']) ? null : new ProvisionedThroughputDescription([
+                    'LastIncreaseDateTime' => (isset($item['ProvisionedThroughput']['LastIncreaseDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['ProvisionedThroughput']['LastIncreaseDateTime'])))) ? $d : null,
+                    'LastDecreaseDateTime' => (isset($item['ProvisionedThroughput']['LastDecreaseDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['ProvisionedThroughput']['LastDecreaseDateTime'])))) ? $d : null,
+                    'NumberOfDecreasesToday' => isset($item['ProvisionedThroughput']['NumberOfDecreasesToday']) ? (string) $item['ProvisionedThroughput']['NumberOfDecreasesToday'] : null,
+                    'ReadCapacityUnits' => isset($item['ProvisionedThroughput']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughput']['ReadCapacityUnits'] : null,
+                    'WriteCapacityUnits' => isset($item['ProvisionedThroughput']['WriteCapacityUnits']) ? (string) $item['ProvisionedThroughput']['WriteCapacityUnits'] : null,
+                ]),
+                'IndexSizeBytes' => isset($item['IndexSizeBytes']) ? (string) $item['IndexSizeBytes'] : null,
+                'ItemCount' => isset($item['ItemCount']) ? (string) $item['ItemCount'] : null,
+                'IndexArn' => isset($item['IndexArn']) ? (string) $item['IndexArn'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultKeySchema(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new KeySchemaElement([
+                'AttributeName' => (string) $item['AttributeName'],
+                'KeyType' => (string) $item['KeyType'],
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultLocalSecondaryIndexDescriptionList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new LocalSecondaryIndexDescription([
+                'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
+                'KeySchema' => empty($item['KeySchema']) ? [] : $this->populateResultKeySchema($item['KeySchema']),
+                'Projection' => empty($item['Projection']) ? null : new Projection([
+                    'ProjectionType' => isset($item['Projection']['ProjectionType']) ? (string) $item['Projection']['ProjectionType'] : null,
+                    'NonKeyAttributes' => empty($item['Projection']['NonKeyAttributes']) ? [] : $this->populateResultNonKeyAttributeNameList($item['Projection']['NonKeyAttributes']),
+                ]),
+                'IndexSizeBytes' => isset($item['IndexSizeBytes']) ? (string) $item['IndexSizeBytes'] : null,
+                'ItemCount' => isset($item['ItemCount']) ? (string) $item['ItemCount'] : null,
+                'IndexArn' => isset($item['IndexArn']) ? (string) $item['IndexArn'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultNonKeyAttributeNameList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (string) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultReplicaDescriptionList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new ReplicaDescription([
+                'RegionName' => isset($item['RegionName']) ? (string) $item['RegionName'] : null,
+                'ReplicaStatus' => isset($item['ReplicaStatus']) ? (string) $item['ReplicaStatus'] : null,
+                'ReplicaStatusDescription' => isset($item['ReplicaStatusDescription']) ? (string) $item['ReplicaStatusDescription'] : null,
+                'ReplicaStatusPercentProgress' => isset($item['ReplicaStatusPercentProgress']) ? (string) $item['ReplicaStatusPercentProgress'] : null,
+                'KMSMasterKeyId' => isset($item['KMSMasterKeyId']) ? (string) $item['KMSMasterKeyId'] : null,
+                'ProvisionedThroughputOverride' => empty($item['ProvisionedThroughputOverride']) ? null : new ProvisionedThroughputOverride([
+                    'ReadCapacityUnits' => isset($item['ProvisionedThroughputOverride']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughputOverride']['ReadCapacityUnits'] : null,
+                ]),
+                'GlobalSecondaryIndexes' => empty($item['GlobalSecondaryIndexes']) ? [] : $this->populateResultReplicaGlobalSecondaryIndexDescriptionList($item['GlobalSecondaryIndexes']),
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultReplicaGlobalSecondaryIndexDescriptionList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new ReplicaGlobalSecondaryIndexDescription([
+                'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
+                'ProvisionedThroughputOverride' => empty($item['ProvisionedThroughputOverride']) ? null : new ProvisionedThroughputOverride([
+                    'ReadCapacityUnits' => isset($item['ProvisionedThroughputOverride']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughputOverride']['ReadCapacityUnits'] : null,
+                ]),
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/DynamoDb/src/Result/DescribeTableOutput.php
+++ b/src/Service/DynamoDb/src/Result/DescribeTableOutput.php
@@ -89,6 +89,9 @@ class DescribeTableOutput extends Result
         ]);
     }
 
+    /**
+     * @return AttributeDefinition[]
+     */
     private function populateResultAttributeDefinitions(array $json): array
     {
         $items = [];
@@ -102,6 +105,9 @@ class DescribeTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return GlobalSecondaryIndexDescription[]
+     */
     private function populateResultGlobalSecondaryIndexDescriptionList(array $json): array
     {
         $items = [];
@@ -131,6 +137,9 @@ class DescribeTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return KeySchemaElement[]
+     */
     private function populateResultKeySchema(array $json): array
     {
         $items = [];
@@ -144,6 +153,9 @@ class DescribeTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return LocalSecondaryIndexDescription[]
+     */
     private function populateResultLocalSecondaryIndexDescriptionList(array $json): array
     {
         $items = [];
@@ -164,6 +176,9 @@ class DescribeTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return string[]
+     */
     private function populateResultNonKeyAttributeNameList(array $json): array
     {
         $items = [];
@@ -177,6 +192,9 @@ class DescribeTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return ReplicaDescription[]
+     */
     private function populateResultReplicaDescriptionList(array $json): array
     {
         $items = [];
@@ -197,6 +215,9 @@ class DescribeTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return ReplicaGlobalSecondaryIndexDescription[]
+     */
     private function populateResultReplicaGlobalSecondaryIndexDescriptionList(array $json): array
     {
         $items = [];

--- a/src/Service/DynamoDb/src/Result/GetItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/GetItemOutput.php
@@ -62,6 +62,9 @@ class GetItemOutput extends Result
         ]);
     }
 
+    /**
+     * @return array<string, AttributeValue>
+     */
     private function populateResultAttributeMap(array $json): array
     {
         $items = [];
@@ -72,6 +75,9 @@ class GetItemOutput extends Result
         return $items;
     }
 
+    /**
+     * @return array<string, Capacity>
+     */
     private function populateResultSecondaryIndexesCapacityMap(array $json): array
     {
         $items = [];

--- a/src/Service/DynamoDb/src/Result/GetItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/GetItemOutput.php
@@ -45,27 +45,8 @@ class GetItemOutput extends Result
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue> */
-        $fn['map-AttributeMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = AttributeValue::create($value);
-            }
 
-            return $items;
-        };
-
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\Capacity> */
-        $fn['map-SecondaryIndexesCapacityMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = Capacity::create($value);
-            }
-
-            return $items;
-        };
-        $this->Item = empty($data['Item']) ? [] : $fn['map-AttributeMap']($data['Item']);
+        $this->Item = empty($data['Item']) ? [] : $this->populateResultAttributeMap($data['Item']);
         $this->ConsumedCapacity = empty($data['ConsumedCapacity']) ? null : new ConsumedCapacity([
             'TableName' => isset($data['ConsumedCapacity']['TableName']) ? (string) $data['ConsumedCapacity']['TableName'] : null,
             'CapacityUnits' => isset($data['ConsumedCapacity']['CapacityUnits']) ? (float) $data['ConsumedCapacity']['CapacityUnits'] : null,
@@ -76,8 +57,28 @@ class GetItemOutput extends Result
                 'WriteCapacityUnits' => isset($data['ConsumedCapacity']['Table']['WriteCapacityUnits']) ? (float) $data['ConsumedCapacity']['Table']['WriteCapacityUnits'] : null,
                 'CapacityUnits' => isset($data['ConsumedCapacity']['Table']['CapacityUnits']) ? (float) $data['ConsumedCapacity']['Table']['CapacityUnits'] : null,
             ]),
-            'LocalSecondaryIndexes' => empty($data['ConsumedCapacity']['LocalSecondaryIndexes']) ? [] : $fn['map-SecondaryIndexesCapacityMap']($data['ConsumedCapacity']['LocalSecondaryIndexes']),
-            'GlobalSecondaryIndexes' => empty($data['ConsumedCapacity']['GlobalSecondaryIndexes']) ? [] : $fn['map-SecondaryIndexesCapacityMap']($data['ConsumedCapacity']['GlobalSecondaryIndexes']),
+            'LocalSecondaryIndexes' => empty($data['ConsumedCapacity']['LocalSecondaryIndexes']) ? [] : $this->populateResultSecondaryIndexesCapacityMap($data['ConsumedCapacity']['LocalSecondaryIndexes']),
+            'GlobalSecondaryIndexes' => empty($data['ConsumedCapacity']['GlobalSecondaryIndexes']) ? [] : $this->populateResultSecondaryIndexesCapacityMap($data['ConsumedCapacity']['GlobalSecondaryIndexes']),
         ]);
+    }
+
+    private function populateResultAttributeMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = AttributeValue::create($value);
+        }
+
+        return $items;
+    }
+
+    private function populateResultSecondaryIndexesCapacityMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = Capacity::create($value);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/DynamoDb/src/Result/ListTablesOutput.php
+++ b/src/Service/DynamoDb/src/Result/ListTablesOutput.php
@@ -118,6 +118,9 @@ class ListTablesOutput extends Result implements \IteratorAggregate
         $this->LastEvaluatedTableName = isset($data['LastEvaluatedTableName']) ? (string) $data['LastEvaluatedTableName'] : null;
     }
 
+    /**
+     * @return string[]
+     */
     private function populateResultTableNameList(array $json): array
     {
         $items = [];

--- a/src/Service/DynamoDb/src/Result/ListTablesOutput.php
+++ b/src/Service/DynamoDb/src/Result/ListTablesOutput.php
@@ -113,19 +113,21 @@ class ListTablesOutput extends Result implements \IteratorAggregate
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-TableNameList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (string) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
 
-            return $items;
-        };
-        $this->TableNames = empty($data['TableNames']) ? [] : $fn['list-TableNameList']($data['TableNames']);
+        $this->TableNames = empty($data['TableNames']) ? [] : $this->populateResultTableNameList($data['TableNames']);
         $this->LastEvaluatedTableName = isset($data['LastEvaluatedTableName']) ? (string) $data['LastEvaluatedTableName'] : null;
+    }
+
+    private function populateResultTableNameList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (string) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
     }
 }

--- a/src/Service/DynamoDb/src/Result/PutItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/PutItemOutput.php
@@ -61,48 +61,8 @@ class PutItemOutput extends Result
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue> */
-        $fn['map-AttributeMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = AttributeValue::create($value);
-            }
 
-            return $items;
-        };
-
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\Capacity> */
-        $fn['map-SecondaryIndexesCapacityMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = Capacity::create($value);
-            }
-
-            return $items;
-        };
-
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue> */
-        $fn['map-ItemCollectionKeyAttributeMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = AttributeValue::create($value);
-            }
-
-            return $items;
-        };
-        $fn['list-ItemCollectionSizeEstimateRange'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (float) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
-
-            return $items;
-        };
-        $this->Attributes = empty($data['Attributes']) ? [] : $fn['map-AttributeMap']($data['Attributes']);
+        $this->Attributes = empty($data['Attributes']) ? [] : $this->populateResultAttributeMap($data['Attributes']);
         $this->ConsumedCapacity = empty($data['ConsumedCapacity']) ? null : new ConsumedCapacity([
             'TableName' => isset($data['ConsumedCapacity']['TableName']) ? (string) $data['ConsumedCapacity']['TableName'] : null,
             'CapacityUnits' => isset($data['ConsumedCapacity']['CapacityUnits']) ? (float) $data['ConsumedCapacity']['CapacityUnits'] : null,
@@ -113,12 +73,55 @@ class PutItemOutput extends Result
                 'WriteCapacityUnits' => isset($data['ConsumedCapacity']['Table']['WriteCapacityUnits']) ? (float) $data['ConsumedCapacity']['Table']['WriteCapacityUnits'] : null,
                 'CapacityUnits' => isset($data['ConsumedCapacity']['Table']['CapacityUnits']) ? (float) $data['ConsumedCapacity']['Table']['CapacityUnits'] : null,
             ]),
-            'LocalSecondaryIndexes' => empty($data['ConsumedCapacity']['LocalSecondaryIndexes']) ? [] : $fn['map-SecondaryIndexesCapacityMap']($data['ConsumedCapacity']['LocalSecondaryIndexes']),
-            'GlobalSecondaryIndexes' => empty($data['ConsumedCapacity']['GlobalSecondaryIndexes']) ? [] : $fn['map-SecondaryIndexesCapacityMap']($data['ConsumedCapacity']['GlobalSecondaryIndexes']),
+            'LocalSecondaryIndexes' => empty($data['ConsumedCapacity']['LocalSecondaryIndexes']) ? [] : $this->populateResultSecondaryIndexesCapacityMap($data['ConsumedCapacity']['LocalSecondaryIndexes']),
+            'GlobalSecondaryIndexes' => empty($data['ConsumedCapacity']['GlobalSecondaryIndexes']) ? [] : $this->populateResultSecondaryIndexesCapacityMap($data['ConsumedCapacity']['GlobalSecondaryIndexes']),
         ]);
         $this->ItemCollectionMetrics = empty($data['ItemCollectionMetrics']) ? null : new ItemCollectionMetrics([
-            'ItemCollectionKey' => empty($data['ItemCollectionMetrics']['ItemCollectionKey']) ? [] : $fn['map-ItemCollectionKeyAttributeMap']($data['ItemCollectionMetrics']['ItemCollectionKey']),
-            'SizeEstimateRangeGB' => empty($data['ItemCollectionMetrics']['SizeEstimateRangeGB']) ? [] : $fn['list-ItemCollectionSizeEstimateRange']($data['ItemCollectionMetrics']['SizeEstimateRangeGB']),
+            'ItemCollectionKey' => empty($data['ItemCollectionMetrics']['ItemCollectionKey']) ? [] : $this->populateResultItemCollectionKeyAttributeMap($data['ItemCollectionMetrics']['ItemCollectionKey']),
+            'SizeEstimateRangeGB' => empty($data['ItemCollectionMetrics']['SizeEstimateRangeGB']) ? [] : $this->populateResultItemCollectionSizeEstimateRange($data['ItemCollectionMetrics']['SizeEstimateRangeGB']),
         ]);
+    }
+
+    private function populateResultAttributeMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = AttributeValue::create($value);
+        }
+
+        return $items;
+    }
+
+    private function populateResultItemCollectionKeyAttributeMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = AttributeValue::create($value);
+        }
+
+        return $items;
+    }
+
+    private function populateResultItemCollectionSizeEstimateRange(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (float) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultSecondaryIndexesCapacityMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = Capacity::create($value);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/DynamoDb/src/Result/PutItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/PutItemOutput.php
@@ -82,6 +82,9 @@ class PutItemOutput extends Result
         ]);
     }
 
+    /**
+     * @return array<string, AttributeValue>
+     */
     private function populateResultAttributeMap(array $json): array
     {
         $items = [];
@@ -92,6 +95,9 @@ class PutItemOutput extends Result
         return $items;
     }
 
+    /**
+     * @return array<string, AttributeValue>
+     */
     private function populateResultItemCollectionKeyAttributeMap(array $json): array
     {
         $items = [];
@@ -102,6 +108,9 @@ class PutItemOutput extends Result
         return $items;
     }
 
+    /**
+     * @return float[]
+     */
     private function populateResultItemCollectionSizeEstimateRange(array $json): array
     {
         $items = [];
@@ -115,6 +124,9 @@ class PutItemOutput extends Result
         return $items;
     }
 
+    /**
+     * @return array<string, Capacity>
+     */
     private function populateResultSecondaryIndexesCapacityMap(array $json): array
     {
         $items = [];

--- a/src/Service/DynamoDb/src/Result/QueryOutput.php
+++ b/src/Service/DynamoDb/src/Result/QueryOutput.php
@@ -184,6 +184,9 @@ class QueryOutput extends Result implements \IteratorAggregate
         ]);
     }
 
+    /**
+     * @return array<string, AttributeValue>
+     */
     private function populateResultAttributeMap(array $json): array
     {
         $items = [];
@@ -194,6 +197,9 @@ class QueryOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return array[]
+     */
     private function populateResultItemList(array $json): array
     {
         $items = [];
@@ -207,6 +213,9 @@ class QueryOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return array<string, AttributeValue>
+     */
     private function populateResultKey(array $json): array
     {
         $items = [];
@@ -217,6 +226,9 @@ class QueryOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return array<string, Capacity>
+     */
     private function populateResultSecondaryIndexesCapacityMap(array $json): array
     {
         $items = [];

--- a/src/Service/DynamoDb/src/Result/QueryOutput.php
+++ b/src/Service/DynamoDb/src/Result/QueryOutput.php
@@ -164,52 +164,11 @@ class QueryOutput extends Result implements \IteratorAggregate
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-ItemList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = empty($item) ? [] : $fn['map-AttributeMap']($item);
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
 
-            return $items;
-        };
-
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue> */
-        $fn['map-AttributeMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = AttributeValue::create($value);
-            }
-
-            return $items;
-        };
-
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue> */
-        $fn['map-Key'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = AttributeValue::create($value);
-            }
-
-            return $items;
-        };
-
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\Capacity> */
-        $fn['map-SecondaryIndexesCapacityMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = Capacity::create($value);
-            }
-
-            return $items;
-        };
-        $this->Items = empty($data['Items']) ? [] : $fn['list-ItemList']($data['Items']);
+        $this->Items = empty($data['Items']) ? [] : $this->populateResultItemList($data['Items']);
         $this->Count = isset($data['Count']) ? (int) $data['Count'] : null;
         $this->ScannedCount = isset($data['ScannedCount']) ? (int) $data['ScannedCount'] : null;
-        $this->LastEvaluatedKey = empty($data['LastEvaluatedKey']) ? [] : $fn['map-Key']($data['LastEvaluatedKey']);
+        $this->LastEvaluatedKey = empty($data['LastEvaluatedKey']) ? [] : $this->populateResultKey($data['LastEvaluatedKey']);
         $this->ConsumedCapacity = empty($data['ConsumedCapacity']) ? null : new ConsumedCapacity([
             'TableName' => isset($data['ConsumedCapacity']['TableName']) ? (string) $data['ConsumedCapacity']['TableName'] : null,
             'CapacityUnits' => isset($data['ConsumedCapacity']['CapacityUnits']) ? (float) $data['ConsumedCapacity']['CapacityUnits'] : null,
@@ -220,8 +179,51 @@ class QueryOutput extends Result implements \IteratorAggregate
                 'WriteCapacityUnits' => isset($data['ConsumedCapacity']['Table']['WriteCapacityUnits']) ? (float) $data['ConsumedCapacity']['Table']['WriteCapacityUnits'] : null,
                 'CapacityUnits' => isset($data['ConsumedCapacity']['Table']['CapacityUnits']) ? (float) $data['ConsumedCapacity']['Table']['CapacityUnits'] : null,
             ]),
-            'LocalSecondaryIndexes' => empty($data['ConsumedCapacity']['LocalSecondaryIndexes']) ? [] : $fn['map-SecondaryIndexesCapacityMap']($data['ConsumedCapacity']['LocalSecondaryIndexes']),
-            'GlobalSecondaryIndexes' => empty($data['ConsumedCapacity']['GlobalSecondaryIndexes']) ? [] : $fn['map-SecondaryIndexesCapacityMap']($data['ConsumedCapacity']['GlobalSecondaryIndexes']),
+            'LocalSecondaryIndexes' => empty($data['ConsumedCapacity']['LocalSecondaryIndexes']) ? [] : $this->populateResultSecondaryIndexesCapacityMap($data['ConsumedCapacity']['LocalSecondaryIndexes']),
+            'GlobalSecondaryIndexes' => empty($data['ConsumedCapacity']['GlobalSecondaryIndexes']) ? [] : $this->populateResultSecondaryIndexesCapacityMap($data['ConsumedCapacity']['GlobalSecondaryIndexes']),
         ]);
+    }
+
+    private function populateResultAttributeMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = AttributeValue::create($value);
+        }
+
+        return $items;
+    }
+
+    private function populateResultItemList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = empty($item) ? [] : $this->populateResultAttributeMap($item);
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultKey(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = AttributeValue::create($value);
+        }
+
+        return $items;
+    }
+
+    private function populateResultSecondaryIndexesCapacityMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = Capacity::create($value);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/DynamoDb/src/Result/ScanOutput.php
+++ b/src/Service/DynamoDb/src/Result/ScanOutput.php
@@ -164,52 +164,11 @@ class ScanOutput extends Result implements \IteratorAggregate
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-ItemList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = empty($item) ? [] : $fn['map-AttributeMap']($item);
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
 
-            return $items;
-        };
-
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue> */
-        $fn['map-AttributeMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = AttributeValue::create($value);
-            }
-
-            return $items;
-        };
-
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue> */
-        $fn['map-Key'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = AttributeValue::create($value);
-            }
-
-            return $items;
-        };
-
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\Capacity> */
-        $fn['map-SecondaryIndexesCapacityMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = Capacity::create($value);
-            }
-
-            return $items;
-        };
-        $this->Items = empty($data['Items']) ? [] : $fn['list-ItemList']($data['Items']);
+        $this->Items = empty($data['Items']) ? [] : $this->populateResultItemList($data['Items']);
         $this->Count = isset($data['Count']) ? (int) $data['Count'] : null;
         $this->ScannedCount = isset($data['ScannedCount']) ? (int) $data['ScannedCount'] : null;
-        $this->LastEvaluatedKey = empty($data['LastEvaluatedKey']) ? [] : $fn['map-Key']($data['LastEvaluatedKey']);
+        $this->LastEvaluatedKey = empty($data['LastEvaluatedKey']) ? [] : $this->populateResultKey($data['LastEvaluatedKey']);
         $this->ConsumedCapacity = empty($data['ConsumedCapacity']) ? null : new ConsumedCapacity([
             'TableName' => isset($data['ConsumedCapacity']['TableName']) ? (string) $data['ConsumedCapacity']['TableName'] : null,
             'CapacityUnits' => isset($data['ConsumedCapacity']['CapacityUnits']) ? (float) $data['ConsumedCapacity']['CapacityUnits'] : null,
@@ -220,8 +179,51 @@ class ScanOutput extends Result implements \IteratorAggregate
                 'WriteCapacityUnits' => isset($data['ConsumedCapacity']['Table']['WriteCapacityUnits']) ? (float) $data['ConsumedCapacity']['Table']['WriteCapacityUnits'] : null,
                 'CapacityUnits' => isset($data['ConsumedCapacity']['Table']['CapacityUnits']) ? (float) $data['ConsumedCapacity']['Table']['CapacityUnits'] : null,
             ]),
-            'LocalSecondaryIndexes' => empty($data['ConsumedCapacity']['LocalSecondaryIndexes']) ? [] : $fn['map-SecondaryIndexesCapacityMap']($data['ConsumedCapacity']['LocalSecondaryIndexes']),
-            'GlobalSecondaryIndexes' => empty($data['ConsumedCapacity']['GlobalSecondaryIndexes']) ? [] : $fn['map-SecondaryIndexesCapacityMap']($data['ConsumedCapacity']['GlobalSecondaryIndexes']),
+            'LocalSecondaryIndexes' => empty($data['ConsumedCapacity']['LocalSecondaryIndexes']) ? [] : $this->populateResultSecondaryIndexesCapacityMap($data['ConsumedCapacity']['LocalSecondaryIndexes']),
+            'GlobalSecondaryIndexes' => empty($data['ConsumedCapacity']['GlobalSecondaryIndexes']) ? [] : $this->populateResultSecondaryIndexesCapacityMap($data['ConsumedCapacity']['GlobalSecondaryIndexes']),
         ]);
+    }
+
+    private function populateResultAttributeMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = AttributeValue::create($value);
+        }
+
+        return $items;
+    }
+
+    private function populateResultItemList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = empty($item) ? [] : $this->populateResultAttributeMap($item);
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultKey(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = AttributeValue::create($value);
+        }
+
+        return $items;
+    }
+
+    private function populateResultSecondaryIndexesCapacityMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = Capacity::create($value);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/DynamoDb/src/Result/ScanOutput.php
+++ b/src/Service/DynamoDb/src/Result/ScanOutput.php
@@ -184,6 +184,9 @@ class ScanOutput extends Result implements \IteratorAggregate
         ]);
     }
 
+    /**
+     * @return array<string, AttributeValue>
+     */
     private function populateResultAttributeMap(array $json): array
     {
         $items = [];
@@ -194,6 +197,9 @@ class ScanOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return array[]
+     */
     private function populateResultItemList(array $json): array
     {
         $items = [];
@@ -207,6 +213,9 @@ class ScanOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return array<string, AttributeValue>
+     */
     private function populateResultKey(array $json): array
     {
         $items = [];
@@ -217,6 +226,9 @@ class ScanOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return array<string, Capacity>
+     */
     private function populateResultSecondaryIndexesCapacityMap(array $json): array
     {
         $items = [];

--- a/src/Service/DynamoDb/src/Result/UpdateItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/UpdateItemOutput.php
@@ -82,6 +82,9 @@ class UpdateItemOutput extends Result
         ]);
     }
 
+    /**
+     * @return array<string, AttributeValue>
+     */
     private function populateResultAttributeMap(array $json): array
     {
         $items = [];
@@ -92,6 +95,9 @@ class UpdateItemOutput extends Result
         return $items;
     }
 
+    /**
+     * @return array<string, AttributeValue>
+     */
     private function populateResultItemCollectionKeyAttributeMap(array $json): array
     {
         $items = [];
@@ -102,6 +108,9 @@ class UpdateItemOutput extends Result
         return $items;
     }
 
+    /**
+     * @return float[]
+     */
     private function populateResultItemCollectionSizeEstimateRange(array $json): array
     {
         $items = [];
@@ -115,6 +124,9 @@ class UpdateItemOutput extends Result
         return $items;
     }
 
+    /**
+     * @return array<string, Capacity>
+     */
     private function populateResultSecondaryIndexesCapacityMap(array $json): array
     {
         $items = [];

--- a/src/Service/DynamoDb/src/Result/UpdateItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/UpdateItemOutput.php
@@ -61,48 +61,8 @@ class UpdateItemOutput extends Result
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue> */
-        $fn['map-AttributeMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = AttributeValue::create($value);
-            }
 
-            return $items;
-        };
-
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\Capacity> */
-        $fn['map-SecondaryIndexesCapacityMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = Capacity::create($value);
-            }
-
-            return $items;
-        };
-
-        /** @return array<string, \AsyncAws\DynamoDb\ValueObject\AttributeValue> */
-        $fn['map-ItemCollectionKeyAttributeMap'] = static function (array $json): array {
-            $items = [];
-            foreach ($json as $name => $value) {
-                $items[(string) $name] = AttributeValue::create($value);
-            }
-
-            return $items;
-        };
-        $fn['list-ItemCollectionSizeEstimateRange'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (float) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
-
-            return $items;
-        };
-        $this->Attributes = empty($data['Attributes']) ? [] : $fn['map-AttributeMap']($data['Attributes']);
+        $this->Attributes = empty($data['Attributes']) ? [] : $this->populateResultAttributeMap($data['Attributes']);
         $this->ConsumedCapacity = empty($data['ConsumedCapacity']) ? null : new ConsumedCapacity([
             'TableName' => isset($data['ConsumedCapacity']['TableName']) ? (string) $data['ConsumedCapacity']['TableName'] : null,
             'CapacityUnits' => isset($data['ConsumedCapacity']['CapacityUnits']) ? (float) $data['ConsumedCapacity']['CapacityUnits'] : null,
@@ -113,12 +73,55 @@ class UpdateItemOutput extends Result
                 'WriteCapacityUnits' => isset($data['ConsumedCapacity']['Table']['WriteCapacityUnits']) ? (float) $data['ConsumedCapacity']['Table']['WriteCapacityUnits'] : null,
                 'CapacityUnits' => isset($data['ConsumedCapacity']['Table']['CapacityUnits']) ? (float) $data['ConsumedCapacity']['Table']['CapacityUnits'] : null,
             ]),
-            'LocalSecondaryIndexes' => empty($data['ConsumedCapacity']['LocalSecondaryIndexes']) ? [] : $fn['map-SecondaryIndexesCapacityMap']($data['ConsumedCapacity']['LocalSecondaryIndexes']),
-            'GlobalSecondaryIndexes' => empty($data['ConsumedCapacity']['GlobalSecondaryIndexes']) ? [] : $fn['map-SecondaryIndexesCapacityMap']($data['ConsumedCapacity']['GlobalSecondaryIndexes']),
+            'LocalSecondaryIndexes' => empty($data['ConsumedCapacity']['LocalSecondaryIndexes']) ? [] : $this->populateResultSecondaryIndexesCapacityMap($data['ConsumedCapacity']['LocalSecondaryIndexes']),
+            'GlobalSecondaryIndexes' => empty($data['ConsumedCapacity']['GlobalSecondaryIndexes']) ? [] : $this->populateResultSecondaryIndexesCapacityMap($data['ConsumedCapacity']['GlobalSecondaryIndexes']),
         ]);
         $this->ItemCollectionMetrics = empty($data['ItemCollectionMetrics']) ? null : new ItemCollectionMetrics([
-            'ItemCollectionKey' => empty($data['ItemCollectionMetrics']['ItemCollectionKey']) ? [] : $fn['map-ItemCollectionKeyAttributeMap']($data['ItemCollectionMetrics']['ItemCollectionKey']),
-            'SizeEstimateRangeGB' => empty($data['ItemCollectionMetrics']['SizeEstimateRangeGB']) ? [] : $fn['list-ItemCollectionSizeEstimateRange']($data['ItemCollectionMetrics']['SizeEstimateRangeGB']),
+            'ItemCollectionKey' => empty($data['ItemCollectionMetrics']['ItemCollectionKey']) ? [] : $this->populateResultItemCollectionKeyAttributeMap($data['ItemCollectionMetrics']['ItemCollectionKey']),
+            'SizeEstimateRangeGB' => empty($data['ItemCollectionMetrics']['SizeEstimateRangeGB']) ? [] : $this->populateResultItemCollectionSizeEstimateRange($data['ItemCollectionMetrics']['SizeEstimateRangeGB']),
         ]);
+    }
+
+    private function populateResultAttributeMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = AttributeValue::create($value);
+        }
+
+        return $items;
+    }
+
+    private function populateResultItemCollectionKeyAttributeMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = AttributeValue::create($value);
+        }
+
+        return $items;
+    }
+
+    private function populateResultItemCollectionSizeEstimateRange(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (float) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultSecondaryIndexesCapacityMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = Capacity::create($value);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/DynamoDb/src/Result/UpdateTableOutput.php
+++ b/src/Service/DynamoDb/src/Result/UpdateTableOutput.php
@@ -89,6 +89,9 @@ class UpdateTableOutput extends Result
         ]);
     }
 
+    /**
+     * @return AttributeDefinition[]
+     */
     private function populateResultAttributeDefinitions(array $json): array
     {
         $items = [];
@@ -102,6 +105,9 @@ class UpdateTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return GlobalSecondaryIndexDescription[]
+     */
     private function populateResultGlobalSecondaryIndexDescriptionList(array $json): array
     {
         $items = [];
@@ -131,6 +137,9 @@ class UpdateTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return KeySchemaElement[]
+     */
     private function populateResultKeySchema(array $json): array
     {
         $items = [];
@@ -144,6 +153,9 @@ class UpdateTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return LocalSecondaryIndexDescription[]
+     */
     private function populateResultLocalSecondaryIndexDescriptionList(array $json): array
     {
         $items = [];
@@ -164,6 +176,9 @@ class UpdateTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return string[]
+     */
     private function populateResultNonKeyAttributeNameList(array $json): array
     {
         $items = [];
@@ -177,6 +192,9 @@ class UpdateTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return ReplicaDescription[]
+     */
     private function populateResultReplicaDescriptionList(array $json): array
     {
         $items = [];
@@ -197,6 +215,9 @@ class UpdateTableOutput extends Result
         return $items;
     }
 
+    /**
+     * @return ReplicaGlobalSecondaryIndexDescription[]
+     */
     private function populateResultReplicaGlobalSecondaryIndexDescriptionList(array $json): array
     {
         $items = [];

--- a/src/Service/DynamoDb/src/Result/UpdateTableOutput.php
+++ b/src/Service/DynamoDb/src/Result/UpdateTableOutput.php
@@ -37,120 +37,11 @@ class UpdateTableOutput extends Result
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-AttributeDefinitions'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new AttributeDefinition([
-                    'AttributeName' => (string) $item['AttributeName'],
-                    'AttributeType' => (string) $item['AttributeType'],
-                ]);
-            }
 
-            return $items;
-        };
-        $fn['list-KeySchema'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new KeySchemaElement([
-                    'AttributeName' => (string) $item['AttributeName'],
-                    'KeyType' => (string) $item['KeyType'],
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-LocalSecondaryIndexDescriptionList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new LocalSecondaryIndexDescription([
-                    'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
-                    'KeySchema' => empty($item['KeySchema']) ? [] : $fn['list-KeySchema']($item['KeySchema']),
-                    'Projection' => empty($item['Projection']) ? null : new Projection([
-                        'ProjectionType' => isset($item['Projection']['ProjectionType']) ? (string) $item['Projection']['ProjectionType'] : null,
-                        'NonKeyAttributes' => empty($item['Projection']['NonKeyAttributes']) ? [] : $fn['list-NonKeyAttributeNameList']($item['Projection']['NonKeyAttributes']),
-                    ]),
-                    'IndexSizeBytes' => isset($item['IndexSizeBytes']) ? (string) $item['IndexSizeBytes'] : null,
-                    'ItemCount' => isset($item['ItemCount']) ? (string) $item['ItemCount'] : null,
-                    'IndexArn' => isset($item['IndexArn']) ? (string) $item['IndexArn'] : null,
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-NonKeyAttributeNameList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (string) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
-
-            return $items;
-        };
-        $fn['list-GlobalSecondaryIndexDescriptionList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new GlobalSecondaryIndexDescription([
-                    'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
-                    'KeySchema' => empty($item['KeySchema']) ? [] : $fn['list-KeySchema']($item['KeySchema']),
-                    'Projection' => empty($item['Projection']) ? null : new Projection([
-                        'ProjectionType' => isset($item['Projection']['ProjectionType']) ? (string) $item['Projection']['ProjectionType'] : null,
-                        'NonKeyAttributes' => empty($item['Projection']['NonKeyAttributes']) ? [] : $fn['list-NonKeyAttributeNameList']($item['Projection']['NonKeyAttributes']),
-                    ]),
-                    'IndexStatus' => isset($item['IndexStatus']) ? (string) $item['IndexStatus'] : null,
-                    'Backfilling' => isset($item['Backfilling']) ? filter_var($item['Backfilling'], \FILTER_VALIDATE_BOOLEAN) : null,
-                    'ProvisionedThroughput' => empty($item['ProvisionedThroughput']) ? null : new ProvisionedThroughputDescription([
-                        'LastIncreaseDateTime' => (isset($item['ProvisionedThroughput']['LastIncreaseDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['ProvisionedThroughput']['LastIncreaseDateTime'])))) ? $d : null,
-                        'LastDecreaseDateTime' => (isset($item['ProvisionedThroughput']['LastDecreaseDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['ProvisionedThroughput']['LastDecreaseDateTime'])))) ? $d : null,
-                        'NumberOfDecreasesToday' => isset($item['ProvisionedThroughput']['NumberOfDecreasesToday']) ? (string) $item['ProvisionedThroughput']['NumberOfDecreasesToday'] : null,
-                        'ReadCapacityUnits' => isset($item['ProvisionedThroughput']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughput']['ReadCapacityUnits'] : null,
-                        'WriteCapacityUnits' => isset($item['ProvisionedThroughput']['WriteCapacityUnits']) ? (string) $item['ProvisionedThroughput']['WriteCapacityUnits'] : null,
-                    ]),
-                    'IndexSizeBytes' => isset($item['IndexSizeBytes']) ? (string) $item['IndexSizeBytes'] : null,
-                    'ItemCount' => isset($item['ItemCount']) ? (string) $item['ItemCount'] : null,
-                    'IndexArn' => isset($item['IndexArn']) ? (string) $item['IndexArn'] : null,
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-ReplicaDescriptionList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new ReplicaDescription([
-                    'RegionName' => isset($item['RegionName']) ? (string) $item['RegionName'] : null,
-                    'ReplicaStatus' => isset($item['ReplicaStatus']) ? (string) $item['ReplicaStatus'] : null,
-                    'ReplicaStatusDescription' => isset($item['ReplicaStatusDescription']) ? (string) $item['ReplicaStatusDescription'] : null,
-                    'ReplicaStatusPercentProgress' => isset($item['ReplicaStatusPercentProgress']) ? (string) $item['ReplicaStatusPercentProgress'] : null,
-                    'KMSMasterKeyId' => isset($item['KMSMasterKeyId']) ? (string) $item['KMSMasterKeyId'] : null,
-                    'ProvisionedThroughputOverride' => empty($item['ProvisionedThroughputOverride']) ? null : new ProvisionedThroughputOverride([
-                        'ReadCapacityUnits' => isset($item['ProvisionedThroughputOverride']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughputOverride']['ReadCapacityUnits'] : null,
-                    ]),
-                    'GlobalSecondaryIndexes' => empty($item['GlobalSecondaryIndexes']) ? [] : $fn['list-ReplicaGlobalSecondaryIndexDescriptionList']($item['GlobalSecondaryIndexes']),
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-ReplicaGlobalSecondaryIndexDescriptionList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new ReplicaGlobalSecondaryIndexDescription([
-                    'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
-                    'ProvisionedThroughputOverride' => empty($item['ProvisionedThroughputOverride']) ? null : new ProvisionedThroughputOverride([
-                        'ReadCapacityUnits' => isset($item['ProvisionedThroughputOverride']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughputOverride']['ReadCapacityUnits'] : null,
-                    ]),
-                ]);
-            }
-
-            return $items;
-        };
         $this->TableDescription = empty($data['TableDescription']) ? null : new TableDescription([
-            'AttributeDefinitions' => empty($data['TableDescription']['AttributeDefinitions']) ? [] : $fn['list-AttributeDefinitions']($data['TableDescription']['AttributeDefinitions']),
+            'AttributeDefinitions' => empty($data['TableDescription']['AttributeDefinitions']) ? [] : $this->populateResultAttributeDefinitions($data['TableDescription']['AttributeDefinitions']),
             'TableName' => isset($data['TableDescription']['TableName']) ? (string) $data['TableDescription']['TableName'] : null,
-            'KeySchema' => empty($data['TableDescription']['KeySchema']) ? [] : $fn['list-KeySchema']($data['TableDescription']['KeySchema']),
+            'KeySchema' => empty($data['TableDescription']['KeySchema']) ? [] : $this->populateResultKeySchema($data['TableDescription']['KeySchema']),
             'TableStatus' => isset($data['TableDescription']['TableStatus']) ? (string) $data['TableDescription']['TableStatus'] : null,
             'CreationDateTime' => (isset($data['TableDescription']['CreationDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $data['TableDescription']['CreationDateTime'])))) ? $d : null,
             'ProvisionedThroughput' => empty($data['TableDescription']['ProvisionedThroughput']) ? null : new ProvisionedThroughputDescription([
@@ -168,8 +59,8 @@ class UpdateTableOutput extends Result
                 'BillingMode' => isset($data['TableDescription']['BillingModeSummary']['BillingMode']) ? (string) $data['TableDescription']['BillingModeSummary']['BillingMode'] : null,
                 'LastUpdateToPayPerRequestDateTime' => (isset($data['TableDescription']['BillingModeSummary']['LastUpdateToPayPerRequestDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $data['TableDescription']['BillingModeSummary']['LastUpdateToPayPerRequestDateTime'])))) ? $d : null,
             ]),
-            'LocalSecondaryIndexes' => empty($data['TableDescription']['LocalSecondaryIndexes']) ? [] : $fn['list-LocalSecondaryIndexDescriptionList']($data['TableDescription']['LocalSecondaryIndexes']),
-            'GlobalSecondaryIndexes' => empty($data['TableDescription']['GlobalSecondaryIndexes']) ? [] : $fn['list-GlobalSecondaryIndexDescriptionList']($data['TableDescription']['GlobalSecondaryIndexes']),
+            'LocalSecondaryIndexes' => empty($data['TableDescription']['LocalSecondaryIndexes']) ? [] : $this->populateResultLocalSecondaryIndexDescriptionList($data['TableDescription']['LocalSecondaryIndexes']),
+            'GlobalSecondaryIndexes' => empty($data['TableDescription']['GlobalSecondaryIndexes']) ? [] : $this->populateResultGlobalSecondaryIndexDescriptionList($data['TableDescription']['GlobalSecondaryIndexes']),
             'StreamSpecification' => empty($data['TableDescription']['StreamSpecification']) ? null : new StreamSpecification([
                 'StreamEnabled' => filter_var($data['TableDescription']['StreamSpecification']['StreamEnabled'], \FILTER_VALIDATE_BOOLEAN),
                 'StreamViewType' => isset($data['TableDescription']['StreamSpecification']['StreamViewType']) ? (string) $data['TableDescription']['StreamSpecification']['StreamViewType'] : null,
@@ -177,7 +68,7 @@ class UpdateTableOutput extends Result
             'LatestStreamLabel' => isset($data['TableDescription']['LatestStreamLabel']) ? (string) $data['TableDescription']['LatestStreamLabel'] : null,
             'LatestStreamArn' => isset($data['TableDescription']['LatestStreamArn']) ? (string) $data['TableDescription']['LatestStreamArn'] : null,
             'GlobalTableVersion' => isset($data['TableDescription']['GlobalTableVersion']) ? (string) $data['TableDescription']['GlobalTableVersion'] : null,
-            'Replicas' => empty($data['TableDescription']['Replicas']) ? [] : $fn['list-ReplicaDescriptionList']($data['TableDescription']['Replicas']),
+            'Replicas' => empty($data['TableDescription']['Replicas']) ? [] : $this->populateResultReplicaDescriptionList($data['TableDescription']['Replicas']),
             'RestoreSummary' => empty($data['TableDescription']['RestoreSummary']) ? null : new RestoreSummary([
                 'SourceBackupArn' => isset($data['TableDescription']['RestoreSummary']['SourceBackupArn']) ? (string) $data['TableDescription']['RestoreSummary']['SourceBackupArn'] : null,
                 'SourceTableArn' => isset($data['TableDescription']['RestoreSummary']['SourceTableArn']) ? (string) $data['TableDescription']['RestoreSummary']['SourceTableArn'] : null,
@@ -196,5 +87,128 @@ class UpdateTableOutput extends Result
                 'ArchivalBackupArn' => isset($data['TableDescription']['ArchivalSummary']['ArchivalBackupArn']) ? (string) $data['TableDescription']['ArchivalSummary']['ArchivalBackupArn'] : null,
             ]),
         ]);
+    }
+
+    private function populateResultAttributeDefinitions(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new AttributeDefinition([
+                'AttributeName' => (string) $item['AttributeName'],
+                'AttributeType' => (string) $item['AttributeType'],
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultGlobalSecondaryIndexDescriptionList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new GlobalSecondaryIndexDescription([
+                'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
+                'KeySchema' => empty($item['KeySchema']) ? [] : $this->populateResultKeySchema($item['KeySchema']),
+                'Projection' => empty($item['Projection']) ? null : new Projection([
+                    'ProjectionType' => isset($item['Projection']['ProjectionType']) ? (string) $item['Projection']['ProjectionType'] : null,
+                    'NonKeyAttributes' => empty($item['Projection']['NonKeyAttributes']) ? [] : $this->populateResultNonKeyAttributeNameList($item['Projection']['NonKeyAttributes']),
+                ]),
+                'IndexStatus' => isset($item['IndexStatus']) ? (string) $item['IndexStatus'] : null,
+                'Backfilling' => isset($item['Backfilling']) ? filter_var($item['Backfilling'], \FILTER_VALIDATE_BOOLEAN) : null,
+                'ProvisionedThroughput' => empty($item['ProvisionedThroughput']) ? null : new ProvisionedThroughputDescription([
+                    'LastIncreaseDateTime' => (isset($item['ProvisionedThroughput']['LastIncreaseDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['ProvisionedThroughput']['LastIncreaseDateTime'])))) ? $d : null,
+                    'LastDecreaseDateTime' => (isset($item['ProvisionedThroughput']['LastDecreaseDateTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['ProvisionedThroughput']['LastDecreaseDateTime'])))) ? $d : null,
+                    'NumberOfDecreasesToday' => isset($item['ProvisionedThroughput']['NumberOfDecreasesToday']) ? (string) $item['ProvisionedThroughput']['NumberOfDecreasesToday'] : null,
+                    'ReadCapacityUnits' => isset($item['ProvisionedThroughput']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughput']['ReadCapacityUnits'] : null,
+                    'WriteCapacityUnits' => isset($item['ProvisionedThroughput']['WriteCapacityUnits']) ? (string) $item['ProvisionedThroughput']['WriteCapacityUnits'] : null,
+                ]),
+                'IndexSizeBytes' => isset($item['IndexSizeBytes']) ? (string) $item['IndexSizeBytes'] : null,
+                'ItemCount' => isset($item['ItemCount']) ? (string) $item['ItemCount'] : null,
+                'IndexArn' => isset($item['IndexArn']) ? (string) $item['IndexArn'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultKeySchema(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new KeySchemaElement([
+                'AttributeName' => (string) $item['AttributeName'],
+                'KeyType' => (string) $item['KeyType'],
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultLocalSecondaryIndexDescriptionList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new LocalSecondaryIndexDescription([
+                'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
+                'KeySchema' => empty($item['KeySchema']) ? [] : $this->populateResultKeySchema($item['KeySchema']),
+                'Projection' => empty($item['Projection']) ? null : new Projection([
+                    'ProjectionType' => isset($item['Projection']['ProjectionType']) ? (string) $item['Projection']['ProjectionType'] : null,
+                    'NonKeyAttributes' => empty($item['Projection']['NonKeyAttributes']) ? [] : $this->populateResultNonKeyAttributeNameList($item['Projection']['NonKeyAttributes']),
+                ]),
+                'IndexSizeBytes' => isset($item['IndexSizeBytes']) ? (string) $item['IndexSizeBytes'] : null,
+                'ItemCount' => isset($item['ItemCount']) ? (string) $item['ItemCount'] : null,
+                'IndexArn' => isset($item['IndexArn']) ? (string) $item['IndexArn'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultNonKeyAttributeNameList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (string) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultReplicaDescriptionList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new ReplicaDescription([
+                'RegionName' => isset($item['RegionName']) ? (string) $item['RegionName'] : null,
+                'ReplicaStatus' => isset($item['ReplicaStatus']) ? (string) $item['ReplicaStatus'] : null,
+                'ReplicaStatusDescription' => isset($item['ReplicaStatusDescription']) ? (string) $item['ReplicaStatusDescription'] : null,
+                'ReplicaStatusPercentProgress' => isset($item['ReplicaStatusPercentProgress']) ? (string) $item['ReplicaStatusPercentProgress'] : null,
+                'KMSMasterKeyId' => isset($item['KMSMasterKeyId']) ? (string) $item['KMSMasterKeyId'] : null,
+                'ProvisionedThroughputOverride' => empty($item['ProvisionedThroughputOverride']) ? null : new ProvisionedThroughputOverride([
+                    'ReadCapacityUnits' => isset($item['ProvisionedThroughputOverride']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughputOverride']['ReadCapacityUnits'] : null,
+                ]),
+                'GlobalSecondaryIndexes' => empty($item['GlobalSecondaryIndexes']) ? [] : $this->populateResultReplicaGlobalSecondaryIndexDescriptionList($item['GlobalSecondaryIndexes']),
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultReplicaGlobalSecondaryIndexDescriptionList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new ReplicaGlobalSecondaryIndexDescription([
+                'IndexName' => isset($item['IndexName']) ? (string) $item['IndexName'] : null,
+                'ProvisionedThroughputOverride' => empty($item['ProvisionedThroughputOverride']) ? null : new ProvisionedThroughputOverride([
+                    'ReadCapacityUnits' => isset($item['ProvisionedThroughputOverride']['ReadCapacityUnits']) ? (string) $item['ProvisionedThroughputOverride']['ReadCapacityUnits'] : null,
+                ]),
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/EventBridge/src/Result/PutEventsResponse.php
+++ b/src/Service/EventBridge/src/Result/PutEventsResponse.php
@@ -44,6 +44,9 @@ class PutEventsResponse extends Result
         $this->Entries = empty($data['Entries']) ? [] : $this->populateResultPutEventsResultEntryList($data['Entries']);
     }
 
+    /**
+     * @return PutEventsResultEntry[]
+     */
     private function populateResultPutEventsResultEntryList(array $json): array
     {
         $items = [];

--- a/src/Service/EventBridge/src/Result/PutEventsResponse.php
+++ b/src/Service/EventBridge/src/Result/PutEventsResponse.php
@@ -39,20 +39,22 @@ class PutEventsResponse extends Result
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-PutEventsResultEntryList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new PutEventsResultEntry([
-                    'EventId' => isset($item['EventId']) ? (string) $item['EventId'] : null,
-                    'ErrorCode' => isset($item['ErrorCode']) ? (string) $item['ErrorCode'] : null,
-                    'ErrorMessage' => isset($item['ErrorMessage']) ? (string) $item['ErrorMessage'] : null,
-                ]);
-            }
 
-            return $items;
-        };
         $this->FailedEntryCount = isset($data['FailedEntryCount']) ? (int) $data['FailedEntryCount'] : null;
-        $this->Entries = empty($data['Entries']) ? [] : $fn['list-PutEventsResultEntryList']($data['Entries']);
+        $this->Entries = empty($data['Entries']) ? [] : $this->populateResultPutEventsResultEntryList($data['Entries']);
+    }
+
+    private function populateResultPutEventsResultEntryList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new PutEventsResultEntry([
+                'EventId' => isset($item['EventId']) ? (string) $item['EventId'] : null,
+                'ErrorCode' => isset($item['ErrorCode']) ? (string) $item['ErrorCode'] : null,
+                'ErrorMessage' => isset($item['ErrorMessage']) ? (string) $item['ErrorMessage'] : null,
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/Iam/src/Result/CreateUserResponse.php
+++ b/src/Service/Iam/src/Result/CreateUserResponse.php
@@ -42,6 +42,9 @@ class CreateUserResponse extends Result
         ]);
     }
 
+    /**
+     * @return Tag[]
+     */
     private function populateResultTagListType(\SimpleXMLElement $xml): array
     {
         $items = [];

--- a/src/Service/Iam/src/Result/CreateUserResponse.php
+++ b/src/Service/Iam/src/Result/CreateUserResponse.php
@@ -38,17 +38,20 @@ class CreateUserResponse extends Result
                 'PermissionsBoundaryType' => ($v = $data->User->PermissionsBoundary->PermissionsBoundaryType) ? (string) $v : null,
                 'PermissionsBoundaryArn' => ($v = $data->User->PermissionsBoundary->PermissionsBoundaryArn) ? (string) $v : null,
             ]),
-            'Tags' => !$data->User->Tags ? [] : (function (\SimpleXMLElement $xml): array {
-                $items = [];
-                foreach ($xml->member as $item) {
-                    $items[] = new Tag([
-                        'Key' => (string) $item->Key,
-                        'Value' => (string) $item->Value,
-                    ]);
-                }
-
-                return $items;
-            })($data->User->Tags),
+            'Tags' => !$data->User->Tags ? [] : $this->populateResultTagListType($data->User->Tags),
         ]);
+    }
+
+    private function populateResultTagListType(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml->member as $item) {
+            $items[] = new Tag([
+                'Key' => (string) $item->Key,
+                'Value' => (string) $item->Value,
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/Iam/src/Result/GetUserResponse.php
+++ b/src/Service/Iam/src/Result/GetUserResponse.php
@@ -38,17 +38,20 @@ class GetUserResponse extends Result
                 'PermissionsBoundaryType' => ($v = $data->User->PermissionsBoundary->PermissionsBoundaryType) ? (string) $v : null,
                 'PermissionsBoundaryArn' => ($v = $data->User->PermissionsBoundary->PermissionsBoundaryArn) ? (string) $v : null,
             ]),
-            'Tags' => !$data->User->Tags ? [] : (function (\SimpleXMLElement $xml): array {
-                $items = [];
-                foreach ($xml->member as $item) {
-                    $items[] = new Tag([
-                        'Key' => (string) $item->Key,
-                        'Value' => (string) $item->Value,
-                    ]);
-                }
-
-                return $items;
-            })($data->User->Tags),
+            'Tags' => !$data->User->Tags ? [] : $this->populateResultTagListType($data->User->Tags),
         ]);
+    }
+
+    private function populateResultTagListType(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml->member as $item) {
+            $items[] = new Tag([
+                'Key' => (string) $item->Key,
+                'Value' => (string) $item->Value,
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/Iam/src/Result/GetUserResponse.php
+++ b/src/Service/Iam/src/Result/GetUserResponse.php
@@ -42,6 +42,9 @@ class GetUserResponse extends Result
         ]);
     }
 
+    /**
+     * @return Tag[]
+     */
     private function populateResultTagListType(\SimpleXMLElement $xml): array
     {
         $items = [];

--- a/src/Service/Iam/src/Result/ListUsersResponse.php
+++ b/src/Service/Iam/src/Result/ListUsersResponse.php
@@ -137,6 +137,9 @@ class ListUsersResponse extends Result implements \IteratorAggregate
         $this->Marker = ($v = $data->Marker) ? (string) $v : null;
     }
 
+    /**
+     * @return Tag[]
+     */
     private function populateResultTagListType(\SimpleXMLElement $xml): array
     {
         $items = [];
@@ -150,6 +153,9 @@ class ListUsersResponse extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return User[]
+     */
     private function populateResultUserListType(\SimpleXMLElement $xml): array
     {
         $items = [];

--- a/src/Service/Iam/src/Result/ListUsersResponse.php
+++ b/src/Service/Iam/src/Result/ListUsersResponse.php
@@ -132,37 +132,43 @@ class ListUsersResponse extends Result implements \IteratorAggregate
         $data = new \SimpleXMLElement($response->getContent());
         $data = $data->ListUsersResult;
 
-        $this->Users = (function (\SimpleXMLElement $xml): array {
-            $items = [];
-            foreach ($xml->member as $item) {
-                $items[] = new User([
-                    'Path' => (string) $item->Path,
-                    'UserName' => (string) $item->UserName,
-                    'UserId' => (string) $item->UserId,
-                    'Arn' => (string) $item->Arn,
-                    'CreateDate' => new \DateTimeImmutable((string) $item->CreateDate),
-                    'PasswordLastUsed' => ($v = $item->PasswordLastUsed) ? new \DateTimeImmutable((string) $v) : null,
-                    'PermissionsBoundary' => !$item->PermissionsBoundary ? null : new AttachedPermissionsBoundary([
-                        'PermissionsBoundaryType' => ($v = $item->PermissionsBoundary->PermissionsBoundaryType) ? (string) $v : null,
-                        'PermissionsBoundaryArn' => ($v = $item->PermissionsBoundary->PermissionsBoundaryArn) ? (string) $v : null,
-                    ]),
-                    'Tags' => !$item->Tags ? [] : (function (\SimpleXMLElement $xml): array {
-                        $items = [];
-                        foreach ($xml->member as $item) {
-                            $items[] = new Tag([
-                                'Key' => (string) $item->Key,
-                                'Value' => (string) $item->Value,
-                            ]);
-                        }
-
-                        return $items;
-                    })($item->Tags),
-                ]);
-            }
-
-            return $items;
-        })($data->Users);
+        $this->Users = $this->populateResultUserListType($data->Users);
         $this->IsTruncated = ($v = $data->IsTruncated) ? filter_var((string) $v, \FILTER_VALIDATE_BOOLEAN) : null;
         $this->Marker = ($v = $data->Marker) ? (string) $v : null;
+    }
+
+    private function populateResultTagListType(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml->member as $item) {
+            $items[] = new Tag([
+                'Key' => (string) $item->Key,
+                'Value' => (string) $item->Value,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultUserListType(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml->member as $item) {
+            $items[] = new User([
+                'Path' => (string) $item->Path,
+                'UserName' => (string) $item->UserName,
+                'UserId' => (string) $item->UserId,
+                'Arn' => (string) $item->Arn,
+                'CreateDate' => new \DateTimeImmutable((string) $item->CreateDate),
+                'PasswordLastUsed' => ($v = $item->PasswordLastUsed) ? new \DateTimeImmutable((string) $v) : null,
+                'PermissionsBoundary' => !$item->PermissionsBoundary ? null : new AttachedPermissionsBoundary([
+                    'PermissionsBoundaryType' => ($v = $item->PermissionsBoundary->PermissionsBoundaryType) ? (string) $v : null,
+                    'PermissionsBoundaryArn' => ($v = $item->PermissionsBoundary->PermissionsBoundaryArn) ? (string) $v : null,
+                ]),
+                'Tags' => !$item->Tags ? [] : $this->populateResultTagListType($item->Tags),
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/Lambda/src/Result/ListLayerVersionsResponse.php
+++ b/src/Service/Lambda/src/Result/ListLayerVersionsResponse.php
@@ -112,34 +112,38 @@ class ListLayerVersionsResponse extends Result implements \IteratorAggregate
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-LayerVersionsList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new LayerVersionsListItem([
-                    'LayerVersionArn' => isset($item['LayerVersionArn']) ? (string) $item['LayerVersionArn'] : null,
-                    'Version' => isset($item['Version']) ? (string) $item['Version'] : null,
-                    'Description' => isset($item['Description']) ? (string) $item['Description'] : null,
-                    'CreatedDate' => isset($item['CreatedDate']) ? (string) $item['CreatedDate'] : null,
-                    'CompatibleRuntimes' => empty($item['CompatibleRuntimes']) ? [] : $fn['list-CompatibleRuntimes']($item['CompatibleRuntimes']),
-                    'LicenseInfo' => isset($item['LicenseInfo']) ? (string) $item['LicenseInfo'] : null,
-                ]);
-            }
 
-            return $items;
-        };
-        $fn['list-CompatibleRuntimes'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (string) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
-
-            return $items;
-        };
         $this->NextMarker = isset($data['NextMarker']) ? (string) $data['NextMarker'] : null;
-        $this->LayerVersions = empty($data['LayerVersions']) ? [] : $fn['list-LayerVersionsList']($data['LayerVersions']);
+        $this->LayerVersions = empty($data['LayerVersions']) ? [] : $this->populateResultLayerVersionsList($data['LayerVersions']);
+    }
+
+    private function populateResultCompatibleRuntimes(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (string) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultLayerVersionsList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new LayerVersionsListItem([
+                'LayerVersionArn' => isset($item['LayerVersionArn']) ? (string) $item['LayerVersionArn'] : null,
+                'Version' => isset($item['Version']) ? (string) $item['Version'] : null,
+                'Description' => isset($item['Description']) ? (string) $item['Description'] : null,
+                'CreatedDate' => isset($item['CreatedDate']) ? (string) $item['CreatedDate'] : null,
+                'CompatibleRuntimes' => empty($item['CompatibleRuntimes']) ? [] : $this->populateResultCompatibleRuntimes($item['CompatibleRuntimes']),
+                'LicenseInfo' => isset($item['LicenseInfo']) ? (string) $item['LicenseInfo'] : null,
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/Lambda/src/Result/ListLayerVersionsResponse.php
+++ b/src/Service/Lambda/src/Result/ListLayerVersionsResponse.php
@@ -4,6 +4,7 @@ namespace AsyncAws\Lambda\Result;
 
 use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
+use AsyncAws\Lambda\Enum\Runtime;
 use AsyncAws\Lambda\Input\ListLayerVersionsRequest;
 use AsyncAws\Lambda\LambdaClient;
 use AsyncAws\Lambda\ValueObject\LayerVersionsListItem;
@@ -117,6 +118,9 @@ class ListLayerVersionsResponse extends Result implements \IteratorAggregate
         $this->LayerVersions = empty($data['LayerVersions']) ? [] : $this->populateResultLayerVersionsList($data['LayerVersions']);
     }
 
+    /**
+     * @return list<Runtime::*>
+     */
     private function populateResultCompatibleRuntimes(array $json): array
     {
         $items = [];
@@ -130,6 +134,9 @@ class ListLayerVersionsResponse extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return LayerVersionsListItem[]
+     */
     private function populateResultLayerVersionsList(array $json): array
     {
         $items = [];

--- a/src/Service/Lambda/src/Result/PublishLayerVersionResponse.php
+++ b/src/Service/Lambda/src/Result/PublishLayerVersionResponse.php
@@ -128,6 +128,9 @@ class PublishLayerVersionResponse extends Result
         $this->LicenseInfo = isset($data['LicenseInfo']) ? (string) $data['LicenseInfo'] : null;
     }
 
+    /**
+     * @return list<Runtime::*>
+     */
     private function populateResultCompatibleRuntimes(array $json): array
     {
         $items = [];

--- a/src/Service/Lambda/src/Result/PublishLayerVersionResponse.php
+++ b/src/Service/Lambda/src/Result/PublishLayerVersionResponse.php
@@ -113,18 +113,7 @@ class PublishLayerVersionResponse extends Result
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-CompatibleRuntimes'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (string) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
 
-            return $items;
-        };
         $this->Content = empty($data['Content']) ? null : new LayerVersionContentOutput([
             'Location' => isset($data['Content']['Location']) ? (string) $data['Content']['Location'] : null,
             'CodeSha256' => isset($data['Content']['CodeSha256']) ? (string) $data['Content']['CodeSha256'] : null,
@@ -135,7 +124,20 @@ class PublishLayerVersionResponse extends Result
         $this->Description = isset($data['Description']) ? (string) $data['Description'] : null;
         $this->CreatedDate = isset($data['CreatedDate']) ? (string) $data['CreatedDate'] : null;
         $this->Version = isset($data['Version']) ? (string) $data['Version'] : null;
-        $this->CompatibleRuntimes = empty($data['CompatibleRuntimes']) ? [] : $fn['list-CompatibleRuntimes']($data['CompatibleRuntimes']);
+        $this->CompatibleRuntimes = empty($data['CompatibleRuntimes']) ? [] : $this->populateResultCompatibleRuntimes($data['CompatibleRuntimes']);
         $this->LicenseInfo = isset($data['LicenseInfo']) ? (string) $data['LicenseInfo'] : null;
+    }
+
+    private function populateResultCompatibleRuntimes(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (string) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
     }
 }

--- a/src/Service/RdsDataService/src/Result/BatchExecuteStatementResponse.php
+++ b/src/Service/RdsDataService/src/Result/BatchExecuteStatementResponse.php
@@ -28,97 +28,111 @@ class BatchExecuteStatementResponse extends Result
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-UpdateResults'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new UpdateResult([
-                    'generatedFields' => empty($item['generatedFields']) ? [] : $fn['list-FieldList']($item['generatedFields']),
-                ]);
-            }
 
-            return $items;
-        };
-        $fn['list-FieldList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new Field([
-                    'arrayValue' => empty($item['arrayValue']) ? null : new ArrayValue([
-                        'arrayValues' => empty($item['arrayValue']['arrayValues']) ? [] : $fn['list-ArrayOfArray']($item['arrayValue']['arrayValues']),
-                        'booleanValues' => empty($item['arrayValue']['booleanValues']) ? [] : $fn['list-BooleanArray']($item['arrayValue']['booleanValues']),
-                        'doubleValues' => empty($item['arrayValue']['doubleValues']) ? [] : $fn['list-DoubleArray']($item['arrayValue']['doubleValues']),
-                        'longValues' => empty($item['arrayValue']['longValues']) ? [] : $fn['list-LongArray']($item['arrayValue']['longValues']),
-                        'stringValues' => empty($item['arrayValue']['stringValues']) ? [] : $fn['list-StringArray']($item['arrayValue']['stringValues']),
-                    ]),
-                    'blobValue' => isset($item['blobValue']) ? base64_decode((string) $item['blobValue']) : null,
-                    'booleanValue' => isset($item['booleanValue']) ? filter_var($item['booleanValue'], \FILTER_VALIDATE_BOOLEAN) : null,
-                    'doubleValue' => isset($item['doubleValue']) ? (float) $item['doubleValue'] : null,
-                    'isNull' => isset($item['isNull']) ? filter_var($item['isNull'], \FILTER_VALIDATE_BOOLEAN) : null,
-                    'longValue' => isset($item['longValue']) ? (string) $item['longValue'] : null,
-                    'stringValue' => isset($item['stringValue']) ? (string) $item['stringValue'] : null,
-                ]);
-            }
+        $this->updateResults = empty($data['updateResults']) ? [] : $this->populateResultUpdateResults($data['updateResults']);
+    }
 
-            return $items;
-        };
-        $fn['list-ArrayOfArray'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new ArrayValue([
-                    'arrayValues' => empty($item['arrayValues']) ? [] : $fn['list-ArrayOfArray']($item['arrayValues']),
-                    'booleanValues' => empty($item['booleanValues']) ? [] : $fn['list-BooleanArray']($item['booleanValues']),
-                    'doubleValues' => empty($item['doubleValues']) ? [] : $fn['list-DoubleArray']($item['doubleValues']),
-                    'longValues' => empty($item['longValues']) ? [] : $fn['list-LongArray']($item['longValues']),
-                    'stringValues' => empty($item['stringValues']) ? [] : $fn['list-StringArray']($item['stringValues']),
-                ]);
-            }
+    private function populateResultArrayOfArray(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new ArrayValue([
+                'arrayValues' => empty($item['arrayValues']) ? [] : $this->populateResultArrayOfArray($item['arrayValues']),
+                'booleanValues' => empty($item['booleanValues']) ? [] : $this->populateResultBooleanArray($item['booleanValues']),
+                'doubleValues' => empty($item['doubleValues']) ? [] : $this->populateResultDoubleArray($item['doubleValues']),
+                'longValues' => empty($item['longValues']) ? [] : $this->populateResultLongArray($item['longValues']),
+                'stringValues' => empty($item['stringValues']) ? [] : $this->populateResultStringArray($item['stringValues']),
+            ]);
+        }
 
-            return $items;
-        };
-        $fn['list-BooleanArray'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? filter_var($item, \FILTER_VALIDATE_BOOLEAN) : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
+        return $items;
+    }
 
-            return $items;
-        };
-        $fn['list-DoubleArray'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (float) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
+    private function populateResultBooleanArray(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? filter_var($item, \FILTER_VALIDATE_BOOLEAN) : null;
+            if (null !== $a) {
+                $items[] = $a;
             }
+        }
 
-            return $items;
-        };
-        $fn['list-LongArray'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (string) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
+        return $items;
+    }
+
+    private function populateResultDoubleArray(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (float) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
             }
+        }
 
-            return $items;
-        };
-        $fn['list-StringArray'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (string) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
+        return $items;
+    }
+
+    private function populateResultFieldList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new Field([
+                'arrayValue' => empty($item['arrayValue']) ? null : new ArrayValue([
+                    'arrayValues' => empty($item['arrayValue']['arrayValues']) ? [] : $this->populateResultArrayOfArray($item['arrayValue']['arrayValues']),
+                    'booleanValues' => empty($item['arrayValue']['booleanValues']) ? [] : $this->populateResultBooleanArray($item['arrayValue']['booleanValues']),
+                    'doubleValues' => empty($item['arrayValue']['doubleValues']) ? [] : $this->populateResultDoubleArray($item['arrayValue']['doubleValues']),
+                    'longValues' => empty($item['arrayValue']['longValues']) ? [] : $this->populateResultLongArray($item['arrayValue']['longValues']),
+                    'stringValues' => empty($item['arrayValue']['stringValues']) ? [] : $this->populateResultStringArray($item['arrayValue']['stringValues']),
+                ]),
+                'blobValue' => isset($item['blobValue']) ? base64_decode((string) $item['blobValue']) : null,
+                'booleanValue' => isset($item['booleanValue']) ? filter_var($item['booleanValue'], \FILTER_VALIDATE_BOOLEAN) : null,
+                'doubleValue' => isset($item['doubleValue']) ? (float) $item['doubleValue'] : null,
+                'isNull' => isset($item['isNull']) ? filter_var($item['isNull'], \FILTER_VALIDATE_BOOLEAN) : null,
+                'longValue' => isset($item['longValue']) ? (string) $item['longValue'] : null,
+                'stringValue' => isset($item['stringValue']) ? (string) $item['stringValue'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultLongArray(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (string) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
             }
+        }
 
-            return $items;
-        };
-        $this->updateResults = empty($data['updateResults']) ? [] : $fn['list-UpdateResults']($data['updateResults']);
+        return $items;
+    }
+
+    private function populateResultStringArray(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (string) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultUpdateResults(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new UpdateResult([
+                'generatedFields' => empty($item['generatedFields']) ? [] : $this->populateResultFieldList($item['generatedFields']),
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/RdsDataService/src/Result/BatchExecuteStatementResponse.php
+++ b/src/Service/RdsDataService/src/Result/BatchExecuteStatementResponse.php
@@ -32,6 +32,9 @@ class BatchExecuteStatementResponse extends Result
         $this->updateResults = empty($data['updateResults']) ? [] : $this->populateResultUpdateResults($data['updateResults']);
     }
 
+    /**
+     * @return ArrayValue[]
+     */
     private function populateResultArrayOfArray(array $json): array
     {
         $items = [];
@@ -48,6 +51,9 @@ class BatchExecuteStatementResponse extends Result
         return $items;
     }
 
+    /**
+     * @return bool[]
+     */
     private function populateResultBooleanArray(array $json): array
     {
         $items = [];
@@ -61,6 +67,9 @@ class BatchExecuteStatementResponse extends Result
         return $items;
     }
 
+    /**
+     * @return float[]
+     */
     private function populateResultDoubleArray(array $json): array
     {
         $items = [];
@@ -74,6 +83,9 @@ class BatchExecuteStatementResponse extends Result
         return $items;
     }
 
+    /**
+     * @return Field[]
+     */
     private function populateResultFieldList(array $json): array
     {
         $items = [];
@@ -98,6 +110,9 @@ class BatchExecuteStatementResponse extends Result
         return $items;
     }
 
+    /**
+     * @return string[]
+     */
     private function populateResultLongArray(array $json): array
     {
         $items = [];
@@ -111,6 +126,9 @@ class BatchExecuteStatementResponse extends Result
         return $items;
     }
 
+    /**
+     * @return string[]
+     */
     private function populateResultStringArray(array $json): array
     {
         $items = [];
@@ -124,6 +142,9 @@ class BatchExecuteStatementResponse extends Result
         return $items;
     }
 
+    /**
+     * @return UpdateResult[]
+     */
     private function populateResultUpdateResults(array $json): array
     {
         $items = [];

--- a/src/Service/RdsDataService/src/Result/ExecuteStatementResponse.php
+++ b/src/Service/RdsDataService/src/Result/ExecuteStatementResponse.php
@@ -70,124 +70,140 @@ class ExecuteStatementResponse extends Result
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-Metadata'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new ColumnMetadata([
-                    'arrayBaseColumnType' => isset($item['arrayBaseColumnType']) ? (int) $item['arrayBaseColumnType'] : null,
-                    'isAutoIncrement' => isset($item['isAutoIncrement']) ? filter_var($item['isAutoIncrement'], \FILTER_VALIDATE_BOOLEAN) : null,
-                    'isCaseSensitive' => isset($item['isCaseSensitive']) ? filter_var($item['isCaseSensitive'], \FILTER_VALIDATE_BOOLEAN) : null,
-                    'isCurrency' => isset($item['isCurrency']) ? filter_var($item['isCurrency'], \FILTER_VALIDATE_BOOLEAN) : null,
-                    'isSigned' => isset($item['isSigned']) ? filter_var($item['isSigned'], \FILTER_VALIDATE_BOOLEAN) : null,
-                    'label' => isset($item['label']) ? (string) $item['label'] : null,
-                    'name' => isset($item['name']) ? (string) $item['name'] : null,
-                    'nullable' => isset($item['nullable']) ? (int) $item['nullable'] : null,
-                    'precision' => isset($item['precision']) ? (int) $item['precision'] : null,
-                    'scale' => isset($item['scale']) ? (int) $item['scale'] : null,
-                    'schemaName' => isset($item['schemaName']) ? (string) $item['schemaName'] : null,
-                    'tableName' => isset($item['tableName']) ? (string) $item['tableName'] : null,
-                    'type' => isset($item['type']) ? (int) $item['type'] : null,
-                    'typeName' => isset($item['typeName']) ? (string) $item['typeName'] : null,
-                ]);
-            }
 
-            return $items;
-        };
-        $fn['list-FieldList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new Field([
-                    'arrayValue' => empty($item['arrayValue']) ? null : new ArrayValue([
-                        'arrayValues' => empty($item['arrayValue']['arrayValues']) ? [] : $fn['list-ArrayOfArray']($item['arrayValue']['arrayValues']),
-                        'booleanValues' => empty($item['arrayValue']['booleanValues']) ? [] : $fn['list-BooleanArray']($item['arrayValue']['booleanValues']),
-                        'doubleValues' => empty($item['arrayValue']['doubleValues']) ? [] : $fn['list-DoubleArray']($item['arrayValue']['doubleValues']),
-                        'longValues' => empty($item['arrayValue']['longValues']) ? [] : $fn['list-LongArray']($item['arrayValue']['longValues']),
-                        'stringValues' => empty($item['arrayValue']['stringValues']) ? [] : $fn['list-StringArray']($item['arrayValue']['stringValues']),
-                    ]),
-                    'blobValue' => isset($item['blobValue']) ? base64_decode((string) $item['blobValue']) : null,
-                    'booleanValue' => isset($item['booleanValue']) ? filter_var($item['booleanValue'], \FILTER_VALIDATE_BOOLEAN) : null,
-                    'doubleValue' => isset($item['doubleValue']) ? (float) $item['doubleValue'] : null,
-                    'isNull' => isset($item['isNull']) ? filter_var($item['isNull'], \FILTER_VALIDATE_BOOLEAN) : null,
-                    'longValue' => isset($item['longValue']) ? (string) $item['longValue'] : null,
-                    'stringValue' => isset($item['stringValue']) ? (string) $item['stringValue'] : null,
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-ArrayOfArray'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new ArrayValue([
-                    'arrayValues' => empty($item['arrayValues']) ? [] : $fn['list-ArrayOfArray']($item['arrayValues']),
-                    'booleanValues' => empty($item['booleanValues']) ? [] : $fn['list-BooleanArray']($item['booleanValues']),
-                    'doubleValues' => empty($item['doubleValues']) ? [] : $fn['list-DoubleArray']($item['doubleValues']),
-                    'longValues' => empty($item['longValues']) ? [] : $fn['list-LongArray']($item['longValues']),
-                    'stringValues' => empty($item['stringValues']) ? [] : $fn['list-StringArray']($item['stringValues']),
-                ]);
-            }
-
-            return $items;
-        };
-        $fn['list-BooleanArray'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? filter_var($item, \FILTER_VALIDATE_BOOLEAN) : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
-
-            return $items;
-        };
-        $fn['list-DoubleArray'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (float) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
-
-            return $items;
-        };
-        $fn['list-LongArray'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (string) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
-
-            return $items;
-        };
-        $fn['list-StringArray'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (string) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
-
-            return $items;
-        };
-        $fn['list-SqlRecords'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = empty($item) ? [] : $fn['list-FieldList']($item);
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
-
-            return $items;
-        };
-        $this->columnMetadata = empty($data['columnMetadata']) ? [] : $fn['list-Metadata']($data['columnMetadata']);
-        $this->generatedFields = empty($data['generatedFields']) ? [] : $fn['list-FieldList']($data['generatedFields']);
+        $this->columnMetadata = empty($data['columnMetadata']) ? [] : $this->populateResultMetadata($data['columnMetadata']);
+        $this->generatedFields = empty($data['generatedFields']) ? [] : $this->populateResultFieldList($data['generatedFields']);
         $this->numberOfRecordsUpdated = isset($data['numberOfRecordsUpdated']) ? (string) $data['numberOfRecordsUpdated'] : null;
-        $this->records = empty($data['records']) ? [] : $fn['list-SqlRecords']($data['records']);
+        $this->records = empty($data['records']) ? [] : $this->populateResultSqlRecords($data['records']);
+    }
+
+    private function populateResultArrayOfArray(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new ArrayValue([
+                'arrayValues' => empty($item['arrayValues']) ? [] : $this->populateResultArrayOfArray($item['arrayValues']),
+                'booleanValues' => empty($item['booleanValues']) ? [] : $this->populateResultBooleanArray($item['booleanValues']),
+                'doubleValues' => empty($item['doubleValues']) ? [] : $this->populateResultDoubleArray($item['doubleValues']),
+                'longValues' => empty($item['longValues']) ? [] : $this->populateResultLongArray($item['longValues']),
+                'stringValues' => empty($item['stringValues']) ? [] : $this->populateResultStringArray($item['stringValues']),
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultBooleanArray(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? filter_var($item, \FILTER_VALIDATE_BOOLEAN) : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultDoubleArray(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (float) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultFieldList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new Field([
+                'arrayValue' => empty($item['arrayValue']) ? null : new ArrayValue([
+                    'arrayValues' => empty($item['arrayValue']['arrayValues']) ? [] : $this->populateResultArrayOfArray($item['arrayValue']['arrayValues']),
+                    'booleanValues' => empty($item['arrayValue']['booleanValues']) ? [] : $this->populateResultBooleanArray($item['arrayValue']['booleanValues']),
+                    'doubleValues' => empty($item['arrayValue']['doubleValues']) ? [] : $this->populateResultDoubleArray($item['arrayValue']['doubleValues']),
+                    'longValues' => empty($item['arrayValue']['longValues']) ? [] : $this->populateResultLongArray($item['arrayValue']['longValues']),
+                    'stringValues' => empty($item['arrayValue']['stringValues']) ? [] : $this->populateResultStringArray($item['arrayValue']['stringValues']),
+                ]),
+                'blobValue' => isset($item['blobValue']) ? base64_decode((string) $item['blobValue']) : null,
+                'booleanValue' => isset($item['booleanValue']) ? filter_var($item['booleanValue'], \FILTER_VALIDATE_BOOLEAN) : null,
+                'doubleValue' => isset($item['doubleValue']) ? (float) $item['doubleValue'] : null,
+                'isNull' => isset($item['isNull']) ? filter_var($item['isNull'], \FILTER_VALIDATE_BOOLEAN) : null,
+                'longValue' => isset($item['longValue']) ? (string) $item['longValue'] : null,
+                'stringValue' => isset($item['stringValue']) ? (string) $item['stringValue'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultLongArray(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (string) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultMetadata(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new ColumnMetadata([
+                'arrayBaseColumnType' => isset($item['arrayBaseColumnType']) ? (int) $item['arrayBaseColumnType'] : null,
+                'isAutoIncrement' => isset($item['isAutoIncrement']) ? filter_var($item['isAutoIncrement'], \FILTER_VALIDATE_BOOLEAN) : null,
+                'isCaseSensitive' => isset($item['isCaseSensitive']) ? filter_var($item['isCaseSensitive'], \FILTER_VALIDATE_BOOLEAN) : null,
+                'isCurrency' => isset($item['isCurrency']) ? filter_var($item['isCurrency'], \FILTER_VALIDATE_BOOLEAN) : null,
+                'isSigned' => isset($item['isSigned']) ? filter_var($item['isSigned'], \FILTER_VALIDATE_BOOLEAN) : null,
+                'label' => isset($item['label']) ? (string) $item['label'] : null,
+                'name' => isset($item['name']) ? (string) $item['name'] : null,
+                'nullable' => isset($item['nullable']) ? (int) $item['nullable'] : null,
+                'precision' => isset($item['precision']) ? (int) $item['precision'] : null,
+                'scale' => isset($item['scale']) ? (int) $item['scale'] : null,
+                'schemaName' => isset($item['schemaName']) ? (string) $item['schemaName'] : null,
+                'tableName' => isset($item['tableName']) ? (string) $item['tableName'] : null,
+                'type' => isset($item['type']) ? (int) $item['type'] : null,
+                'typeName' => isset($item['typeName']) ? (string) $item['typeName'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultSqlRecords(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = empty($item) ? [] : $this->populateResultFieldList($item);
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultStringArray(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (string) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
     }
 }

--- a/src/Service/RdsDataService/src/Result/ExecuteStatementResponse.php
+++ b/src/Service/RdsDataService/src/Result/ExecuteStatementResponse.php
@@ -77,6 +77,9 @@ class ExecuteStatementResponse extends Result
         $this->records = empty($data['records']) ? [] : $this->populateResultSqlRecords($data['records']);
     }
 
+    /**
+     * @return ArrayValue[]
+     */
     private function populateResultArrayOfArray(array $json): array
     {
         $items = [];
@@ -93,6 +96,9 @@ class ExecuteStatementResponse extends Result
         return $items;
     }
 
+    /**
+     * @return bool[]
+     */
     private function populateResultBooleanArray(array $json): array
     {
         $items = [];
@@ -106,6 +112,9 @@ class ExecuteStatementResponse extends Result
         return $items;
     }
 
+    /**
+     * @return float[]
+     */
     private function populateResultDoubleArray(array $json): array
     {
         $items = [];
@@ -119,6 +128,9 @@ class ExecuteStatementResponse extends Result
         return $items;
     }
 
+    /**
+     * @return Field[]
+     */
     private function populateResultFieldList(array $json): array
     {
         $items = [];
@@ -143,6 +155,9 @@ class ExecuteStatementResponse extends Result
         return $items;
     }
 
+    /**
+     * @return string[]
+     */
     private function populateResultLongArray(array $json): array
     {
         $items = [];
@@ -156,6 +171,9 @@ class ExecuteStatementResponse extends Result
         return $items;
     }
 
+    /**
+     * @return ColumnMetadata[]
+     */
     private function populateResultMetadata(array $json): array
     {
         $items = [];
@@ -181,6 +199,9 @@ class ExecuteStatementResponse extends Result
         return $items;
     }
 
+    /**
+     * @return Field[][]
+     */
     private function populateResultSqlRecords(array $json): array
     {
         $items = [];
@@ -194,6 +215,9 @@ class ExecuteStatementResponse extends Result
         return $items;
     }
 
+    /**
+     * @return string[]
+     */
     private function populateResultStringArray(array $json): array
     {
         $items = [];

--- a/src/Service/S3/src/Result/DeleteObjectsOutput.php
+++ b/src/Service/S3/src/Result/DeleteObjectsOutput.php
@@ -64,6 +64,9 @@ class DeleteObjectsOutput extends Result
         $this->Errors = !$data->Error ? [] : $this->populateResultErrors($data->Error);
     }
 
+    /**
+     * @return DeletedObject[]
+     */
     private function populateResultDeletedObjects(\SimpleXMLElement $xml): array
     {
         $items = [];
@@ -79,6 +82,9 @@ class DeleteObjectsOutput extends Result
         return $items;
     }
 
+    /**
+     * @return Error[]
+     */
     private function populateResultErrors(\SimpleXMLElement $xml): array
     {
         $items = [];

--- a/src/Service/S3/src/Result/DeleteObjectsOutput.php
+++ b/src/Service/S3/src/Result/DeleteObjectsOutput.php
@@ -60,31 +60,37 @@ class DeleteObjectsOutput extends Result
         $this->RequestCharged = $headers['x-amz-request-charged'][0] ?? null;
 
         $data = new \SimpleXMLElement($response->getContent());
-        $this->Deleted = !$data->Deleted ? [] : (function (\SimpleXMLElement $xml): array {
-            $items = [];
-            foreach ($xml as $item) {
-                $items[] = new DeletedObject([
-                    'Key' => ($v = $item->Key) ? (string) $v : null,
-                    'VersionId' => ($v = $item->VersionId) ? (string) $v : null,
-                    'DeleteMarker' => ($v = $item->DeleteMarker) ? filter_var((string) $v, \FILTER_VALIDATE_BOOLEAN) : null,
-                    'DeleteMarkerVersionId' => ($v = $item->DeleteMarkerVersionId) ? (string) $v : null,
-                ]);
-            }
+        $this->Deleted = !$data->Deleted ? [] : $this->populateResultDeletedObjects($data->Deleted);
+        $this->Errors = !$data->Error ? [] : $this->populateResultErrors($data->Error);
+    }
 
-            return $items;
-        })($data->Deleted);
-        $this->Errors = !$data->Error ? [] : (function (\SimpleXMLElement $xml): array {
-            $items = [];
-            foreach ($xml as $item) {
-                $items[] = new Error([
-                    'Key' => ($v = $item->Key) ? (string) $v : null,
-                    'VersionId' => ($v = $item->VersionId) ? (string) $v : null,
-                    'Code' => ($v = $item->Code) ? (string) $v : null,
-                    'Message' => ($v = $item->Message) ? (string) $v : null,
-                ]);
-            }
+    private function populateResultDeletedObjects(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml as $item) {
+            $items[] = new DeletedObject([
+                'Key' => ($v = $item->Key) ? (string) $v : null,
+                'VersionId' => ($v = $item->VersionId) ? (string) $v : null,
+                'DeleteMarker' => ($v = $item->DeleteMarker) ? filter_var((string) $v, \FILTER_VALIDATE_BOOLEAN) : null,
+                'DeleteMarkerVersionId' => ($v = $item->DeleteMarkerVersionId) ? (string) $v : null,
+            ]);
+        }
 
-            return $items;
-        })($data->Error);
+        return $items;
+    }
+
+    private function populateResultErrors(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml as $item) {
+            $items[] = new Error([
+                'Key' => ($v = $item->Key) ? (string) $v : null,
+                'VersionId' => ($v = $item->VersionId) ? (string) $v : null,
+                'Code' => ($v = $item->Code) ? (string) $v : null,
+                'Message' => ($v = $item->Message) ? (string) $v : null,
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/S3/src/Result/GetObjectAclOutput.php
+++ b/src/Service/S3/src/Result/GetObjectAclOutput.php
@@ -64,6 +64,9 @@ class GetObjectAclOutput extends Result
         $this->Grants = !$data->AccessControlList ? [] : $this->populateResultGrants($data->AccessControlList);
     }
 
+    /**
+     * @return Grant[]
+     */
     private function populateResultGrants(\SimpleXMLElement $xml): array
     {
         $items = [];

--- a/src/Service/S3/src/Result/GetObjectAclOutput.php
+++ b/src/Service/S3/src/Result/GetObjectAclOutput.php
@@ -61,22 +61,25 @@ class GetObjectAclOutput extends Result
             'DisplayName' => ($v = $data->Owner->DisplayName) ? (string) $v : null,
             'ID' => ($v = $data->Owner->ID) ? (string) $v : null,
         ]);
-        $this->Grants = !$data->AccessControlList ? [] : (function (\SimpleXMLElement $xml): array {
-            $items = [];
-            foreach ($xml->Grant as $item) {
-                $items[] = new Grant([
-                    'Grantee' => !$item->Grantee ? null : new Grantee([
-                        'DisplayName' => ($v = $item->Grantee->DisplayName) ? (string) $v : null,
-                        'EmailAddress' => ($v = $item->Grantee->EmailAddress) ? (string) $v : null,
-                        'ID' => ($v = $item->Grantee->ID) ? (string) $v : null,
-                        'Type' => (string) ($item->Grantee->attributes('xsi', true)['type'][0] ?? null),
-                        'URI' => ($v = $item->Grantee->URI) ? (string) $v : null,
-                    ]),
-                    'Permission' => ($v = $item->Permission) ? (string) $v : null,
-                ]);
-            }
+        $this->Grants = !$data->AccessControlList ? [] : $this->populateResultGrants($data->AccessControlList);
+    }
 
-            return $items;
-        })($data->AccessControlList);
+    private function populateResultGrants(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml->Grant as $item) {
+            $items[] = new Grant([
+                'Grantee' => !$item->Grantee ? null : new Grantee([
+                    'DisplayName' => ($v = $item->Grantee->DisplayName) ? (string) $v : null,
+                    'EmailAddress' => ($v = $item->Grantee->EmailAddress) ? (string) $v : null,
+                    'ID' => ($v = $item->Grantee->ID) ? (string) $v : null,
+                    'Type' => (string) ($item->Grantee->attributes('xsi', true)['type'][0] ?? null),
+                    'URI' => ($v = $item->Grantee->URI) ? (string) $v : null,
+                ]),
+                'Permission' => ($v = $item->Permission) ? (string) $v : null,
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/S3/src/Result/ListMultipartUploadsOutput.php
+++ b/src/Service/S3/src/Result/ListMultipartUploadsOutput.php
@@ -299,37 +299,43 @@ class ListMultipartUploadsOutput extends Result implements \IteratorAggregate
         $this->NextUploadIdMarker = ($v = $data->NextUploadIdMarker) ? (string) $v : null;
         $this->MaxUploads = ($v = $data->MaxUploads) ? (int) (string) $v : null;
         $this->IsTruncated = ($v = $data->IsTruncated) ? filter_var((string) $v, \FILTER_VALIDATE_BOOLEAN) : null;
-        $this->Uploads = !$data->Upload ? [] : (function (\SimpleXMLElement $xml): array {
-            $items = [];
-            foreach ($xml as $item) {
-                $items[] = new MultipartUpload([
-                    'UploadId' => ($v = $item->UploadId) ? (string) $v : null,
-                    'Key' => ($v = $item->Key) ? (string) $v : null,
-                    'Initiated' => ($v = $item->Initiated) ? new \DateTimeImmutable((string) $v) : null,
-                    'StorageClass' => ($v = $item->StorageClass) ? (string) $v : null,
-                    'Owner' => !$item->Owner ? null : new Owner([
-                        'DisplayName' => ($v = $item->Owner->DisplayName) ? (string) $v : null,
-                        'ID' => ($v = $item->Owner->ID) ? (string) $v : null,
-                    ]),
-                    'Initiator' => !$item->Initiator ? null : new Initiator([
-                        'ID' => ($v = $item->Initiator->ID) ? (string) $v : null,
-                        'DisplayName' => ($v = $item->Initiator->DisplayName) ? (string) $v : null,
-                    ]),
-                ]);
-            }
-
-            return $items;
-        })($data->Upload);
-        $this->CommonPrefixes = !$data->CommonPrefixes ? [] : (function (\SimpleXMLElement $xml): array {
-            $items = [];
-            foreach ($xml as $item) {
-                $items[] = new CommonPrefix([
-                    'Prefix' => ($v = $item->Prefix) ? (string) $v : null,
-                ]);
-            }
-
-            return $items;
-        })($data->CommonPrefixes);
+        $this->Uploads = !$data->Upload ? [] : $this->populateResultMultipartUploadList($data->Upload);
+        $this->CommonPrefixes = !$data->CommonPrefixes ? [] : $this->populateResultCommonPrefixList($data->CommonPrefixes);
         $this->EncodingType = ($v = $data->EncodingType) ? (string) $v : null;
+    }
+
+    private function populateResultCommonPrefixList(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml as $item) {
+            $items[] = new CommonPrefix([
+                'Prefix' => ($v = $item->Prefix) ? (string) $v : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultMultipartUploadList(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml as $item) {
+            $items[] = new MultipartUpload([
+                'UploadId' => ($v = $item->UploadId) ? (string) $v : null,
+                'Key' => ($v = $item->Key) ? (string) $v : null,
+                'Initiated' => ($v = $item->Initiated) ? new \DateTimeImmutable((string) $v) : null,
+                'StorageClass' => ($v = $item->StorageClass) ? (string) $v : null,
+                'Owner' => !$item->Owner ? null : new Owner([
+                    'DisplayName' => ($v = $item->Owner->DisplayName) ? (string) $v : null,
+                    'ID' => ($v = $item->Owner->ID) ? (string) $v : null,
+                ]),
+                'Initiator' => !$item->Initiator ? null : new Initiator([
+                    'ID' => ($v = $item->Initiator->ID) ? (string) $v : null,
+                    'DisplayName' => ($v = $item->Initiator->DisplayName) ? (string) $v : null,
+                ]),
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/S3/src/Result/ListMultipartUploadsOutput.php
+++ b/src/Service/S3/src/Result/ListMultipartUploadsOutput.php
@@ -304,6 +304,9 @@ class ListMultipartUploadsOutput extends Result implements \IteratorAggregate
         $this->EncodingType = ($v = $data->EncodingType) ? (string) $v : null;
     }
 
+    /**
+     * @return CommonPrefix[]
+     */
     private function populateResultCommonPrefixList(\SimpleXMLElement $xml): array
     {
         $items = [];
@@ -316,6 +319,9 @@ class ListMultipartUploadsOutput extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return MultipartUpload[]
+     */
     private function populateResultMultipartUploadList(\SimpleXMLElement $xml): array
     {
         $items = [];

--- a/src/Service/S3/src/Result/ListObjectsV2Output.php
+++ b/src/Service/S3/src/Result/ListObjectsV2Output.php
@@ -283,42 +283,48 @@ class ListObjectsV2Output extends Result implements \IteratorAggregate
     {
         $data = new \SimpleXMLElement($response->getContent());
         $this->IsTruncated = ($v = $data->IsTruncated) ? filter_var((string) $v, \FILTER_VALIDATE_BOOLEAN) : null;
-        $this->Contents = !$data->Contents ? [] : (function (\SimpleXMLElement $xml): array {
-            $items = [];
-            foreach ($xml as $item) {
-                $items[] = new AwsObject([
-                    'Key' => ($v = $item->Key) ? (string) $v : null,
-                    'LastModified' => ($v = $item->LastModified) ? new \DateTimeImmutable((string) $v) : null,
-                    'ETag' => ($v = $item->ETag) ? (string) $v : null,
-                    'Size' => ($v = $item->Size) ? (string) $v : null,
-                    'StorageClass' => ($v = $item->StorageClass) ? (string) $v : null,
-                    'Owner' => !$item->Owner ? null : new Owner([
-                        'DisplayName' => ($v = $item->Owner->DisplayName) ? (string) $v : null,
-                        'ID' => ($v = $item->Owner->ID) ? (string) $v : null,
-                    ]),
-                ]);
-            }
-
-            return $items;
-        })($data->Contents);
+        $this->Contents = !$data->Contents ? [] : $this->populateResultObjectList($data->Contents);
         $this->Name = ($v = $data->Name) ? (string) $v : null;
         $this->Prefix = ($v = $data->Prefix) ? (string) $v : null;
         $this->Delimiter = ($v = $data->Delimiter) ? (string) $v : null;
         $this->MaxKeys = ($v = $data->MaxKeys) ? (int) (string) $v : null;
-        $this->CommonPrefixes = !$data->CommonPrefixes ? [] : (function (\SimpleXMLElement $xml): array {
-            $items = [];
-            foreach ($xml as $item) {
-                $items[] = new CommonPrefix([
-                    'Prefix' => ($v = $item->Prefix) ? (string) $v : null,
-                ]);
-            }
-
-            return $items;
-        })($data->CommonPrefixes);
+        $this->CommonPrefixes = !$data->CommonPrefixes ? [] : $this->populateResultCommonPrefixList($data->CommonPrefixes);
         $this->EncodingType = ($v = $data->EncodingType) ? (string) $v : null;
         $this->KeyCount = ($v = $data->KeyCount) ? (int) (string) $v : null;
         $this->ContinuationToken = ($v = $data->ContinuationToken) ? (string) $v : null;
         $this->NextContinuationToken = ($v = $data->NextContinuationToken) ? (string) $v : null;
         $this->StartAfter = ($v = $data->StartAfter) ? (string) $v : null;
+    }
+
+    private function populateResultCommonPrefixList(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml as $item) {
+            $items[] = new CommonPrefix([
+                'Prefix' => ($v = $item->Prefix) ? (string) $v : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultObjectList(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml as $item) {
+            $items[] = new AwsObject([
+                'Key' => ($v = $item->Key) ? (string) $v : null,
+                'LastModified' => ($v = $item->LastModified) ? new \DateTimeImmutable((string) $v) : null,
+                'ETag' => ($v = $item->ETag) ? (string) $v : null,
+                'Size' => ($v = $item->Size) ? (string) $v : null,
+                'StorageClass' => ($v = $item->StorageClass) ? (string) $v : null,
+                'Owner' => !$item->Owner ? null : new Owner([
+                    'DisplayName' => ($v = $item->Owner->DisplayName) ? (string) $v : null,
+                    'ID' => ($v = $item->Owner->ID) ? (string) $v : null,
+                ]),
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/S3/src/Result/ListObjectsV2Output.php
+++ b/src/Service/S3/src/Result/ListObjectsV2Output.php
@@ -296,6 +296,9 @@ class ListObjectsV2Output extends Result implements \IteratorAggregate
         $this->StartAfter = ($v = $data->StartAfter) ? (string) $v : null;
     }
 
+    /**
+     * @return CommonPrefix[]
+     */
     private function populateResultCommonPrefixList(\SimpleXMLElement $xml): array
     {
         $items = [];
@@ -308,6 +311,9 @@ class ListObjectsV2Output extends Result implements \IteratorAggregate
         return $items;
     }
 
+    /**
+     * @return AwsObject[]
+     */
     private function populateResultObjectList(\SimpleXMLElement $xml): array
     {
         $items = [];

--- a/src/Service/S3/src/Result/ListPartsOutput.php
+++ b/src/Service/S3/src/Result/ListPartsOutput.php
@@ -288,19 +288,7 @@ class ListPartsOutput extends Result implements \IteratorAggregate
         $this->NextPartNumberMarker = ($v = $data->NextPartNumberMarker) ? (int) (string) $v : null;
         $this->MaxParts = ($v = $data->MaxParts) ? (int) (string) $v : null;
         $this->IsTruncated = ($v = $data->IsTruncated) ? filter_var((string) $v, \FILTER_VALIDATE_BOOLEAN) : null;
-        $this->Parts = !$data->Part ? [] : (function (\SimpleXMLElement $xml): array {
-            $items = [];
-            foreach ($xml as $item) {
-                $items[] = new Part([
-                    'PartNumber' => ($v = $item->PartNumber) ? (int) (string) $v : null,
-                    'LastModified' => ($v = $item->LastModified) ? new \DateTimeImmutable((string) $v) : null,
-                    'ETag' => ($v = $item->ETag) ? (string) $v : null,
-                    'Size' => ($v = $item->Size) ? (string) $v : null,
-                ]);
-            }
-
-            return $items;
-        })($data->Part);
+        $this->Parts = !$data->Part ? [] : $this->populateResultParts($data->Part);
         $this->Initiator = !$data->Initiator ? null : new Initiator([
             'ID' => ($v = $data->Initiator->ID) ? (string) $v : null,
             'DisplayName' => ($v = $data->Initiator->DisplayName) ? (string) $v : null,
@@ -310,5 +298,20 @@ class ListPartsOutput extends Result implements \IteratorAggregate
             'ID' => ($v = $data->Owner->ID) ? (string) $v : null,
         ]);
         $this->StorageClass = ($v = $data->StorageClass) ? (string) $v : null;
+    }
+
+    private function populateResultParts(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml as $item) {
+            $items[] = new Part([
+                'PartNumber' => ($v = $item->PartNumber) ? (int) (string) $v : null,
+                'LastModified' => ($v = $item->LastModified) ? new \DateTimeImmutable((string) $v) : null,
+                'ETag' => ($v = $item->ETag) ? (string) $v : null,
+                'Size' => ($v = $item->Size) ? (string) $v : null,
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/S3/src/Result/ListPartsOutput.php
+++ b/src/Service/S3/src/Result/ListPartsOutput.php
@@ -300,6 +300,9 @@ class ListPartsOutput extends Result implements \IteratorAggregate
         $this->StorageClass = ($v = $data->StorageClass) ? (string) $v : null;
     }
 
+    /**
+     * @return Part[]
+     */
     private function populateResultParts(\SimpleXMLElement $xml): array
     {
         $items = [];

--- a/src/Service/Sns/src/Result/ListSubscriptionsByTopicResponse.php
+++ b/src/Service/Sns/src/Result/ListSubscriptionsByTopicResponse.php
@@ -115,20 +115,23 @@ class ListSubscriptionsByTopicResponse extends Result implements \IteratorAggreg
         $data = new \SimpleXMLElement($response->getContent());
         $data = $data->ListSubscriptionsByTopicResult;
 
-        $this->Subscriptions = !$data->Subscriptions ? [] : (function (\SimpleXMLElement $xml): array {
-            $items = [];
-            foreach ($xml->member as $item) {
-                $items[] = new Subscription([
-                    'SubscriptionArn' => ($v = $item->SubscriptionArn) ? (string) $v : null,
-                    'Owner' => ($v = $item->Owner) ? (string) $v : null,
-                    'Protocol' => ($v = $item->Protocol) ? (string) $v : null,
-                    'Endpoint' => ($v = $item->Endpoint) ? (string) $v : null,
-                    'TopicArn' => ($v = $item->TopicArn) ? (string) $v : null,
-                ]);
-            }
-
-            return $items;
-        })($data->Subscriptions);
+        $this->Subscriptions = !$data->Subscriptions ? [] : $this->populateResultSubscriptionsList($data->Subscriptions);
         $this->NextToken = ($v = $data->NextToken) ? (string) $v : null;
+    }
+
+    private function populateResultSubscriptionsList(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml->member as $item) {
+            $items[] = new Subscription([
+                'SubscriptionArn' => ($v = $item->SubscriptionArn) ? (string) $v : null,
+                'Owner' => ($v = $item->Owner) ? (string) $v : null,
+                'Protocol' => ($v = $item->Protocol) ? (string) $v : null,
+                'Endpoint' => ($v = $item->Endpoint) ? (string) $v : null,
+                'TopicArn' => ($v = $item->TopicArn) ? (string) $v : null,
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/Sns/src/Result/ListSubscriptionsByTopicResponse.php
+++ b/src/Service/Sns/src/Result/ListSubscriptionsByTopicResponse.php
@@ -119,6 +119,9 @@ class ListSubscriptionsByTopicResponse extends Result implements \IteratorAggreg
         $this->NextToken = ($v = $data->NextToken) ? (string) $v : null;
     }
 
+    /**
+     * @return Subscription[]
+     */
     private function populateResultSubscriptionsList(\SimpleXMLElement $xml): array
     {
         $items = [];

--- a/src/Service/Sqs/src/Result/GetQueueAttributesResult.php
+++ b/src/Service/Sqs/src/Result/GetQueueAttributesResult.php
@@ -38,10 +38,10 @@ class GetQueueAttributesResult extends Result
     {
         $items = [];
         foreach ($xml as $item) {
-            $a = (string) $item->Value;
-            if (null !== $a) {
-                $items[$item->Name->__toString()] = $a;
+            if (null === $a = $item->Value) {
+                continue;
             }
+            $items[$item->Name->__toString()] = (string) $a;
         }
 
         return $items;

--- a/src/Service/Sqs/src/Result/GetQueueAttributesResult.php
+++ b/src/Service/Sqs/src/Result/GetQueueAttributesResult.php
@@ -31,11 +31,14 @@ class GetQueueAttributesResult extends Result
         $this->Attributes = !$data->Attribute ? [] : $this->populateResultQueueAttributeMap($data->Attribute);
     }
 
+    /**
+     * @return array<QueueAttributeName::*, string>
+     */
     private function populateResultQueueAttributeMap(\SimpleXMLElement $xml): array
     {
         $items = [];
         foreach ($xml as $item) {
-            $a = ($v = $item->Value) ? (string) $v : null;
+            $a = (string) $item->Value;
             if (null !== $a) {
                 $items[$item->Name->__toString()] = $a;
             }

--- a/src/Service/Sqs/src/Result/GetQueueAttributesResult.php
+++ b/src/Service/Sqs/src/Result/GetQueueAttributesResult.php
@@ -28,16 +28,19 @@ class GetQueueAttributesResult extends Result
         $data = new \SimpleXMLElement($response->getContent());
         $data = $data->GetQueueAttributesResult;
 
-        $this->Attributes = !$data->Attribute ? [] : (function (\SimpleXMLElement $xml): array {
-            $items = [];
-            foreach ($xml as $item) {
-                $a = ($v = $item->Value) ? (string) $v : null;
-                if (null !== $a) {
-                    $items[$item->Name->__toString()] = $a;
-                }
-            }
+        $this->Attributes = !$data->Attribute ? [] : $this->populateResultQueueAttributeMap($data->Attribute);
+    }
 
-            return $items;
-        })($data->Attribute);
+    private function populateResultQueueAttributeMap(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml as $item) {
+            $a = ($v = $item->Value) ? (string) $v : null;
+            if (null !== $a) {
+                $items[$item->Name->__toString()] = $a;
+            }
+        }
+
+        return $items;
     }
 }

--- a/src/Service/Sqs/src/Result/ListQueuesResult.php
+++ b/src/Service/Sqs/src/Result/ListQueuesResult.php
@@ -40,16 +40,19 @@ class ListQueuesResult extends Result implements \IteratorAggregate
         $data = new \SimpleXMLElement($response->getContent());
         $data = $data->ListQueuesResult;
 
-        $this->QueueUrls = !$data->QueueUrl ? [] : (function (\SimpleXMLElement $xml): array {
-            $items = [];
-            foreach ($xml as $item) {
-                $a = ($v = $item) ? (string) $v : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
+        $this->QueueUrls = !$data->QueueUrl ? [] : $this->populateResultQueueUrlList($data->QueueUrl);
+    }
 
-            return $items;
-        })($data->QueueUrl);
+    private function populateResultQueueUrlList(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml as $item) {
+            $a = ($v = $item) ? (string) $v : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
     }
 }

--- a/src/Service/Sqs/src/Result/ListQueuesResult.php
+++ b/src/Service/Sqs/src/Result/ListQueuesResult.php
@@ -43,6 +43,9 @@ class ListQueuesResult extends Result implements \IteratorAggregate
         $this->QueueUrls = !$data->QueueUrl ? [] : $this->populateResultQueueUrlList($data->QueueUrl);
     }
 
+    /**
+     * @return string[]
+     */
     private function populateResultQueueUrlList(\SimpleXMLElement $xml): array
     {
         $items = [];

--- a/src/Service/Sqs/src/Result/ReceiveMessageResult.php
+++ b/src/Service/Sqs/src/Result/ReceiveMessageResult.php
@@ -56,12 +56,15 @@ class ReceiveMessageResult extends Result
     {
         $items = [];
         foreach ($xml as $item) {
+            if (null === $a = $item->Value) {
+                continue;
+            }
             $items[$item->Name->__toString()] = new MessageAttributeValue([
-                'StringValue' => ($v = $item->Value->StringValue) ? (string) $v : null,
-                'BinaryValue' => ($v = $item->Value->BinaryValue) ? base64_decode((string) $v) : null,
-                'StringListValues' => !$item->Value->StringListValue ? [] : $this->populateResultStringList($item->Value->StringListValue),
-                'BinaryListValues' => !$item->Value->BinaryListValue ? [] : $this->populateResultBinaryList($item->Value->BinaryListValue),
-                'DataType' => (string) $item->Value->DataType,
+                'StringValue' => ($v = $a->StringValue) ? (string) $v : null,
+                'BinaryValue' => ($v = $a->BinaryValue) ? base64_decode((string) $v) : null,
+                'StringListValues' => !$a->StringListValue ? [] : $this->populateResultStringList($a->StringListValue),
+                'BinaryListValues' => !$a->BinaryListValue ? [] : $this->populateResultBinaryList($a->BinaryListValue),
+                'DataType' => (string) $a->DataType,
             ]);
         }
 
@@ -96,10 +99,10 @@ class ReceiveMessageResult extends Result
     {
         $items = [];
         foreach ($xml as $item) {
-            $a = (string) $item->Value;
-            if (null !== $a) {
-                $items[$item->Name->__toString()] = $a;
+            if (null === $a = $item->Value) {
+                continue;
             }
+            $items[$item->Name->__toString()] = (string) $a;
         }
 
         return $items;

--- a/src/Service/Sqs/src/Result/ReceiveMessageResult.php
+++ b/src/Service/Sqs/src/Result/ReceiveMessageResult.php
@@ -4,6 +4,7 @@ namespace AsyncAws\Sqs\Result;
 
 use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
+use AsyncAws\Sqs\Enum\MessageSystemAttributeName;
 use AsyncAws\Sqs\ValueObject\Message;
 use AsyncAws\Sqs\ValueObject\MessageAttributeValue;
 
@@ -32,6 +33,9 @@ class ReceiveMessageResult extends Result
         $this->Messages = !$data->Message ? [] : $this->populateResultMessageList($data->Message);
     }
 
+    /**
+     * @return string[]
+     */
     private function populateResultBinaryList(\SimpleXMLElement $xml): array
     {
         $items = [];
@@ -45,11 +49,14 @@ class ReceiveMessageResult extends Result
         return $items;
     }
 
+    /**
+     * @return array<string, MessageAttributeValue>
+     */
     private function populateResultMessageBodyAttributeMap(\SimpleXMLElement $xml): array
     {
         $items = [];
         foreach ($xml as $item) {
-            $items[$item->Name->__toString()] = !$item->Value ? null : new MessageAttributeValue([
+            $items[$item->Name->__toString()] = new MessageAttributeValue([
                 'StringValue' => ($v = $item->Value->StringValue) ? (string) $v : null,
                 'BinaryValue' => ($v = $item->Value->BinaryValue) ? base64_decode((string) $v) : null,
                 'StringListValues' => !$item->Value->StringListValue ? [] : $this->populateResultStringList($item->Value->StringListValue),
@@ -61,6 +68,9 @@ class ReceiveMessageResult extends Result
         return $items;
     }
 
+    /**
+     * @return Message[]
+     */
     private function populateResultMessageList(\SimpleXMLElement $xml): array
     {
         $items = [];
@@ -79,11 +89,14 @@ class ReceiveMessageResult extends Result
         return $items;
     }
 
+    /**
+     * @return array<MessageSystemAttributeName::*, string>
+     */
     private function populateResultMessageSystemAttributeMap(\SimpleXMLElement $xml): array
     {
         $items = [];
         foreach ($xml as $item) {
-            $a = ($v = $item->Value) ? (string) $v : null;
+            $a = (string) $item->Value;
             if (null !== $a) {
                 $items[$item->Name->__toString()] = $a;
             }
@@ -92,6 +105,9 @@ class ReceiveMessageResult extends Result
         return $items;
     }
 
+    /**
+     * @return string[]
+     */
     private function populateResultStringList(\SimpleXMLElement $xml): array
     {
         $items = [];

--- a/src/Service/Sqs/src/Result/ReceiveMessageResult.php
+++ b/src/Service/Sqs/src/Result/ReceiveMessageResult.php
@@ -29,64 +29,79 @@ class ReceiveMessageResult extends Result
         $data = new \SimpleXMLElement($response->getContent());
         $data = $data->ReceiveMessageResult;
 
-        $this->Messages = !$data->Message ? [] : (function (\SimpleXMLElement $xml): array {
-            $items = [];
-            foreach ($xml as $item) {
-                $items[] = new Message([
-                    'MessageId' => ($v = $item->MessageId) ? (string) $v : null,
-                    'ReceiptHandle' => ($v = $item->ReceiptHandle) ? (string) $v : null,
-                    'MD5OfBody' => ($v = $item->MD5OfBody) ? (string) $v : null,
-                    'Body' => ($v = $item->Body) ? (string) $v : null,
-                    'Attributes' => !$item->Attribute ? [] : (function (\SimpleXMLElement $xml): array {
-                        $items = [];
-                        foreach ($xml as $item) {
-                            $a = ($v = $item->Value) ? (string) $v : null;
-                            if (null !== $a) {
-                                $items[$item->Name->__toString()] = $a;
-                            }
-                        }
+        $this->Messages = !$data->Message ? [] : $this->populateResultMessageList($data->Message);
+    }
 
-                        return $items;
-                    })($item->Attribute),
-                    'MD5OfMessageAttributes' => ($v = $item->MD5OfMessageAttributes) ? (string) $v : null,
-                    'MessageAttributes' => !$item->MessageAttribute ? [] : (function (\SimpleXMLElement $xml): array {
-                        $items = [];
-                        foreach ($xml as $item) {
-                            $items[$item->Name->__toString()] = !$item->Value ? null : new MessageAttributeValue([
-                                'StringValue' => ($v = $item->Value->StringValue) ? (string) $v : null,
-                                'BinaryValue' => ($v = $item->Value->BinaryValue) ? base64_decode((string) $v) : null,
-                                'StringListValues' => !$item->Value->StringListValue ? [] : (function (\SimpleXMLElement $xml): array {
-                                    $items = [];
-                                    foreach ($xml->StringListValue as $item) {
-                                        $a = ($v = $item) ? (string) $v : null;
-                                        if (null !== $a) {
-                                            $items[] = $a;
-                                        }
-                                    }
-
-                                    return $items;
-                                })($item->Value->StringListValue),
-                                'BinaryListValues' => !$item->Value->BinaryListValue ? [] : (function (\SimpleXMLElement $xml): array {
-                                    $items = [];
-                                    foreach ($xml->BinaryListValue as $item) {
-                                        $a = ($v = $item) ? base64_decode((string) $v) : null;
-                                        if (null !== $a) {
-                                            $items[] = $a;
-                                        }
-                                    }
-
-                                    return $items;
-                                })($item->Value->BinaryListValue),
-                                'DataType' => (string) $item->Value->DataType,
-                            ]);
-                        }
-
-                        return $items;
-                    })($item->MessageAttribute),
-                ]);
+    private function populateResultBinaryList(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml->BinaryListValue as $item) {
+            $a = ($v = $item) ? base64_decode((string) $v) : null;
+            if (null !== $a) {
+                $items[] = $a;
             }
+        }
 
-            return $items;
-        })($data->Message);
+        return $items;
+    }
+
+    private function populateResultMessageBodyAttributeMap(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml as $item) {
+            $items[$item->Name->__toString()] = !$item->Value ? null : new MessageAttributeValue([
+                'StringValue' => ($v = $item->Value->StringValue) ? (string) $v : null,
+                'BinaryValue' => ($v = $item->Value->BinaryValue) ? base64_decode((string) $v) : null,
+                'StringListValues' => !$item->Value->StringListValue ? [] : $this->populateResultStringList($item->Value->StringListValue),
+                'BinaryListValues' => !$item->Value->BinaryListValue ? [] : $this->populateResultBinaryList($item->Value->BinaryListValue),
+                'DataType' => (string) $item->Value->DataType,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultMessageList(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml as $item) {
+            $items[] = new Message([
+                'MessageId' => ($v = $item->MessageId) ? (string) $v : null,
+                'ReceiptHandle' => ($v = $item->ReceiptHandle) ? (string) $v : null,
+                'MD5OfBody' => ($v = $item->MD5OfBody) ? (string) $v : null,
+                'Body' => ($v = $item->Body) ? (string) $v : null,
+                'Attributes' => !$item->Attribute ? [] : $this->populateResultMessageSystemAttributeMap($item->Attribute),
+                'MD5OfMessageAttributes' => ($v = $item->MD5OfMessageAttributes) ? (string) $v : null,
+                'MessageAttributes' => !$item->MessageAttribute ? [] : $this->populateResultMessageBodyAttributeMap($item->MessageAttribute),
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultMessageSystemAttributeMap(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml as $item) {
+            $a = ($v = $item->Value) ? (string) $v : null;
+            if (null !== $a) {
+                $items[$item->Name->__toString()] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    private function populateResultStringList(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml->StringListValue as $item) {
+            $a = ($v = $item) ? (string) $v : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
     }
 }

--- a/src/Service/Ssm/src/Result/GetParametersByPathResult.php
+++ b/src/Service/Ssm/src/Result/GetParametersByPathResult.php
@@ -117,6 +117,9 @@ class GetParametersByPathResult extends Result implements \IteratorAggregate
         $this->NextToken = isset($data['NextToken']) ? (string) $data['NextToken'] : null;
     }
 
+    /**
+     * @return Parameter[]
+     */
     private function populateResultParameterList(array $json): array
     {
         $items = [];

--- a/src/Service/Ssm/src/Result/GetParametersByPathResult.php
+++ b/src/Service/Ssm/src/Result/GetParametersByPathResult.php
@@ -112,26 +112,28 @@ class GetParametersByPathResult extends Result implements \IteratorAggregate
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-ParameterList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new Parameter([
-                    'Name' => isset($item['Name']) ? (string) $item['Name'] : null,
-                    'Type' => isset($item['Type']) ? (string) $item['Type'] : null,
-                    'Value' => isset($item['Value']) ? (string) $item['Value'] : null,
-                    'Version' => isset($item['Version']) ? (string) $item['Version'] : null,
-                    'Selector' => isset($item['Selector']) ? (string) $item['Selector'] : null,
-                    'SourceResult' => isset($item['SourceResult']) ? (string) $item['SourceResult'] : null,
-                    'LastModifiedDate' => (isset($item['LastModifiedDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['LastModifiedDate'])))) ? $d : null,
-                    'ARN' => isset($item['ARN']) ? (string) $item['ARN'] : null,
-                    'DataType' => isset($item['DataType']) ? (string) $item['DataType'] : null,
-                ]);
-            }
 
-            return $items;
-        };
-        $this->Parameters = empty($data['Parameters']) ? [] : $fn['list-ParameterList']($data['Parameters']);
+        $this->Parameters = empty($data['Parameters']) ? [] : $this->populateResultParameterList($data['Parameters']);
         $this->NextToken = isset($data['NextToken']) ? (string) $data['NextToken'] : null;
+    }
+
+    private function populateResultParameterList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new Parameter([
+                'Name' => isset($item['Name']) ? (string) $item['Name'] : null,
+                'Type' => isset($item['Type']) ? (string) $item['Type'] : null,
+                'Value' => isset($item['Value']) ? (string) $item['Value'] : null,
+                'Version' => isset($item['Version']) ? (string) $item['Version'] : null,
+                'Selector' => isset($item['Selector']) ? (string) $item['Selector'] : null,
+                'SourceResult' => isset($item['SourceResult']) ? (string) $item['SourceResult'] : null,
+                'LastModifiedDate' => (isset($item['LastModifiedDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['LastModifiedDate'])))) ? $d : null,
+                'ARN' => isset($item['ARN']) ? (string) $item['ARN'] : null,
+                'DataType' => isset($item['DataType']) ? (string) $item['DataType'] : null,
+            ]);
+        }
+
+        return $items;
     }
 }

--- a/src/Service/Ssm/src/Result/GetParametersResult.php
+++ b/src/Service/Ssm/src/Result/GetParametersResult.php
@@ -41,37 +41,41 @@ class GetParametersResult extends Result
     protected function populateResult(Response $response): void
     {
         $data = $response->toArray();
-        $fn = [];
-        $fn['list-ParameterList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $items[] = new Parameter([
-                    'Name' => isset($item['Name']) ? (string) $item['Name'] : null,
-                    'Type' => isset($item['Type']) ? (string) $item['Type'] : null,
-                    'Value' => isset($item['Value']) ? (string) $item['Value'] : null,
-                    'Version' => isset($item['Version']) ? (string) $item['Version'] : null,
-                    'Selector' => isset($item['Selector']) ? (string) $item['Selector'] : null,
-                    'SourceResult' => isset($item['SourceResult']) ? (string) $item['SourceResult'] : null,
-                    'LastModifiedDate' => (isset($item['LastModifiedDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['LastModifiedDate'])))) ? $d : null,
-                    'ARN' => isset($item['ARN']) ? (string) $item['ARN'] : null,
-                    'DataType' => isset($item['DataType']) ? (string) $item['DataType'] : null,
-                ]);
-            }
 
-            return $items;
-        };
-        $fn['list-ParameterNameList'] = static function (array $json) use (&$fn): array {
-            $items = [];
-            foreach ($json as $item) {
-                $a = isset($item) ? (string) $item : null;
-                if (null !== $a) {
-                    $items[] = $a;
-                }
-            }
+        $this->Parameters = empty($data['Parameters']) ? [] : $this->populateResultParameterList($data['Parameters']);
+        $this->InvalidParameters = empty($data['InvalidParameters']) ? [] : $this->populateResultParameterNameList($data['InvalidParameters']);
+    }
 
-            return $items;
-        };
-        $this->Parameters = empty($data['Parameters']) ? [] : $fn['list-ParameterList']($data['Parameters']);
-        $this->InvalidParameters = empty($data['InvalidParameters']) ? [] : $fn['list-ParameterNameList']($data['InvalidParameters']);
+    private function populateResultParameterList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new Parameter([
+                'Name' => isset($item['Name']) ? (string) $item['Name'] : null,
+                'Type' => isset($item['Type']) ? (string) $item['Type'] : null,
+                'Value' => isset($item['Value']) ? (string) $item['Value'] : null,
+                'Version' => isset($item['Version']) ? (string) $item['Version'] : null,
+                'Selector' => isset($item['Selector']) ? (string) $item['Selector'] : null,
+                'SourceResult' => isset($item['SourceResult']) ? (string) $item['SourceResult'] : null,
+                'LastModifiedDate' => (isset($item['LastModifiedDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', \sprintf('%.6F', $item['LastModifiedDate'])))) ? $d : null,
+                'ARN' => isset($item['ARN']) ? (string) $item['ARN'] : null,
+                'DataType' => isset($item['DataType']) ? (string) $item['DataType'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    private function populateResultParameterNameList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $a = isset($item) ? (string) $item : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
     }
 }

--- a/src/Service/Ssm/src/Result/GetParametersResult.php
+++ b/src/Service/Ssm/src/Result/GetParametersResult.php
@@ -46,6 +46,9 @@ class GetParametersResult extends Result
         $this->InvalidParameters = empty($data['InvalidParameters']) ? [] : $this->populateResultParameterNameList($data['InvalidParameters']);
     }
 
+    /**
+     * @return Parameter[]
+     */
     private function populateResultParameterList(array $json): array
     {
         $items = [];
@@ -66,6 +69,9 @@ class GetParametersResult extends Result
         return $items;
     }
 
+    /**
+     * @return string[]
+     */
     private function populateResultParameterNameList(array $json): array
     {
         $items = [];


### PR DESCRIPTION
This PR replace the `$fn` array (passed by reference) by private methods.

The code is more readable, and recursion is easier to handle.

I wonder if I shouldn't do the same for XmlParser: currently closures are not static and declared in loops, I beleive their is a potential performance optimization by replacing theme by real methods