### PR TITLE
Update test to show on issue in code

### DIFF
--- a/src/Integration/Laravel/Filesystem/composer.json
+++ b/src/Integration/Laravel/Filesystem/composer.json
@@ -13,7 +13,7 @@
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
         "async-aws/core": "^1.0",
-        "async-aws/flysystem-s3": "^0.3.3",
+        "async-aws/flysystem-s3": "^0.4.0",
         "async-aws/simple-s3": "^0.1",
         "illuminate/filesystem": "^6.18.13 || ^7.10",
         "illuminate/support": "^6.18.13 || ^7.10"

--- a/src/Integration/Laravel/Filesystem/tests/Unit/ServiceProviderTest.php
+++ b/src/Integration/Laravel/Filesystem/tests/Unit/ServiceProviderTest.php
@@ -43,9 +43,7 @@ class ServiceProviderTest extends TestCase
         self::assertEquals('my_bucket', $bucket);
 
         // Verify config
-        $property = $refl->getProperty('client');
-        $property->setAccessible(true);
-        $client = $property->getValue($s3FilesystemAdapter);
+        $client = $s3FilesystemAdapter->getClient();
 
         $config = $client->getConfiguration();
         self::assertEquals('my_key', $config->get('accessKeyId'));


### PR DESCRIPTION
Hi again, I'm back with another issue with using Laravel's `Storage::url` with the async-aws integration (#603).

This commit updates the test for S3FilesystemV1 to point out a issue in how the code works when trying to access a url for a S3 object using the Filesystem adapter in Laravel.

I have code like this
```
Storage::disk('public')->url($filename);
```

where the disk public is configured with:
```php
'driver' => 'async-aws-s3',
```

The issue that I see is that `\AsyncAws\Illuminate\Filesystem\AsyncAwsFilesystemAdapter::url` is accessing the S3FilesystemV1 and trying to call `getClient` on it which does not exists in the version required by this (0.3.3).
It is added and tagged in 0.4.0.

I have added one more commit the requires `^0.4.0` of `async-aws/flysystem-s3` and fixes this issue.