### PR TITLE
Default empty DynamoDB M value to an empty object

### DIFF
--- a/src/Service/DynamoDb/src/ValueObject/AttributeValue.php
+++ b/src/Service/DynamoDb/src/ValueObject/AttributeValue.php
@@ -192,8 +192,12 @@ final class AttributeValue
             }
         }
         if (null !== $v = $this->M) {
-            foreach ($v as $name => $v) {
-                $payload['M'][$name] = $v->requestBody();
+            if (empty($v)) {
+                $payload['M'] = new \stdClass();
+            } else {
+                foreach ($v as $name => $v) {
+                    $payload['M'][$name] = $v->requestBody();
+                }
             }
         }
         if (null !== $v = $this->L) {


### PR DESCRIPTION
Currently an empty `M` value fails with: `Unrecognized collection type class` which is correct since when you set `M` to `[]` it will leave the `$payload` empty.

It cannot however be an empty array since that encodes to an incorrect value it needs to be an object so it encodes to `{}` (json) correctly.