### PR TITLE
add Laravel S3 region support

### DIFF
--- a/src/Integration/Laravel/Filesystem/src/AsyncAwsFilesystemManager.php
+++ b/src/Integration/Laravel/Filesystem/src/AsyncAwsFilesystemManager.php
@@ -28,6 +28,10 @@ class AsyncAwsFilesystemManager extends FilesystemManager
             $s3Config['endpoint'] = $config['endpoint'];
         }
 
+        if (!empty($config['region'])) {
+            $s3Config['region'] = $config['region'];
+        }
+
         $root = $config['root'] ?? '';
         $options = $config['options'] ?? [];
 

--- a/src/Integration/Laravel/Filesystem/tests/Unit/ServiceProviderTest.php
+++ b/src/Integration/Laravel/Filesystem/tests/Unit/ServiceProviderTest.php
@@ -27,6 +27,7 @@ class ServiceProviderTest extends TestCase
             'key' => 'my_key',
             'secret' => 'my_secret',
             'bucket' => 'my_bucket',
+            'region' => 'ap-southeast-1',
         ]);
 
         self::assertInstanceOf(FilesystemAdapter::class, $illuminateFilesystemAdapter);
@@ -49,5 +50,6 @@ class ServiceProviderTest extends TestCase
         $config = $client->getConfiguration();
         self::assertEquals('my_key', $config->get('accessKeyId'));
         self::assertEquals('my_secret', $config->get('accessKeySecret'));
+        self::assertEquals('ap-southeast-1', $config->get('region'));
     }
 }


### PR DESCRIPTION
This PR add support for `region` option in Laravel Filesystem integration to match other integrated services.