### PR TITLE
Add some more introduction on the different clients

### DIFF
--- a/docs/clients/sts.md
+++ b/docs/clients/sts.md
@@ -3,6 +3,7 @@ layout: client
 category: clients
 name: STS
 package: async-aws/core
+fqcn: AsyncAws\Core\Sts\StsClient
 ---
 
 ## Usage

--- a/website/Twig/AsyncAwsTwigExtension.php
+++ b/website/Twig/AsyncAwsTwigExtension.php
@@ -37,6 +37,7 @@ class AsyncAwsTwigExtension extends AbstractExtension
     {
         return [
             new TwigFilter('asset', [$this, 'parseAssetUrls']),
+            new TwigFilter('lcfirst', function($str) { return lcfirst($str);}),
         ];
     }
 

--- a/website/Twig/AsyncAwsTwigExtension.php
+++ b/website/Twig/AsyncAwsTwigExtension.php
@@ -38,6 +38,9 @@ class AsyncAwsTwigExtension extends AbstractExtension
         return [
             new TwigFilter('asset', [$this, 'parseAssetUrls']),
             new TwigFilter('lcfirst', function($str) { return lcfirst($str);}),
+            new TwigFilter('printHLJSUseStatement', [$this, 'printHighlightUseStatement'], [
+                'is_safe' => ['html'],
+            ]),
         ];
     }
 
@@ -71,6 +74,16 @@ class AsyncAwsTwigExtension extends AbstractExtension
     public function renderScript(string $name)
     {
         return $this->renderTag($name, 'js', '<script src="%s"></script>');
+    }
+    public function printHighlightUseStatement(string $name)
+    {
+        $parts = explode('\\', $name);
+        $output = '<span class="hljs-keyword">use</span> ';
+        foreach ($parts as $part) {
+            $output.='<span class="hljs-title">'.$part.'</span>\\';
+        }
+
+        return substr($output, 0, -1).';';
     }
 
     private function getManifest(): array

--- a/website/template/client.twig
+++ b/website/template/client.twig
@@ -23,17 +23,22 @@
         A new client object may be instantiated by:
     </p>
 
-    <pre><code class="language-shell php">${{ name|lcfirst }} = new \{{ clientFqcn }}();</code></pre>
+    <pre><code class="language-php hljs">{{ clientFqcn|printHLJSUseStatement }}
+
+${{ name|lcfirst }} = <span class="hljs-keyword">new</span> {{ name }}Client();
+</code></pre>
 
     <p>
         The authentication parameters is read from the environment by default.
         You can also specify a AWS access id and secret:
     </p>
 
-    <pre><code class="language-shell php">${{ name|lcfirst }} = new \{{ clientFqcn }}([
-    'accessKeyId'=>'my_access_key',
-    'accessKeySecret'=>'my_access_secret',
-    'region'=>'eu-central-1',
+    <pre><code class="language-php hljs">{{ clientFqcn|printHLJSUseStatement }}
+
+${{ name|lcfirst }} = <span class="hljs-keyword">new</span> {{ name }}Client([
+    <span class="hljs-string">'accessKeyId'</span> => <span class="hljs-string">'my_access_key'</span>,
+    <span class="hljs-string">'accessKeySecret'</span> => <span class="hljs-string">'my_access_secret'</span>,
+    <span class="hljs-string">'region'</span> => <span class="hljs-string">'central'</span>,
 ]);</code></pre>
 
     <p>
@@ -42,7 +47,7 @@
 
     {{ content|asset|raw }}
 
-    <hr>
+    <hr style="margin-top:6rem; margin-bottom:3rem;">
 
     <p>
         The source code to this page is found on

--- a/website/template/client.twig
+++ b/website/template/client.twig
@@ -38,7 +38,7 @@ ${{ name|lcfirst }} = <span class="hljs-keyword">new</span> {{ name }}Client();
 ${{ name|lcfirst }} = <span class="hljs-keyword">new</span> {{ name }}Client([
     <span class="hljs-string">'accessKeyId'</span> => <span class="hljs-string">'my_access_key'</span>,
     <span class="hljs-string">'accessKeySecret'</span> => <span class="hljs-string">'my_access_secret'</span>,
-    <span class="hljs-string">'region'</span> => <span class="hljs-string">'central'</span>,
+    <span class="hljs-string">'region'</span> => <span class="hljs-string">'eu-central-1'</span>,
 ]);</code></pre>
 
     <p>

--- a/website/template/client.twig
+++ b/website/template/client.twig
@@ -4,14 +4,48 @@
 
     <h1>{{ name }} client</h1>
 
-    <p>This page contains some example usage for {{ name }}. There are other
-        resources that explain <a href="/authentication/">authentication</a> and
-        <a href="/clients/">configuration</a>.</p>
-
-    <p>The {{ name }} package could be installed with Composer.</p>
+    <p>
+        This page contains examples with the {{ name }} client. See the
+        <a href="/clients/">client introduction</a> for a more detailed description
+        how to use a client. You may also want to consider the
+        <a href="/authentication/">authentication</a> documentation to understand
+        the many ways you can authenticate with AWS.
+    </p>
+    <p>
+        The {{ name }} package could be installed with Composer.
+    </p>
 
     <pre><code class="language-shell hljs">composer require {{ package }}</code></pre>
 
+    {% set clientFqcn = fqcn|default('AsyncAws\\'~name~'\\'~name~'Client') %}
+
+    <p>
+        A new client object may be instantiated by:
+    </p>
+
+    <pre><code class="language-shell php">${{ name|lcfirst }} = new \{{ clientFqcn }}();</code></pre>
+
+    <p>
+        The authentication parameters is read from the environment by default.
+        You can also specify a AWS access id and secret:
+    </p>
+
+    <pre><code class="language-shell php">${{ name|lcfirst }} = new \{{ clientFqcn }}([
+    'accessKeyId'=>'my_access_key',
+    'accessKeySecret'=>'my_access_secret',
+    'region'=>'eu-central-1',
+]);</code></pre>
+
+    <p>
+        For all available options, see the <a href="/configuration.html">configuration reference</a>.
+    </p>
+
     {{ content|asset|raw }}
 
+    <hr>
+
+    <p>
+        The source code to this page is found on
+        <a href="https://github.com/async-aws/aws/tree/master/docs/clients">GitHub</a>.
+    </p>
 {% endblock %}


### PR DESCRIPTION
I notice myself linking to the S3 page directly time to time. But that is not a "95% what you need to use it". 

I added some generic introduction for each client. They link to more detailed docs. 

<img width="1411" alt="Screenshot 2020-11-04 at 19 29 46" src="https://user-images.githubusercontent.com/1275206/98153842-1d652500-1ed4-11eb-8c41-567a7067e254.png">

