### PR TITLE
Fix type error

### DIFF
--- a/src/Core/src/Credentials/IniFileLoader.php
+++ b/src/Core/src/Credentials/IniFileLoader.php
@@ -53,7 +53,7 @@ final class IniFileLoader
             }
 
             foreach ($this->parseIniFile($filepath) as $name => $profile) {
-                $name = \preg_replace('/^profile /', '', $name);
+                $name = \preg_replace('/^profile /', '', (string) $name);
                 if (!isset($profilesData[$name])) {
                     $profilesData[$name] = \array_map('trim', $profile);
                 } else {


### PR DESCRIPTION
The profile name seems to be cast to an integer if it looks like an integer.

That's the case for example with a `7777` profile, I got the following error:

```
PHP Fatal error:  Uncaught TypeError: preg_replace(): Argument #3 ($subject) must be of type array|string, int given in .../vendor/async-aws/core/src/Credentials/IniFileLoader.php:56
Stack trace:
#0 .../vendor/async-aws/core/src/Credentials/IniFileLoader.php(56): preg_replace('/^profile /', '', 7777)
```