### PR TITLE
Fix endpoint without region

### DIFF
--- a/src/Core/src/Sts/StsClient.php
+++ b/src/Core/src/Sts/StsClient.php
@@ -3,7 +3,6 @@
 namespace AsyncAws\Core\Sts;
 
 use AsyncAws\Core\AbstractApi;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Sts\Input\AssumeRoleRequest;
 use AsyncAws\Core\Sts\Input\AssumeRoleWithWebIdentityRequest;
@@ -107,32 +106,6 @@ class StsClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'af-south-1':
-            case 'ap-east-1':
-            case 'ap-northeast-1':
-            case 'ap-northeast-2':
-            case 'ap-south-1':
-            case 'ap-southeast-1':
-            case 'ap-southeast-2':
-            case 'ca-central-1':
-            case 'eu-central-1':
-            case 'eu-north-1':
-            case 'eu-south-1':
-            case 'eu-west-1':
-            case 'eu-west-2':
-            case 'eu-west-3':
-            case 'me-south-1':
-            case 'sa-east-1':
-            case 'us-east-1':
-            case 'us-east-2':
-            case 'us-west-1':
-            case 'us-west-2':
-                return [
-                    'endpoint' => "https://sts.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'sts',
-                    'signVersions' => ['v4'],
-                ];
             case 'cn-north-1':
             case 'cn-northwest-1':
                 return [
@@ -207,7 +180,12 @@ class StsClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "Sts".', $region));
+        return [
+            'endpoint' => "https://sts.$region.amazonaws.com",
+            'signRegion' => $region,
+            'signService' => 'sts',
+            'signVersions' => ['v4'],
+        ];
     }
 
     protected function getServiceCode(): string

--- a/src/Core/tests/Integration/StsClientTest.php
+++ b/src/Core/tests/Integration/StsClientTest.php
@@ -3,7 +3,6 @@
 namespace AsyncAws\Core\Tests\Integration;
 
 use AsyncAws\Core\Credentials\NullProvider;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\Sts\Input\AssumeRoleRequest;
 use AsyncAws\Core\Sts\Input\AssumeRoleWithWebIdentityRequest;
 use AsyncAws\Core\Sts\Input\GetCallerIdentityRequest;

--- a/src/Core/tests/Integration/StsClientTest.php
+++ b/src/Core/tests/Integration/StsClientTest.php
@@ -96,14 +96,16 @@ class StsClientTest extends TestCase
         self::assertNotEmpty($client->presign(new AssumeRoleRequest(['RoleArn' => 'demo', 'RoleSessionName' => 'demo'])));
     }
 
+    /**
+     * A region that is not recognized should be treated as "default" region.
+     */
     public function testNonAwsRegion(): void
     {
         $client = new StsClient([
             'region' => 'test',
         ], new NullProvider());
 
-        $this->expectException(UnsupportedRegion::class);
-        $client->presign(new AssumeRoleRequest(['RoleArn' => 'demo', 'RoleSessionName' => 'demo']));
+        self::assertNotEmpty($client->presign(new AssumeRoleRequest(['RoleArn' => 'demo', 'RoleSessionName' => 'demo'])));
     }
 
     public function testCustomEndpointSignature(): void

--- a/src/Service/CloudFormation/src/CloudFormationClient.php
+++ b/src/Service/CloudFormation/src/CloudFormationClient.php
@@ -9,7 +9,6 @@ use AsyncAws\CloudFormation\Result\DescribeStacksOutput;
 use AsyncAws\CloudFormation\ValueObject\Stack;
 use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\Configuration;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 
 class CloudFormationClient extends AbstractApi
