### PR TITLE
Update to avoid bug in symfony/http-kernel: >5.0, <5.1.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/deprecation-contracts": "^2.1",
         "symfony/filesystem": "^5.0",
         "symfony/finder": "^4.4 || ^5.0",
-        "symfony/http-kernel": "^4.4 || ^5.0",
+        "symfony/http-kernel": "^4.4 || ^5.1.5",
         "symfony/phpunit-bridge": "^5.0"
     },
     "autoload": {

--- a/src/Integration/Symfony/Bundle/composer.json
+++ b/src/Integration/Symfony/Bundle/composer.json
@@ -16,7 +16,7 @@
         "async-aws/core": "^1.0",
         "symfony/config": "^4.4 || ^5.0",
         "symfony/dependency-injection": "^4.4 || ^5.0",
-        "symfony/http-kernel": "^4.4 || ^5.0"
+        "symfony/http-kernel": "^4.4 || ^5.1.5"
     },
     "require-dev": {
         "async-aws/s3": "^1.0",


### PR DESCRIPTION
Should we do this? 

Dependabot clearly recommends us to do this.. But it is a security issue in a class we are not using. 

Im also considering what responsibility we have compared to the end user. 