### PR TITLE
Make sure we update branch alias after major version

### DIFF
--- a/src/Core/.github/workflows/branch_alias.yml
+++ b/src/Core/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Integration/Aws/DynamoDbSession/.github/workflows/branch_alias.yml
+++ b/src/Integration/Aws/DynamoDbSession/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Integration/Aws/SimpleS3/.github/workflows/branch_alias.yml
+++ b/src/Integration/Aws/SimpleS3/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Integration/Flysystem/S3/.github/workflows/branch_alias.yml
+++ b/src/Integration/Flysystem/S3/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Integration/Laravel/Cache/.github/workflows/branch_alias.yml
+++ b/src/Integration/Laravel/Cache/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Integration/Laravel/Filesystem/.github/workflows/branch_alias.yml
+++ b/src/Integration/Laravel/Filesystem/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Integration/Laravel/Mail/.github/workflows/branch_alias.yml
+++ b/src/Integration/Laravel/Mail/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Integration/Laravel/Queue/.github/workflows/branch_alias.yml
+++ b/src/Integration/Laravel/Queue/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Integration/Monolog/CloudWatch/.github/workflows/branch_alias.yml
+++ b/src/Integration/Monolog/CloudWatch/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Integration/Symfony/Bundle/.github/workflows/branch_alias.yml
+++ b/src/Integration/Symfony/Bundle/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/.template/.github/workflows/branch_alias.yml
+++ b/src/Service/.template/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/CloudFormation/.github/workflows/branch_alias.yml
+++ b/src/Service/CloudFormation/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/CloudFront/.github/workflows/branch_alias.yml
+++ b/src/Service/CloudFront/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/CloudWatchLogs/.github/workflows/branch_alias.yml
+++ b/src/Service/CloudWatchLogs/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/CodeDeploy/.github/workflows/branch_alias.yml
+++ b/src/Service/CodeDeploy/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/CognitoIdentityProvider/.github/workflows/branch_alias.yml
+++ b/src/Service/CognitoIdentityProvider/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/DynamoDb/.github/workflows/branch_alias.yml
+++ b/src/Service/DynamoDb/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/Ecr/.github/workflows/branch_alias.yml
+++ b/src/Service/Ecr/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/EventBridge/.github/workflows/branch_alias.yml
+++ b/src/Service/EventBridge/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/Iam/.github/workflows/branch_alias.yml
+++ b/src/Service/Iam/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/Lambda/.github/workflows/branch_alias.yml
+++ b/src/Service/Lambda/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/RdsDataService/.github/workflows/branch_alias.yml
+++ b/src/Service/RdsDataService/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/Rekognition/.github/workflows/branch_alias.yml
+++ b/src/Service/Rekognition/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/S3/.github/workflows/branch_alias.yml
+++ b/src/Service/S3/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/Ses/.github/workflows/branch_alias.yml
+++ b/src/Service/Ses/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/Sns/.github/workflows/branch_alias.yml
+++ b/src/Service/Sns/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/Sqs/.github/workflows/branch_alias.yml
+++ b/src/Service/Sqs/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi

--- a/src/Service/Ssm/.github/workflows/branch_alias.yml
+++ b/src/Service/Ssm/.github/workflows/branch_alias.yml
@@ -45,7 +45,7 @@ jobs:
                 exit 1;
             fi
 
-            if [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
+            if [ ${CURRENT_ARR[0]} -eq ${NEW_ARR[0]} ] && [ ${CURRENT_ARR[1]} -gt ${NEW_ARR[1]} ]; then
                 echo "The current value for minor version is larger"
                 exit 1;
             fi


### PR DESCRIPTION
The current branch alias on SNS is 0.6. We failed to update that because our branch alias workflow did not look at the major version. 

It just saw that the minor version was bigger so it exited: https://github.com/async-aws/sns/runs/1331919079?check_suite_focus=true

