### PR TITLE
Prepare for 1.0.0 of Symfony Bundle

### DIFF
--- a/src/Integration/Symfony/Bundle/CHANGELOG.md
+++ b/src/Integration/Symfony/Bundle/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+## 1.0.0
+
+No changes since 0.2.6
+
 ## 0.2.6
 
 ### Added

--- a/src/Integration/Symfony/Bundle/composer.json
+++ b/src/Integration/Symfony/Bundle/composer.json
@@ -22,7 +22,7 @@
         "async-aws/s3": "^1.0",
         "async-aws/ses": "^1.0",
         "async-aws/sqs": "^1.0",
-        "async-aws/ssm": "^0.1",
+        "async-aws/ssm": "^0.2",
         "matthiasnoback/symfony-config-test": "^4.1",
         "nyholm/symfony-bundle-test": "^1.6.1",
         "symfony/cache": "^4.4 || ^5.0"

--- a/src/Integration/Symfony/Bundle/composer.json
+++ b/src/Integration/Symfony/Bundle/composer.json
@@ -29,7 +29,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.4-dev"
+            "dev-master": "1.1-dev"
         }
     },
     "autoload": {


### PR DESCRIPTION
The Symfony Bundle has basically kept BC since 0.1. It has over 2000 downloads. 
I suggest tagging 1.0.