### PR TITLE
[Main] Minor cleanup

### DIFF
--- a/tests/Unit/MetaFileTest.php
+++ b/tests/Unit/MetaFileTest.php
@@ -47,8 +47,6 @@ class MetaFileTest extends TestCase
         $root = \dirname(__DIR__, 2);
         $finder
             ->files()
-            ->ignoreDotFiles(false)
-            ->ignoreVCS(true)
             ->in($root . '/src/*/.github/workflows')
             ->in($root . '/src/*/*/.github/workflows')
             ->in($root . '/src/*/*/*/.github/workflows')


### PR DESCRIPTION
An earlier version of this test needed this. But that is not true any more. 

Ie, The `*` will no longer match a `dot-file` (`.github`). 