### PR TITLE
fix: edge case where aws config file could be a directory

### DIFF
--- a/src/Core/src/Credentials/IniFileLoader.php
+++ b/src/Core/src/Credentials/IniFileLoader.php
@@ -48,7 +48,7 @@ final class IniFileLoader
                 $homeDir = $homeDir ?? $this->getHomeDir();
                 $filepath = $homeDir . \substr($filepath, 1);
             }
-            if (!\is_readable($filepath)) {
+            if (!\is_readable($filepath) || !\is_file($filepath)) {
                 continue;
             }
 


### PR DESCRIPTION
I have encountered this issue on github actions

This is weird but I an error with file_get_contents failing.
![image](https://user-images.githubusercontent.com/54712/100891853-00fbde80-34ba-11eb-85f6-253c305002a1.png)
