### PR TITLE
Allow non-standard region with custom endpoint

### DIFF
--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Fixed
+
+- Allow signing request with non-standard region when using custom endpoint?
+
 ## 1.4.2
 
 ### Fixed

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -228,11 +228,12 @@ abstract class AbstractApi
         if (!isset($this->signers[$region])) {
             $factories = $this->getSignerFactories();
             $factory = null;
-            if (!$this->configuration->isDefault('endpoint') && !$this->configuration->isDefault('region')) {
+            if ($this->configuration->isDefault('endpoint') || $this->configuration->isDefault('region')) {
+                $metadata = $this->getEndpointMetadata($region);
+            } else {
+                // Allow non-aws region with custom endpoint
                 $metadata = $this->getEndpointMetadata(Configuration::DEFAULT_REGION);
                 $metadata['signRegion'] = $region;
-            } else {
-                $metadata = $this->getEndpointMetadata($region);
             }
 
             foreach ($metadata['signVersions'] as $signatureVersion) {

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -226,9 +226,15 @@ abstract class AbstractApi
         /** @var string $region */
         $region = $region ?? ($this->configuration->isDefault('region') ? null : $this->configuration->get('region'));
         if (!isset($this->signers[$region])) {
-            $metadata = $this->getEndpointMetadata($region);
             $factories = $this->getSignerFactories();
             $factory = null;
+            if (!$this->configuration->isDefault('endpoint') && !$this->configuration->isDefault('region')) {
+                $metadata = $this->getEndpointMetadata(Configuration::DEFAULT_REGION);
+                $metadata['signRegion'] = $region;
+            } else {
+                $metadata = $this->getEndpointMetadata($region);
+            }
+
             foreach ($metadata['signVersions'] as $signatureVersion) {
                 if (isset($factories[$signatureVersion])) {
                     $factory = $factories[$signatureVersion];

--- a/src/Core/tests/Integration/StsClientTest.php
+++ b/src/Core/tests/Integration/StsClientTest.php
@@ -11,7 +11,6 @@ use AsyncAws\Core\Sts\Input\PolicyDescriptorType;
 use AsyncAws\Core\Sts\Input\Tag;
 use AsyncAws\Core\Sts\StsClient;
 use AsyncAws\Core\Test\TestCase;
-use AsyncAws\S3\Input\CreateBucketRequest;
 
 class StsClientTest extends TestCase
 {

--- a/src/Core/tests/Integration/StsClientTest.php
+++ b/src/Core/tests/Integration/StsClientTest.php
@@ -11,6 +11,7 @@ use AsyncAws\Core\Sts\Input\PolicyDescriptorType;
 use AsyncAws\Core\Sts\Input\Tag;
 use AsyncAws\Core\Sts\StsClient;
 use AsyncAws\Core\Test\TestCase;
+use AsyncAws\S3\Input\CreateBucketRequest;
 
 class StsClientTest extends TestCase
 {
@@ -104,6 +105,21 @@ class StsClientTest extends TestCase
 
         $this->expectException(UnsupportedRegion::class);
         $client->presign(new AssumeRoleRequest(['RoleArn' => 'demo', 'RoleSessionName' => 'demo']));
+    }
+
+    public function testCustomEndpointSignature(): void
+    {
+        $client = new StsClient([
+            'endpoint' => 'https://custom.acme.com',
+            'region' => 'demo',
+            'accessKeyId' => '123',
+            'accessKeySecret' => '123',
+        ]);
+
+        $url = $client->presign(new CreateBucketRequest(['Bucket' => 'foo']));
+        \parse_str(\parse_url($url, \PHP_URL_QUERY), $query);
+
+        self::assertStringContainsString('/demo/', $query['X-Amz-Credential']);
     }
 
     private function getClient(): StsClient

--- a/src/Core/tests/Integration/StsClientTest.php
+++ b/src/Core/tests/Integration/StsClientTest.php
@@ -116,7 +116,10 @@ class StsClientTest extends TestCase
             'accessKeySecret' => '123',
         ]);
 
-        $url = $client->presign(new CreateBucketRequest(['Bucket' => 'foo']));
+        $url = $client->presign(new AssumeRoleRequest([
+            'RoleArn' => 'test',
+            'RoleSessionName' => 'test',
+        ]));
         \parse_str(\parse_url($url, \PHP_URL_QUERY), $query);
 
         self::assertStringContainsString('/demo/', $query['X-Amz-Credential']);

--- a/src/Service/S3/tests/Unit/S3ClientTest.php
+++ b/src/Service/S3/tests/Unit/S3ClientTest.php
@@ -81,21 +81,6 @@ class S3ClientTest extends TestCase
         self::assertSame('http://foo.custom.com/', $client->presign(new CreateBucketRequest(['Bucket' => 'foo'])));
     }
 
-    public function testCustomEndpointSignature(): void
-    {
-        $client = new S3Client([
-            'endpoint' => 'https://s3.fr-par.scw.cloud',
-            'region' => 'fr-par',
-            'accessKeyId' => '123',
-            'accessKeySecret' => '123',
-        ]);
-
-        $url = $client->presign(new CreateBucketRequest(['Bucket' => 'foo']));
-        \parse_str(\parse_url($url, \PHP_URL_QUERY), $query);
-
-        self::assertStringContainsString('/fr-par/', $query['X-Amz-Credential']);
-    }
-
     public function testCompleteMultipartUpload(): void
     {
         $client = new S3Client([], new NullProvider(), new MockHttpClient());

--- a/src/Service/S3/tests/Unit/S3ClientTest.php
+++ b/src/Service/S3/tests/Unit/S3ClientTest.php
@@ -91,7 +91,7 @@ class S3ClientTest extends TestCase
         ]);
 
         $url = $client->presign(new CreateBucketRequest(['Bucket' => 'foo']));
-        \parse_str(\parse_url($url, PHP_URL_QUERY), $query);
+        \parse_str(\parse_url($url, \PHP_URL_QUERY), $query);
 
         self::assertStringContainsString('/fr-par/', $query['X-Amz-Credential']);
     }

--- a/src/Service/S3/tests/Unit/S3ClientTest.php
+++ b/src/Service/S3/tests/Unit/S3ClientTest.php
@@ -81,6 +81,21 @@ class S3ClientTest extends TestCase
         self::assertSame('http://foo.custom.com/', $client->presign(new CreateBucketRequest(['Bucket' => 'foo'])));
     }
 
+    public function testCustomEndpointSignature(): void
+    {
+        $client = new S3Client([
+            'endpoint' => 'https://s3.fr-par.scw.cloud',
+            'region' => 'fr-par',
+            'accessKeyId' => '123',
+            'accessKeySecret' => '123',
+        ]);
+
+        $url = $client->presign(new CreateBucketRequest(['Bucket' => 'foo']));
+        \parse_str(\parse_url($url, PHP_URL_QUERY), $query);
+
+        self::assertStringContainsString('/fr-par/', $query['X-Amz-Credential']);
+    }
+
     public function testCompleteMultipartUpload(): void
     {
         $client = new S3Client([], new NullProvider(), new MockHttpClient());


### PR DESCRIPTION
Fixes #757 by using "default" signature information when calling a custom endpoint