### PR TITLE
Add a "debug" config to print HTTP requests and responses

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -33,6 +33,15 @@ The AWS region the client should be targeting.
 > **Note**: Region can also be defined by providing a `@region` parameter in
 > operation's input
 
+### debug
+
+**Default:** 'false'
+
+When this is set to `true` we will write the full HTTP request and response as
+an `debug` log entry. Make sure you pass a logger to the `Client`.
+
+> **Note**: This will have an negative impact on performance.
+
 ### profile
 
 **Default:** 'default'

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -136,6 +136,15 @@ abstract class AbstractApi
             ]
         );
 
+        if (\filter_var($configuration->get('debug'), \FILTER_VALIDATE_BOOLEAN)) {
+            $this->logger->debug('AsyncAws HTTP request sent', [
+                'method' => $request->getMethod(),
+                'endpoint' => $request->getEndpoint(),
+                'headers' => json_encode($request->getHeaders()),
+                'body' => 0 === $length ? null : $requestBody,
+            ]);
+        }
+
         return new Response($response, $this->httpClient, $this->logger);
     }
 

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -136,7 +136,7 @@ abstract class AbstractApi
             ]
         );
 
-        if (\filter_var($configuration->get('debug'), \FILTER_VALIDATE_BOOLEAN)) {
+        if (\filter_var($this->configuration->get('debug'), \FILTER_VALIDATE_BOOLEAN)) {
             $this->logger->debug('AsyncAws HTTP request sent', [
                 'method' => $request->getMethod(),
                 'endpoint' => $request->getEndpoint(),

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -136,8 +136,8 @@ abstract class AbstractApi
             ]
         );
 
-        if (\filter_var($this->configuration->get('debug'), \FILTER_VALIDATE_BOOLEAN)) {
-            $this->logger->debug('AsyncAws HTTP request sent', [
+        if ($debug = \filter_var($this->configuration->get('debug'), \FILTER_VALIDATE_BOOLEAN)) {
+            $this->logger->debug('AsyncAws HTTP request sent: {method} {endpoint}', [
                 'method' => $request->getMethod(),
                 'endpoint' => $request->getEndpoint(),
                 'headers' => json_encode($request->getHeaders()),
@@ -145,7 +145,7 @@ abstract class AbstractApi
             ]);
         }
 
-        return new Response($response, $this->httpClient, $this->logger);
+        return new Response($response, $this->httpClient, $this->logger, $debug);
     }
 
     /**

--- a/src/Core/src/Configuration.php
+++ b/src/Core/src/Configuration.php
@@ -17,6 +17,7 @@ final class Configuration
     public const DEFAULT_REGION = 'us-east-1';
 
     public const OPTION_REGION = 'region';
+    public const OPTION_DEBUG = 'debug';
     public const OPTION_PROFILE = 'profile';
     public const OPTION_ACCESS_KEY_ID = 'accessKeyId';
     public const OPTION_SECRET_ACCESS_KEY = 'accessKeySecret';
@@ -34,6 +35,7 @@ final class Configuration
 
     private const AVAILABLE_OPTIONS = [
         self::OPTION_REGION => true,
+        self::OPTION_DEBUG => true,
         self::OPTION_PROFILE => true,
         self::OPTION_ACCESS_KEY_ID => true,
         self::OPTION_SECRET_ACCESS_KEY => true,
@@ -69,6 +71,7 @@ final class Configuration
 
     private const DEFAULT_OPTIONS = [
         self::OPTION_REGION => self::DEFAULT_REGION,
+        self::OPTION_DEBUG => 'false',
         self::OPTION_PROFILE => 'default',
         self::OPTION_SHARED_CREDENTIALS_FILE => '~/.aws/credentials',
         self::OPTION_SHARED_CONFIG_FILE => '~/.aws/config',

--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -121,16 +121,17 @@ class Response
         }
 
         if (true === $this->debug) {
-            $httpStatusCode = $info = $this->info()['status'];
+            $httpStatusCode = $this->httpResponse->getInfo('http_code');
             if (0 === $httpStatusCode) {
                 // Network exception
                 $this->logger->debug('AsyncAws HTTP request could not be sent due network issues');
             } else {
-                $this->logger->debug('AsyncAws HTTP response received', [
+                $this->logger->debug('AsyncAws HTTP response received with status code {status_code}', [
                     'status_code' => $httpStatusCode,
-                    'headers' => json_encode($this->getHeaders()),
-                    'body' => $this->getContent(),
+                    'headers' => json_encode($this->httpResponse->getHeaders(false)),
+                    'body' => $this->httpResponse->getContent(false),
                 ]);
+                $this->bodyDownloaded = true;
             }
         }
 


### PR DESCRIPTION
It could be helpful to see exactly what HTTP requests and responses we are dealing with. The official SDK prints this to stdout but we use PSR3. 