### PR TITLE
Fix website generation

### DIFF
--- a/website/post-process/highlight.js
+++ b/website/post-process/highlight.js
@@ -1,4 +1,4 @@
-const highlight = require('highlight.js/lib/highlight');
+const highlight = require('highlight.js/lib/core');
 
 highlight.registerLanguage('php', require('highlight.js/lib/languages/php'));
 highlight.registerLanguage('ini', require('highlight.js/lib/languages/ini'));


### PR DESCRIPTION
new version of highlight does not export the library

Here is the content of the file
```js
// node_modules/highlight.js/lib/highlight.js

// This file has been deprecated in favor of core.js
var hljs = require('./core');
```