### PR TITLE
Use psalm 3.18 and update baseline

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -52,6 +52,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Psalm
-        uses: docker://vimeo/psalm-github-actions:3.18
+        uses: docker://vimeo/psalm-github-actions:3.18.0
         with:
           args: --no-progress --show-info=false --stats

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -52,6 +52,6 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Psalm
-        uses: docker://vimeo/psalm-github-actions:3.17.2
+        uses: docker://vimeo/psalm-github-actions:3.18
         with:
           args: --no-progress --show-info=false --stats

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="3.16@d03e5ef057d6adc656c0ff7e166c50b73b4f48f3">
+<files psalm-version="3.18.0@a463c894c4323e84121b5978867923efc6f8554a">
+  <file src="src/Core/src/AwsError/AwsErrorFactory.php">
+    <InvalidScalarArgument occurrences="1">
+      <code>$xml</code>
+    </InvalidScalarArgument>
+    <PossiblyUndefinedVariable occurrences="1">
+      <code>$xml</code>
+    </PossiblyUndefinedVariable>
+  </file>
   <file src="src/Core/src/Credentials/PsrCacheProvider.php">
     <InvalidCatch occurrences="1"/>
     <InvalidThrow occurrences="1">


### PR DESCRIPTION
This will make the build green. 

It was way more work to support 4.x. So I'll stick to the 3.x branch for now