### PR TITLE
Clear realpath cache when reading the token from file

### DIFF
--- a/src/Core/src/Credentials/WebIdentityProvider.php
+++ b/src/Core/src/Credentials/WebIdentityProvider.php
@@ -128,9 +128,9 @@ final class WebIdentityProvider implements CredentialProvider
      */
     private function getTokenFileContent(string $tokenFile): string
     {
-        if (! file_exists($tokenFile)) {
-            clearstatcache(true, dirname($tokenFile) . DIRECTORY_SEPARATOR . readlink($tokenFile));
-            clearstatcache(true, dirname($tokenFile) . DIRECTORY_SEPARATOR . dirname(readlink($tokenFile)));
+        if (!file_exists($tokenFile)) {
+            clearstatcache(true, \dirname($tokenFile) . \DIRECTORY_SEPARATOR . readlink($tokenFile));
+            clearstatcache(true, \dirname($tokenFile) . \DIRECTORY_SEPARATOR . \dirname(readlink($tokenFile)));
             clearstatcache(true, $tokenFile);
         }
 

--- a/src/Core/src/Credentials/WebIdentityProvider.php
+++ b/src/Core/src/Credentials/WebIdentityProvider.php
@@ -89,9 +89,7 @@ final class WebIdentityProvider implements CredentialProvider
         }
 
         try {
-            if (false === $token = file_get_contents($tokenFile)) {
-                throw new RuntimeException('failed to read data');
-            }
+            $token = $this->getTokenFileContent($tokenFile);
         } catch (\Exception $e) {
             $this->logger->warning('"Error reading WebIdentityTokenFile "{tokenFile}.', ['tokenFile' => $tokenFile, 'exception' => $e]);
 
@@ -121,5 +119,25 @@ final class WebIdentityProvider implements CredentialProvider
             $credentials->getSessionToken(),
             Credentials::adjustExpireDate($credentials->getExpiration(), $this->getDateFromResult($result))
         );
+    }
+
+    /**
+     * @see https://github.com/async-aws/aws/issues/900
+     * @see https://github.com/aws/aws-sdk-php/issues/2014
+     * @see https://github.com/aws/aws-sdk-php/pull/2043
+     */
+    private function getTokenFileContent(string $tokenFile): string
+    {
+        if (! file_exists($tokenFile)) {
+            clearstatcache(true, dirname($tokenFile) . DIRECTORY_SEPARATOR . readlink($tokenFile));
+            clearstatcache(true, dirname($tokenFile) . DIRECTORY_SEPARATOR . dirname(readlink($tokenFile)));
+            clearstatcache(true, $tokenFile);
+        }
+
+        if (false === $token = file_get_contents($tokenFile)) {
+            throw new RuntimeException('failed to read data');
+        }
+
+        return $token;
     }
 }

--- a/src/Core/src/Credentials/WebIdentityProvider.php
+++ b/src/Core/src/Credentials/WebIdentityProvider.php
@@ -137,7 +137,7 @@ final class WebIdentityProvider implements CredentialProvider
         }
 
         if (false === $token = file_get_contents($tokenFile)) {
-            throw new RuntimeException('failed to read data');
+            throw new RuntimeException('Failed to read data');
         }
 
         return $token;

--- a/src/Core/src/Credentials/WebIdentityProvider.php
+++ b/src/Core/src/Credentials/WebIdentityProvider.php
@@ -129,8 +129,10 @@ final class WebIdentityProvider implements CredentialProvider
     private function getTokenFileContent(string $tokenFile): string
     {
         if (!file_exists($tokenFile)) {
-            clearstatcache(true, \dirname($tokenFile) . \DIRECTORY_SEPARATOR . readlink($tokenFile));
-            clearstatcache(true, \dirname($tokenFile) . \DIRECTORY_SEPARATOR . \dirname(readlink($tokenFile)));
+            $tokenDir = \dirname($tokenFile);
+            $tokenLink = readlink($tokenFile);
+            clearstatcache(true, $tokenDir . \DIRECTORY_SEPARATOR . $tokenLink);
+            clearstatcache(true, $tokenDir . \DIRECTORY_SEPARATOR . \dirname($tokenLink));
             clearstatcache(true, $tokenFile);
         }
 


### PR DESCRIPTION
This fixes #900 by applying the same fix of the official SDK in aws/aws-sdk-php#2043