@@ -64,32 +63,6 @@ class CloudFormationClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'af-south-1':
-            case 'ap-east-1':
-            case 'ap-northeast-1':
-            case 'ap-northeast-2':
-            case 'ap-south-1':
-            case 'ap-southeast-1':
-            case 'ap-southeast-2':
-            case 'ca-central-1':
-            case 'eu-central-1':
-            case 'eu-north-1':
-            case 'eu-south-1':
-            case 'eu-west-1':
-            case 'eu-west-2':
-            case 'eu-west-3':
-            case 'me-south-1':
-            case 'sa-east-1':
-            case 'us-east-1':
-            case 'us-east-2':
-            case 'us-west-1':
-            case 'us-west-2':
-                return [
-                    'endpoint' => "https://cloudformation.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'cloudformation',
-                    'signVersions' => ['v4'],
-                ];
             case 'cn-north-1':
             case 'cn-northwest-1':
                 return [
@@ -156,6 +129,11 @@ class CloudFormationClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "CloudFormation".', $region));
+        return [
+            'endpoint' => "https://cloudformation.$region.amazonaws.com",
+            'signRegion' => $region,
+            'signService' => 'cloudformation',
+            'signVersions' => ['v4'],
+        ];
     }
 }

--- a/src/Service/CloudFront/src/CloudFrontClient.php
+++ b/src/Service/CloudFront/src/CloudFrontClient.php
@@ -6,7 +6,6 @@ use AsyncAws\CloudFront\Input\CreateInvalidationRequest;
 use AsyncAws\CloudFront\Result\CreateInvalidationResult;
 use AsyncAws\CloudFront\ValueObject\InvalidationBatch;
 use AsyncAws\Core\AbstractApi;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 
 class CloudFrontClient extends AbstractApi
@@ -43,32 +42,6 @@ class CloudFrontClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'af-south-1':
-            case 'ap-east-1':
-            case 'ap-northeast-1':
-            case 'ap-northeast-2':
-            case 'ap-south-1':
-            case 'ap-southeast-1':
-            case 'ap-southeast-2':
-            case 'ca-central-1':
-            case 'eu-central-1':
-            case 'eu-north-1':
-            case 'eu-south-1':
-            case 'eu-west-1':
-            case 'eu-west-2':
-            case 'eu-west-3':
-            case 'me-south-1':
-            case 'sa-east-1':
-            case 'us-east-1':
-            case 'us-east-2':
-            case 'us-west-1':
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://cloudfront.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'cloudfront',
-                    'signVersions' => ['v4'],
-                ];
             case 'cn-north-1':
             case 'cn-northwest-1':
                 return [
@@ -79,6 +52,11 @@ class CloudFrontClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "CloudFront".', $region));
+        return [
+            'endpoint' => 'https://cloudfront.amazonaws.com',
+            'signRegion' => 'us-east-1',
+            'signService' => 'cloudfront',
+            'signVersions' => ['v4'],
+        ];
     }
 }

--- a/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
+++ b/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
@@ -10,7 +10,6 @@ use AsyncAws\CloudWatchLogs\Result\PutLogEventsResponse;
 use AsyncAws\CloudWatchLogs\ValueObject\InputLogEvent;
 use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\Configuration;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 
 class CloudWatchLogsClient extends AbstractApi
@@ -69,32 +68,6 @@ class CloudWatchLogsClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'af-south-1':
-            case 'ap-east-1':
-            case 'ap-northeast-1':
-            case 'ap-northeast-2':
-            case 'ap-south-1':
-            case 'ap-southeast-1':
-            case 'ap-southeast-2':
-            case 'ca-central-1':
-            case 'eu-central-1':
-            case 'eu-north-1':
-            case 'eu-south-1':
-            case 'eu-west-1':
-            case 'eu-west-2':
-            case 'eu-west-3':
-            case 'me-south-1':
-            case 'sa-east-1':
-            case 'us-east-1':
-            case 'us-east-2':
-            case 'us-west-1':
-            case 'us-west-2':
-                return [
-                    'endpoint' => "https://logs.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'logs',
-                    'signVersions' => ['v4'],
-                ];
             case 'cn-north-1':
             case 'cn-northwest-1':
                 return [
@@ -161,6 +134,11 @@ class CloudWatchLogsClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "CloudWatchLogs".', $region));
+        return [
+            'endpoint' => "https://logs.$region.amazonaws.com",
+            'signRegion' => $region,
+            'signService' => 'logs',
+            'signVersions' => ['v4'],
+        ];
     }
 }

