### PR TITLE
Simple way to get presigned URLs with Simple S3 client

### DIFF
--- a/src/Integration/Aws/SimpleS3/src/SimpleS3Client.php
+++ b/src/Integration/Aws/SimpleS3/src/SimpleS3Client.php
@@ -7,9 +7,11 @@ namespace AsyncAws\SimpleS3;
 use AsyncAws\Core\Stream\FixedSizeStream;
 use AsyncAws\Core\Stream\ResultStream;
 use AsyncAws\Core\Stream\StreamFactory;
+use AsyncAws\S3\Input\GetObjectRequest;
 use AsyncAws\S3\S3Client;
 use AsyncAws\S3\ValueObject\CompletedMultipartUpload;
 use AsyncAws\S3\ValueObject\CompletedPart;
+use DateTimeImmutable;
 
 /**
  * A simplified S3 client that hides some of the complexity of working with S3.
@@ -24,6 +26,16 @@ class SimpleS3Client extends S3Client
         $uri = sprintf('/%s/%s', urlencode($bucket), str_replace('%2F', '/', rawurlencode($key)));
 
         return $this->getEndpoint($uri, [], null);
+    }
+
+    public function getPresignedUrl(string $bucket, string $key, ?DateTimeImmutable $expires = null): string
+    {
+        $request = new GetObjectRequest([
+            'Bucket' => $bucket,
+            'Key' => $key,
+        ]);
+
+        return $this->presign($request, $expires);
     }
 
     public function download(string $bucket, string $key): ResultStream

--- a/src/Integration/Aws/SimpleS3/tests/Unit/SimpleS3ClientTest.php
+++ b/src/Integration/Aws/SimpleS3/tests/Unit/SimpleS3ClientTest.php
@@ -27,6 +27,13 @@ class SimpleS3ClientTest extends TestCase
         self::assertSame('https://s3.eu-central-1.amazonaws.com/bucket/images/file.jpg', $url);
     }
 
+    public function testGetPresignedUrl()
+    {
+        $client = new SimpleS3Client(['region' => 'eu-central-1'], new NullProvider(), new MockHttpClient());
+        $url = $client->getPresignedUrl('bucket', 'images/file.jpg');
+        self::assertSame('https://bucket.s3.eu-central-1.amazonaws.com/images/file.jpg', $url);
+    }
+
     public function testUploadSmallFileString()
     {
         $object = 'User-agent: *\nDisallow:';


### PR DESCRIPTION
Hi!
I think a simpler way to get presigned S3 urls would be a good addition to the Simple S3 client, so here it is.