### PR TITLE
Prepare release 1.0

### DIFF
--- a/src/Service/CloudFormation/CHANGELOG.md
+++ b/src/Service/CloudFormation/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ## 1.0.0
 
-### Added support for PHP 8
+### Added
+
+- Support for PHP 8
 
 ## 0.5.0
 

--- a/src/Service/CloudWatchLogs/CHANGELOG.md
+++ b/src/Service/CloudWatchLogs/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## NOT RELEASED
 
+## 1.0.0
+
+### Added
+
+- Support for PHP 8
+
 ## 0.2.0
 
 ### Removed

--- a/src/Service/CodeDeploy/CHANGELOG.md
+++ b/src/Service/CodeDeploy/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## NOT RELEASED
 
+## 1.0.0
+
+### Added
+
+- Support for PHP 8
+
 ## 0.2.0
 
 ### Removed

--- a/src/Service/EventBridge/CHANGELOG.md
+++ b/src/Service/EventBridge/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## NOT RELEASED
 
+## 1.0.0
+
+### Added
+
+- Support for PHP 8
+
 ## 0.2.0
 
 ### Removed

--- a/src/Service/Lambda/CHANGELOG.md
+++ b/src/Service/Lambda/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ## 1.0.0
 
-### Added support for PHP 8
+### Added
+
+- Support for PHP 8
 
 ## 0.5.0
 

--- a/src/Service/Sns/CHANGELOG.md
+++ b/src/Service/Sns/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+## 1.0.0
+
+No changes since 0.5.1.
+
 ## 0.5.1
 
 ### Added

--- a/src/Service/Ssm/CHANGELOG.md
+++ b/src/Service/Ssm/CHANGELOG.md
@@ -4,7 +4,9 @@
 
 ## 1.0.0
 
-### Added support for PHP 8
+### Added
+
+- Support for PHP 8
 
 ## 0.2.0
 


### PR DESCRIPTION
The following services have over 1000 downloads and are stable. 

* CloudWatchLogs
* CodeDeploy
* EventBridge
* SNS

I suggest to tag them with 1.0. 