--- a/src/Service/CodeDeploy/src/CodeDeployClient.php
+++ b/src/Service/CodeDeploy/src/CodeDeployClient.php
@@ -7,7 +7,6 @@ use AsyncAws\CodeDeploy\Input\PutLifecycleEventHookExecutionStatusInput;
 use AsyncAws\CodeDeploy\Result\PutLifecycleEventHookExecutionStatusOutput;
 use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\Configuration;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 
 class CodeDeployClient extends AbstractApi
@@ -47,32 +46,6 @@ class CodeDeployClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'af-south-1':
-            case 'ap-east-1':
-            case 'ap-northeast-1':
-            case 'ap-northeast-2':
-            case 'ap-south-1':
-            case 'ap-southeast-1':
-            case 'ap-southeast-2':
-            case 'ca-central-1':
-            case 'eu-central-1':
-            case 'eu-north-1':
-            case 'eu-south-1':
-            case 'eu-west-1':
-            case 'eu-west-2':
-            case 'eu-west-3':
-            case 'me-south-1':
-            case 'sa-east-1':
-            case 'us-east-1':
-            case 'us-east-2':
-            case 'us-west-1':
-            case 'us-west-2':
-                return [
-                    'endpoint' => "https://codedeploy.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'codedeploy',
-                    'signVersions' => ['v4'],
-                ];
             case 'cn-north-1':
             case 'cn-northwest-1':
                 return [
@@ -147,6 +120,11 @@ class CodeDeployClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "CodeDeploy".', $region));
+        return [
+            'endpoint' => "https://codedeploy.$region.amazonaws.com",
+            'signRegion' => $region,
+            'signService' => 'codedeploy',
+            'signVersions' => ['v4'],
+        ];
     }
 }

--- a/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
+++ b/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
@@ -49,7 +49,6 @@ use AsyncAws\CognitoIdentityProvider\ValueObject\SoftwareTokenMfaSettingsType;
 use AsyncAws\CognitoIdentityProvider\ValueObject\UserContextDataType;
 use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\Configuration;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
 
@@ -488,26 +487,6 @@ class CognitoIdentityProviderClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'ap-northeast-1':
-            case 'ap-northeast-2':
-            case 'ap-south-1':
-            case 'ap-southeast-1':
-            case 'ap-southeast-2':
-            case 'ca-central-1':
-            case 'eu-central-1':
-            case 'eu-north-1':
-            case 'eu-west-1':
-            case 'eu-west-2':
-            case 'eu-west-3':
-            case 'us-east-1':
-            case 'us-east-2':
-            case 'us-west-2':
-                return [
-                    'endpoint' => "https://cognito-idp.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'cognito-idp',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-gov-west-1':
                 return [
                     'endpoint' => "https://cognito-idp.$region.amazonaws.com",
@@ -545,6 +524,11 @@ class CognitoIdentityProviderClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "CognitoIdentityProvider".', $region));
+        return [
+            'endpoint' => "https://cognito-idp.$region.amazonaws.com",
+            'signRegion' => $region,
+            'signService' => 'cognito-idp',
+            'signVersions' => ['v4'],
+        ];
     }
 }

--- a/src/Service/DynamoDb/src/DynamoDbClient.php
+++ b/src/Service/DynamoDb/src/DynamoDbClient.php
@@ -4,7 +4,6 @@ namespace AsyncAws\DynamoDb;
 
 use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\Configuration;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\DynamoDb\Enum\BillingMode;
 use AsyncAws\DynamoDb\Enum\ConditionalOperator;
