### PR TITLE
Fix for numeric bucket names like 0344-yyy

### DIFF
--- a/src/Service/S3/CHANGELOG.md
+++ b/src/Service/S3/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 
+- Fixed endpoint issue when a bucket name started with a number.
 - Improve StorageClass documentation.
 
 ## 1.5.0

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -754,7 +754,7 @@ class S3Client extends AbstractApi
             return parent::getEndpoint($uri, $query, $region);
         }
 
-        return \preg_replace('|https?://|', '$0' . $uriParts[1] . '.', parent::getEndpoint('/' . ($uriParts[2] ?? ''), $query, $region));
+        return \preg_replace('|https?://|', '${0}' . $uriParts[1] . '.', parent::getEndpoint('/' . ($uriParts[2] ?? ''), $query, $region));
     }
 
     protected function getEndpointMetadata(?string $region): array

--- a/src/Service/S3/tests/Unit/S3ClientTest.php
+++ b/src/Service/S3/tests/Unit/S3ClientTest.php
@@ -66,6 +66,7 @@ class S3ClientTest extends TestCase
     {
         $client = new S3Client([], new NullProvider(), new MockHttpClient());
         self::assertSame('https://foo.s3.amazonaws.com/', $client->presign(new CreateBucketRequest(['Bucket' => 'foo'])));
+        self::assertSame('https://61515-bar.s3.amazonaws.com/', $client->presign(new CreateBucketRequest(['Bucket' => '61515-bar'])));
         // invalid bucket names
         self::assertSame('https://s3.amazonaws.com/foo.bar', $client->presign(new CreateBucketRequest(['Bucket' => 'foo.bar'])));
         self::assertSame('https://s3.amazonaws.com/foo%20bar', $client->presign(new CreateBucketRequest(['Bucket' => 'foo bar'])));


### PR DESCRIPTION
When interpolating bucket names that start with a number the $0 is
interpolated to $0\d, causing the https:// part to be stripped from the
endpoint resulting in a "Notice: Undefined index: scheme" error.