### PR TITLE
Retry non-idempotent methods

### DIFF
--- a/src/Core/src/HttpClient/AwsRetryStrategy.php
+++ b/src/Core/src/HttpClient/AwsRetryStrategy.php
@@ -13,6 +13,14 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
  */
 class AwsRetryStrategy extends GenericRetryStrategy
 {
+    public const DEFAULT_RETRY_STATUS_CODES = [0, 423, 425, 429, 500, 502, 503, 504, 507, 510];
+
+    // Override Symfony default options for a better integration of AWS servers.
+    public function __construct(array $statusCodes = self::DEFAULT_RETRY_STATUS_CODES, int $delayMs = 1000, float $multiplier = 2.0, int $maxDelayMs = 0, float $jitter = 0.1)
+    {
+        parent::__construct($statusCodes, $delayMs, $multiplier, $maxDelayMs, $jitter);
+    }
+
     public function shouldRetry(AsyncContext $context, ?string $responseContent, ?TransportExceptionInterface $exception): ?bool
     {
         if (parent::shouldRetry($context, $responseContent, $exception)) {


### PR DESCRIPTION
Fixes #708 (again)

This PR override the default Configuration of Symfony's retried status code. To always retries failed requests (even on non-idempotent methods)

With AWS almost all call use POST (not idempotent) meaning errors likes 500 or network issue will not be retried.

But almost all operations are either safe (like Sqs::ListQueues) or idempotent (like Iam::CreateUser, that check user uniqueness)
I think, only Sqs::SendMessage, Ses::SendEmail, Sns::Publish would be "vulnerable". 

My personal opinion, I much prefer sending Sqs Message twice than failing sending one.

This default behavior is overriddable by the user by providing an `AwsRetryStrategy` with `GenericRetryStrategy::DEFAULT_RETRY_STATUS_CODES`.

/cc @starred-gijs