@@ -482,32 +481,6 @@ class DynamoDbClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'af-south-1':
-            case 'ap-east-1':
-            case 'ap-northeast-1':
-            case 'ap-northeast-2':
-            case 'ap-south-1':
-            case 'ap-southeast-1':
-            case 'ap-southeast-2':
-            case 'ca-central-1':
-            case 'eu-central-1':
-            case 'eu-north-1':
-            case 'eu-south-1':
-            case 'eu-west-1':
-            case 'eu-west-2':
-            case 'eu-west-3':
-            case 'me-south-1':
-            case 'sa-east-1':
-            case 'us-east-1':
-            case 'us-east-2':
-            case 'us-west-1':
-            case 'us-west-2':
-                return [
-                    'endpoint' => "https://dynamodb.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'dynamodb',
-                    'signVersions' => ['v4'],
-                ];
             case 'cn-north-1':
             case 'cn-northwest-1':
                 return [
@@ -596,6 +569,11 @@ class DynamoDbClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "DynamoDb".', $region));
+        return [
+            'endpoint' => "https://dynamodb.$region.amazonaws.com",
+            'signRegion' => $region,
+            'signService' => 'dynamodb',
+            'signVersions' => ['v4'],
+        ];
     }
 }

--- a/src/Service/EventBridge/src/EventBridgeClient.php
+++ b/src/Service/EventBridge/src/EventBridgeClient.php
@@ -4,7 +4,6 @@ namespace AsyncAws\EventBridge;
 
 use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\Configuration;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\EventBridge\Input\PutEventsRequest;
 use AsyncAws\EventBridge\Result\PutEventsResponse;
@@ -38,32 +37,6 @@ class EventBridgeClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'af-south-1':
-            case 'ap-east-1':
-            case 'ap-northeast-1':
-            case 'ap-northeast-2':
-            case 'ap-south-1':
-            case 'ap-southeast-1':
-            case 'ap-southeast-2':
-            case 'ca-central-1':
-            case 'eu-central-1':
-            case 'eu-north-1':
-            case 'eu-south-1':
-            case 'eu-west-1':
-            case 'eu-west-2':
-            case 'eu-west-3':
-            case 'me-south-1':
-            case 'sa-east-1':
-            case 'us-east-1':
-            case 'us-east-2':
-            case 'us-west-1':
-            case 'us-west-2':
-                return [
-                    'endpoint' => "https://events.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'events',
-                    'signVersions' => ['v4'],
-                ];
             case 'cn-north-1':
             case 'cn-northwest-1':
                 return [
@@ -130,6 +103,11 @@ class EventBridgeClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "EventBridge".', $region));
+        return [
+            'endpoint' => "https://events.$region.amazonaws.com",
+            'signRegion' => $region,
+            'signService' => 'events',
+            'signVersions' => ['v4'],
+        ];
     }
 }

--- a/src/Service/Iam/src/IamClient.php
+++ b/src/Service/Iam/src/IamClient.php
@@ -3,7 +3,6 @@
 namespace AsyncAws\Iam;
 
 use AsyncAws\Core\AbstractApi;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
 use AsyncAws\Iam\Input\AddUserToGroupRequest;
@@ -201,32 +200,6 @@ class IamClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'af-south-1':
-            case 'ap-east-1':
-            case 'ap-northeast-1':
-            case 'ap-northeast-2':
-            case 'ap-south-1':
-            case 'ap-southeast-1':
-            case 'ap-southeast-2':
-            case 'ca-central-1':
-            case 'eu-central-1':
-            case 'eu-north-1':
-            case 'eu-south-1':
-            case 'eu-west-1':
-            case 'eu-west-2':
-            case 'eu-west-3':
-            case 'me-south-1':
-            case 'sa-east-1':
-            case 'us-east-1':
-            case 'us-east-2':
-            case 'us-west-1':
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://iam.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'iam',
-                    'signVersions' => ['v4'],
-                ];
             case 'cn-north-1':
             case 'cn-northwest-1':
                 return [
@@ -273,6 +246,11 @@ class IamClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "Iam".', $region));
+        return [
+            'endpoint' => 'https://iam.amazonaws.com',
+            'signRegion' => 'us-east-1',
+            'signService' => 'iam',
+            'signVersions' => ['v4'],
+        ];
     }
 }

