### PR TITLE
Better handle timeout

### DIFF
--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -105,12 +105,16 @@ class Response
         }
 
         try {
-            foreach ($this->httpClient->stream($this->httpResponse, $timeout) as $chunk) {
-                if ($chunk->isTimeout()) {
-                    return false;
-                }
-                if ($chunk->isFirst()) {
-                    break;
+            if (null === $timeout) {
+                $this->httpResponse->getStatusCode();
+            } else {
+                foreach ($this->httpClient->stream($this->httpResponse, $timeout) as $chunk) {
+                    if ($chunk->isTimeout()) {
+                        return false;
+                    }
+                    if ($chunk->isFirst()) {
+                        break;
+                    }
                 }
             }
 


### PR DESCRIPTION
When timeout is not provided to the `resolve` function, calling blocking endpoint provides retries on idle requests.
While calling the stream function would requires to deal with it.

This PR + https://github.com/symfony/symfony/pull/38518 should fixes #806