### PR TITLE
Fix missing env variables

### DIFF
--- a/generate
+++ b/generate
@@ -1,6 +1,8 @@
 #!/usr/bin/env php
 <?php
 
+use AsyncAws\Core\EnvVar;
+
 $generatorDir = __DIR__ . '/src/CodeGenerator';
 if (!file_exists($generatorDir . '/generate.php')) {
     echo "Unable to find the `generate.php` script in `/src/CodeGenerator/`.\n";
@@ -14,13 +16,13 @@ if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
 
 require __DIR__ . '/vendor/autoload.php';
 
-if (!isset($_SERVER['ASYNC_AWS_GENERATE_MANIFEST'])) {
+if (null === EnvVar::get('ASYNC_AWS_GENERATE_MANIFEST')) {
     $_SERVER['ASYNC_AWS_GENERATE_MANIFEST'] = __DIR__ . '/manifest.json';
 }
-if (!isset($_SERVER['ASYNC_AWS_GENERATE_SRC'])) {
+if (null === EnvVar::get('ASYNC_AWS_GENERATE_SRC')) {
     $_SERVER['ASYNC_AWS_GENERATE_SRC'] = __DIR__ . '/src';
 }
-if (!isset($_SERVER['SYMFONY_PATCH_TYPE_DECLARATIONS'])) {
+if (null === EnvVar::get('SYMFONY_PATCH_TYPE_DECLARATIONS')) {
     $_SERVER['SYMFONY_PATCH_TYPE_DECLARATIONS'] = 'deprecations=1';
 }
 

--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixed
 
 - Allow signing request with non-standard region when using custom endpoint?
+- Fix unresolved Env Variable in some php configuration
 
 ## 1.4.2
 

--- a/src/Core/src/Configuration.php
+++ b/src/Core/src/Configuration.php
@@ -102,8 +102,8 @@ final class Configuration
             foreach ($fallbackGroup as $option => $envVariableNames) {
                 $envVariableNames = (array) $envVariableNames;
                 foreach ($envVariableNames as $envVariableName) {
-                    if (isset($_SERVER[$envVariableName])) {
-                        $options[$option] = $_SERVER[$envVariableName];
+                    if (null !== $envVariableValue = EnvVar::get($envVariableName)) {
+                        $options[$option] = $envVariableValue;
 
                         break;
                     }

--- a/src/Core/src/Credentials/IniFileLoader.php
+++ b/src/Core/src/Credentials/IniFileLoader.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\Core\Credentials;
 
+use AsyncAws\Core\EnvVar;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
@@ -65,13 +66,13 @@ final class IniFileLoader
     private function getHomeDir(): string
     {
         // On Linux/Unix-like systems, use the HOME environment variable
-        if (\is_string($homeDir = $_SERVER['HOME'] ?? null)) {
+        if (null !== $homeDir = EnvVar::get('HOME')) {
             return $homeDir;
         }
 
         // Get the HOMEDRIVE and HOMEPATH values for Windows hosts
-        $homeDrive = $_SERVER['HOMEDRIVE'] ?? null;
-        $homePath = $_SERVER['HOMEPATH'] ?? null;
+        $homeDrive = EnvVar::get('HOMEDRIVE');
+        $homePath = EnvVar::get('HOMEPATH');
 
         return ($homeDrive && $homePath) ? $homeDrive . $homePath : '/';
     }

--- a/src/Core/src/EnvVar.php
+++ b/src/Core/src/EnvVar.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace AsyncAws\Core;
 
 /**
- * Helper to safely read environment variables
+ * Helper to safely read environment variables.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
-
+ *
  * @internal
  */
 final class EnvVar

--- a/src/Core/src/EnvVar.php
+++ b/src/Core/src/EnvVar.php
@@ -4,6 +4,13 @@ declare(strict_types=1);
 
 namespace AsyncAws\Core;
 
+/**
+ * Helper to safely read environment variables
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+
+ * @internal
+ */
 final class EnvVar
 {
     public static function get(string $name): ?string

--- a/src/Core/src/EnvVar.php
+++ b/src/Core/src/EnvVar.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core;
+
+final class EnvVar
+{
+    public static function get(string $name): ?string
+    {
+        if (isset($_ENV[$name])) {
+            // variable_order = *E*GPCS
+            return $_ENV[$name];
+        } elseif (isset($_SERVER[$name]) && 0 !== strpos($name, 'HTTP_')) {
+            // fastcgi_param, env var, ...
+            return $_SERVER[$name];
+        } elseif (false === ($env = getenv($name)) || null === $env) {
+            // getenv not thread safe
+            return null;
+        }
+
+        return $env;
+    }
+}

--- a/src/Core/src/EnvVar.php
+++ b/src/Core/src/EnvVar.php
@@ -21,7 +21,7 @@ final class EnvVar
         } elseif (isset($_SERVER[$name]) && 0 !== strpos($name, 'HTTP_')) {
             // fastcgi_param, env var, ...
             return $_SERVER[$name];
-        } elseif (false === ($env = getenv($name)) || null === $env) {
+        } elseif (false === $env = getenv($name)) {
             // getenv not thread safe
             return null;
         }


### PR DESCRIPTION
This PR fixes https://github.com/async-aws/aws/pull/633#issuecomment-670718131 about undefined env variable by fallbacking on `$_ENV`, `$_SERVER` then `getenv`.

This is inspired from https://github.com/symfony/symfony/blob/be6146c56625b8b1ad5b8fec5bdb5dc6d4023234/src/Symfony/Component/DependencyInjection/EnvVarProcessor.php#L130-L134