--- a/src/Service/Lambda/src/LambdaClient.php
+++ b/src/Service/Lambda/src/LambdaClient.php
@@ -4,7 +4,6 @@ namespace AsyncAws\Lambda;
 
 use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\Configuration;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Lambda\Enum\InvocationType;
 use AsyncAws\Lambda\Enum\LogType;
@@ -131,32 +130,6 @@ class LambdaClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'af-south-1':
-            case 'ap-east-1':
-            case 'ap-northeast-1':
-            case 'ap-northeast-2':
-            case 'ap-south-1':
-            case 'ap-southeast-1':
-            case 'ap-southeast-2':
-            case 'ca-central-1':
-            case 'eu-central-1':
-            case 'eu-north-1':
-            case 'eu-south-1':
-            case 'eu-west-1':
-            case 'eu-west-2':
-            case 'eu-west-3':
-            case 'me-south-1':
-            case 'sa-east-1':
-            case 'us-east-1':
-            case 'us-east-2':
-            case 'us-west-1':
-            case 'us-west-2':
-                return [
-                    'endpoint' => "https://lambda.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'lambda',
-                    'signVersions' => ['v4'],
-                ];
             case 'cn-north-1':
             case 'cn-northwest-1':
                 return [
@@ -231,6 +204,11 @@ class LambdaClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "Lambda".', $region));
+        return [
+            'endpoint' => "https://lambda.$region.amazonaws.com",
+            'signRegion' => $region,
+            'signService' => 'lambda',
+            'signVersions' => ['v4'],
+        ];
     }
 }

--- a/src/Service/RdsDataService/src/RdsDataServiceClient.php
+++ b/src/Service/RdsDataService/src/RdsDataServiceClient.php
@@ -4,7 +4,6 @@ namespace AsyncAws\RdsDataService;
 
 use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\Configuration;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\RdsDataService\Input\BatchExecuteStatementRequest;
 use AsyncAws\RdsDataService\Input\BeginTransactionRequest;
@@ -145,32 +144,6 @@ class RdsDataServiceClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'af-south-1':
-            case 'ap-east-1':
-            case 'ap-northeast-1':
-            case 'ap-northeast-2':
-            case 'ap-south-1':
-            case 'ap-southeast-1':
-            case 'ap-southeast-2':
-            case 'ca-central-1':
-            case 'eu-central-1':
-            case 'eu-north-1':
-            case 'eu-south-1':
-            case 'eu-west-1':
-            case 'eu-west-2':
-            case 'eu-west-3':
-            case 'me-south-1':
-            case 'sa-east-1':
-            case 'us-east-1':
-            case 'us-east-2':
-            case 'us-west-1':
-            case 'us-west-2':
-                return [
-                    'endpoint' => "https://rds-data.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'rds-data',
-                    'signVersions' => ['v4'],
-                ];
             case 'cn-north-1':
             case 'cn-northwest-1':
                 return [
@@ -203,6 +176,11 @@ class RdsDataServiceClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "RdsDataService".', $region));
+        return [
+            'endpoint' => "https://rds-data.$region.amazonaws.com",
+            'signRegion' => $region,
+            'signService' => 'rds-data',
+            'signVersions' => ['v4'],
+        ];
     }
 }

--- a/src/Service/Rekognition/src/RekognitionClient.php
+++ b/src/Service/Rekognition/src/RekognitionClient.php
@@ -4,7 +4,6 @@ namespace AsyncAws\Rekognition;
 
 use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\Configuration;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Rekognition\Enum\Attribute;
 use AsyncAws\Rekognition\Enum\QualityFilter;
