### PR TITLE
Allow a custom Session Id separator

### DIFF
--- a/src/Integration/Aws/DynamoDbSession/src/SessionHandler.php
+++ b/src/Integration/Aws/DynamoDbSession/src/SessionHandler.php
@@ -46,7 +46,8 @@ class SessionHandler implements \SessionHandlerInterface
      *   hash_key?: string,
      *   session_lifetime?: int,
      *   session_lifetime_attribute?: string,
-     *   table_name: string
+     *   table_name: string,
+     *   id_separator?: string
      * } $options
      */
     public function __construct(DynamoDbClient $client, array $options)
@@ -56,6 +57,7 @@ class SessionHandler implements \SessionHandlerInterface
         $this->options['data_attribute'] = $this->options['data_attribute'] ?? 'data';
         $this->options['hash_key'] = $this->options['hash_key'] ?? 'id';
         $this->options['session_lifetime_attribute'] = $this->options['session_lifetime_attribute'] ?? 'expires';
+        $this->options['id_separator'] = $this->options['id_separator'] ?? '_';
     }
 
     public function setUp(): void
@@ -193,7 +195,7 @@ class SessionHandler implements \SessionHandlerInterface
 
     private function formatId(string $id): string
     {
-        return trim($this->sessionName . '_' . $id, '_');
+        return trim($this->sessionName . $this->options['id_separator'] . $id, $this->options['id_separator']);
     }
 
     private function formatKey(string $key): array

--- a/src/Integration/Aws/DynamoDbSession/tests/SessionHandlerTest.php
+++ b/src/Integration/Aws/DynamoDbSession/tests/SessionHandlerTest.php
@@ -267,4 +267,27 @@ class SessionHandlerTest extends TestCase
 
         $this->handler->setUp();
     }
+
+    public function testCustomKeySeparator()
+    {
+        $handler = new SessionHandler($this->client, ['table_name' => 'testTable', 'session_lifetime' => 86400, 'id_separator' => '#']);
+        $handler->open(null, 'PHPSESSID');
+
+
+        $this->client
+            ->expects(self::once())
+            ->method('updateItem')
+            ->with(self::equalTo([
+                'TableName' => 'testTable',
+                'Key' => [
+                    'id' => ['S' => 'PHPSESSID#123456789'],
+                ],
+                'AttributeUpdates' => [
+                    'expires' => ['Value' => ['N' => time() + 86400]],
+                    'data' => ['Value' => ['S' => 'test data']],
+                ],
+            ], 10));
+
+        self::assertTrue($handler->write('123456789', 'test data'));
+    }
 }

--- a/src/Integration/Aws/DynamoDbSession/tests/SessionHandlerTest.php
+++ b/src/Integration/Aws/DynamoDbSession/tests/SessionHandlerTest.php
@@ -273,7 +273,6 @@ class SessionHandlerTest extends TestCase
         $handler = new SessionHandler($this->client, ['table_name' => 'testTable', 'session_lifetime' => 86400, 'id_separator' => '#']);
         $handler->open(null, 'PHPSESSID');
 
-
         $this->client
             ->expects(self::once())
             ->method('updateItem')


### PR DESCRIPTION
In order to use the single table pattern of DynamoDB it would be nice to customize the separator to fit different use cases. This PR adds that possibility by allowing to define that option.