### PR TITLE
fix php-cs-fixer running on generated tests

### DIFF
--- a/src/CodeGenerator/src/Command/GenerateCommand.php
+++ b/src/CodeGenerator/src/Command/GenerateCommand.php
@@ -368,7 +368,7 @@ class GenerateCommand extends Command
     private function fixCs(ClassName $clientClass, SymfonyStyle $io): void
     {
         $srcPath = \dirname((new \ReflectionClass($clientClass->getFqdn()))->getFileName());
-        $testPath = \substr($srcPath, 0, \strrpos($srcPath, '/src/')) . '/tests';
+        $testPath = \substr($srcPath, 0, \strrpos($srcPath, '/src')) . '/tests';
 
         if (!\is_dir($srcPath)) {
             throw new \InvalidArgumentException(sprintf('The src dir "%s" does not exists', $srcPath));


### PR DESCRIPTION
running `php-cs-fixer` on generated test was not working as the wrong directory was being formatted - this fixes it.