@@ -203,25 +202,6 @@ class RekognitionClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'ap-northeast-1':
-            case 'ap-northeast-2':
-            case 'ap-south-1':
-            case 'ap-southeast-1':
-            case 'ap-southeast-2':
-            case 'ca-central-1':
-            case 'eu-central-1':
-            case 'eu-west-1':
-            case 'eu-west-2':
-            case 'us-east-1':
-            case 'us-east-2':
-            case 'us-west-1':
-            case 'us-west-2':
-                return [
-                    'endpoint' => "https://rekognition.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'rekognition',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-gov-west-1':
                 return [
                     'endpoint' => "https://rekognition.$region.amazonaws.com",
@@ -273,6 +253,11 @@ class RekognitionClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "Rekognition".', $region));
+        return [
+            'endpoint' => "https://rekognition.$region.amazonaws.com",
+            'signRegion' => $region,
+            'signService' => 'rekognition',
+            'signVersions' => ['v4'],
+        ];
     }
 }

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -3,7 +3,6 @@
 namespace AsyncAws\S3;
 
 use AsyncAws\Core\AbstractApi;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
 use AsyncAws\S3\Enum\BucketCannedACL;
@@ -794,24 +793,6 @@ class S3Client extends AbstractApi
         }
 
         switch ($region) {
-            case 'af-south-1':
-            case 'ap-east-1':
-            case 'ap-northeast-2':
-            case 'ap-south-1':
-            case 'ca-central-1':
-            case 'eu-central-1':
-            case 'eu-north-1':
-            case 'eu-south-1':
-            case 'eu-west-2':
-            case 'eu-west-3':
-            case 'me-south-1':
-            case 'us-east-2':
-                return [
-                    'endpoint' => "https://s3.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 's3',
-                    'signVersions' => ['s3v4'],
-                ];
             case 'cn-north-1':
             case 'cn-northwest-1':
                 return [
@@ -920,7 +901,12 @@ class S3Client extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "S3".', $region));
+        return [
+            'endpoint' => "https://s3.$region.amazonaws.com",
+            'signRegion' => $region,
+            'signService' => 's3',
+            'signVersions' => ['s3v4'],
+        ];
     }
 
     protected function getServiceCode(): string

--- a/src/Service/Ses/src/SesClient.php
+++ b/src/Service/Ses/src/SesClient.php
@@ -4,7 +4,6 @@ namespace AsyncAws\Ses;
 
 use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\Configuration;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Ses\Input\SendEmailRequest;
 use AsyncAws\Ses\Result\SendEmailResponse;
@@ -50,18 +49,6 @@ class SesClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'ap-south-1':
-            case 'ap-southeast-2':
-            case 'eu-central-1':
-            case 'eu-west-1':
-            case 'us-east-1':
-            case 'us-west-2':
-                return [
-                    'endpoint' => "https://email.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'ses',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-gov-west-1':
                 return [
                     'endpoint' => "https://email.$region.amazonaws.com",
@@ -78,7 +65,12 @@ class SesClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "Ses".', $region));
+        return [
+            'endpoint' => "https://email.$region.amazonaws.com",
+            'signRegion' => $region,
+            'signService' => 'ses',
+            'signVersions' => ['v4'],
+        ];
     }
 
     protected function getServiceCode(): string

--- a/src/Service/Sns/src/SnsClient.php
+++ b/src/Service/Sns/src/SnsClient.php
@@ -4,7 +4,6 @@ namespace AsyncAws\Sns;
 
 use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\Configuration;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
 use AsyncAws\Sns\Input\CreatePlatformEndpointInput;
@@ -224,32 +223,6 @@ class SnsClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'af-south-1':
-            case 'ap-east-1':
-            case 'ap-northeast-1':
-            case 'ap-northeast-2':
-            case 'ap-south-1':
-            case 'ap-southeast-1':
-            case 'ap-southeast-2':
-            case 'ca-central-1':
-            case 'eu-central-1':
-            case 'eu-north-1':
-            case 'eu-south-1':
-            case 'eu-west-1':
-            case 'eu-west-2':
-            case 'eu-west-3':
-            case 'me-south-1':
-            case 'sa-east-1':
-            case 'us-east-1':
-            case 'us-east-2':
-            case 'us-west-1':
-            case 'us-west-2':
-                return [
-                    'endpoint' => "https://sns.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'sns',
-                    'signVersions' => ['v4'],
-                ];
             case 'cn-north-1':
             case 'cn-northwest-1':
                 return [
@@ -316,6 +289,11 @@ class SnsClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "Sns".', $region));
+        return [
+            'endpoint' => "https://sns.$region.amazonaws.com",
+            'signRegion' => $region,
+            'signService' => 'sns',
+            'signVersions' => ['v4'],
+        ];
     }
 }

--- a/src/Service/Sqs/src/SqsClient.php
+++ b/src/Service/Sqs/src/SqsClient.php
@@ -4,7 +4,6 @@ namespace AsyncAws\Sqs;
 
 use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\Configuration;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
 use AsyncAws\Sqs\Enum\MessageSystemAttributeName;
@@ -280,31 +279,6 @@ class SqsClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'af-south-1':
-            case 'ap-east-1':
-            case 'ap-northeast-1':
-            case 'ap-northeast-2':
-            case 'ap-south-1':
-            case 'ap-southeast-1':
-            case 'ap-southeast-2':
-            case 'ca-central-1':
-            case 'eu-central-1':
-            case 'eu-north-1':
-            case 'eu-south-1':
-            case 'eu-west-1':
-            case 'eu-west-2':
-            case 'eu-west-3':
-            case 'me-south-1':
-            case 'sa-east-1':
-            case 'us-east-2':
-            case 'us-west-1':
-            case 'us-west-2':
-                return [
-                    'endpoint' => "https://sqs.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'sqs',
-                    'signVersions' => ['v4'],
-                ];
             case 'cn-north-1':
             case 'cn-northwest-1':
                 return [
@@ -378,7 +352,12 @@ class SqsClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "Sqs".', $region));
+        return [
+            'endpoint' => "https://sqs.$region.amazonaws.com",
+            'signRegion' => $region,
+            'signService' => 'sqs',
+            'signVersions' => ['v4'],
+        ];
     }
 
     protected function getServiceCode(): string

--- a/src/Service/Ssm/src/SsmClient.php
+++ b/src/Service/Ssm/src/SsmClient.php
@@ -4,7 +4,6 @@ namespace AsyncAws\Ssm;
 
 use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\Configuration;
-use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Ssm\Enum\ParameterTier;
 use AsyncAws\Ssm\Enum\ParameterType;
@@ -144,32 +143,6 @@ class SsmClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'af-south-1':
-            case 'ap-east-1':
-            case 'ap-northeast-1':
-            case 'ap-northeast-2':
-            case 'ap-south-1':
-            case 'ap-southeast-1':
-            case 'ap-southeast-2':
-            case 'ca-central-1':
-            case 'eu-central-1':
-            case 'eu-north-1':
-            case 'eu-south-1':
-            case 'eu-west-1':
-            case 'eu-west-2':
-            case 'eu-west-3':
-            case 'me-south-1':
-            case 'sa-east-1':
-            case 'us-east-1':
-            case 'us-east-2':
-            case 'us-west-1':
-            case 'us-west-2':
-                return [
-                    'endpoint' => "https://ssm.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'ssm',
-                    'signVersions' => ['v4'],
-                ];
             case 'cn-north-1':
             case 'cn-northwest-1':
                 return [
@@ -244,6 +217,11 @@ class SsmClient extends AbstractApi
                 ];
         }
 
-        throw new UnsupportedRegion(sprintf('The region "%s" is not supported by "Ssm".', $region));
+        return [
+            'endpoint' => "https://ssm.$region.amazonaws.com",
+            'signRegion' => $region,
+            'signService' => 'ssm',
+            'signVersions' => ['v4'],
+        ];
     }
 }


### PR DESCRIPTION
After checking #879, I discovered that the official AWS-SDK always fallback to the default configuration (when it exists) even when the region is not listed in the "endpoints.json" file.

This will fix #879