### PR TITLE
Log 404 errors with log level info, to prevent log-spamming.

### DIFF
--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -357,6 +357,7 @@ class Response
             $this->resolveResult = new $class(...$args);
         }
 
+        $code = null;
         $message = null;
         $context = ['exception' => $this->resolveResult];
         if ($this->resolveResult instanceof HttpException) {
@@ -372,7 +373,12 @@ class Response
         }
 
         if ($this->resolveResult instanceof Exception) {
-            $this->logger->error($message ?? $this->resolveResult->getMessage(), $context);
+            if (404 === $code) {
+                $this->logger->info($message ?? $this->resolveResult->getMessage(), $context);
+            } else {
+                $this->logger->error($message ?? $this->resolveResult->getMessage(), $context);
+            }
+
             $this->didThrow = true;
 
             throw $this->resolveResult;


### PR DESCRIPTION
As mentioned in #507, file-existance-checks will result in numerous errors. Requests with status code 404 will now be logged with log level info, to prevent log spamming in systems like sentry.