### PR TITLE
Generate Exceptions

### DIFF
--- a/src/CodeGenerator/src/Definition/ExceptionShape.php
+++ b/src/CodeGenerator/src/Definition/ExceptionShape.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
-class ExceptionShape extends Shape
+class ExceptionShape extends StructureShape
 {
     public function hasError(): bool
     {
@@ -18,6 +18,22 @@ class ExceptionShape extends Shape
 
     public function getStatusCode(): ?int
     {
-        return $this->data['error']['httpStatusCode'] ?? null;
+        return $this->data['error']['httpStatusCode'] ?? 400;
+    }
+
+    public function isSenderFault(): ?bool
+    {
+        if (isset($this->data['error']['senderFault'])) {
+            return $this->data['error']['senderFault'];
+        }
+        if (isset($this->data['error']['fault'])) {
+            return !$this->data['error']['fault'];
+        }
+        if (isset($this->data['error']['httpStatusCode'])) {
+            return $this->data['error']['httpStatusCode'] < 500;
+        }
+
+        // it's always user's fault!
+        return true;
     }
 }

--- a/src/CodeGenerator/src/Definition/Operation.php
+++ b/src/CodeGenerator/src/Definition/Operation.php
@@ -101,12 +101,15 @@ class Operation
     {
         $errors = [];
         foreach ($this->data['errors'] ?? [] as $error) {
+            if (isset($errors[$error['shape']])) {
+                continue;
+            }
             /** @var ExceptionShape $shape */
             $shape = ($this->shapeLocator)($error['shape']);
-            $errors[] = $shape;
+            $errors[$error['shape']] = $shape;
         }
 
-        return $errors;
+        return array_values($errors);
     }
 
     public function getInput(): StructureShape

--- a/src/CodeGenerator/src/Definition/Operation.php
+++ b/src/CodeGenerator/src/Definition/Operation.php
@@ -94,6 +94,21 @@ class Operation
         return null;
     }
 
+    /**
+     * @return ExceptionShape[]
+     */
+    public function getErrors(): array
+    {
+        $errors = [];
+        foreach ($this->data['errors'] ?? [] as $error) {
+            /** @var ExceptionShape $shape */
+            $shape = ($this->shapeLocator)($error['shape']);
+            $errors[] = $shape;
+        }
+
+        return $errors;
+    }
+
     public function getInput(): StructureShape
     {
         if (isset($this->data['input']['shape'])) {

--- a/src/CodeGenerator/src/Definition/StructureMember.php
+++ b/src/CodeGenerator/src/Definition/StructureMember.php
@@ -8,6 +8,10 @@ class StructureMember extends Member
 {
     public function getName(): string
     {
+        if ($this->getOwnerShape() instanceof ExceptionShape && \in_array(\strtolower($this->data['_name']), ['code', 'message'], true)) {
+            return \strtolower($this->data['_name']);
+        }
+
         return $this->data['_name'];
     }
 
@@ -19,6 +23,15 @@ class StructureMember extends Member
     public function isRequired(): bool
     {
         return $this->data['_required'];
+    }
+
+    public function isNullable(): bool
+    {
+        if ($this->getOwnerShape() instanceof ExceptionShape && \in_array(\strtolower($this->data['_name']), ['code', 'message'], true)) {
+            return false;
+        }
+
+        return true;
     }
 
     public function isStreaming(): bool

--- a/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\CodeGenerator\Generator\CodeGenerator;
+
+use AsyncAws\CodeGenerator\Definition\ListShape;
+use AsyncAws\CodeGenerator\Definition\MapShape;
+use AsyncAws\CodeGenerator\Definition\Operation;
+use AsyncAws\CodeGenerator\Definition\StructureShape;
+use AsyncAws\CodeGenerator\File\FileWriter;
+use AsyncAws\CodeGenerator\Generator\EnumGenerator;
+use AsyncAws\CodeGenerator\Generator\GeneratorHelper;
+use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
+use AsyncAws\CodeGenerator\Generator\ObjectGenerator;
+use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassBuilder;
+use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassRegistry;
+use AsyncAws\CodeGenerator\Generator\ResponseParser\ParserProvider;
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Stream\ResponseBodyStream;
+use AsyncAws\Core\Stream\ResultStream;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Generate method and properties to populate object from AWS response.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal
+ */
+class PopulatorGenerator
+{
+    /**
+     * @var ObjectGenerator
+     */
+    private $objectGenerator;
+
+    /**
+     * @var EnumGenerator
+     */
+    private $enumGenerator;
+
+    /**
+     * @var TypeGenerator
+     */
+    private $typeGenerator;
+
+    /**
+     * @var ParserProvider
+     */
+    private $parserProvider;
+
+    public function __construct(ClassRegistry $classRegistry, NamespaceRegistry $namespaceRegistry, ObjectGenerator $objectGenerator, ?TypeGenerator $typeGenerator = null, ?EnumGenerator $enumGenerator = null, ?ExceptionGenerator $exceptionGenerator = null)
+    {
+        $this->objectGenerator = $objectGenerator;
+        $this->typeGenerator = $typeGenerator ?? new TypeGenerator($namespaceRegistry);
+        $this->enumGenerator = $enumGenerator ?? new EnumGenerator($classRegistry, $namespaceRegistry);
+        $this->parserProvider = new ParserProvider($namespaceRegistry, $this->typeGenerator);
+    }
+
+    public function generate(Operation $operation, StructureShape $shape, ClassBuilder $classBuilder, bool $forException = false): void
+    {
+        $this->generatePopulator($operation, $shape, $classBuilder, $forException);
+        $this->generateProperties($shape, $classBuilder, $forException);
+    }
+
+    /**
+     * Add properties and getters.
+     */
+    private function generateProperties(StructureShape $shape, ClassBuilder $classBuilder, bool $forException): void
+    {
+        foreach ($shape->getMembers() as $member) {
+            $propertyName = GeneratorHelper::normalizeName($member->getName());
+            if ($forException && \in_array($propertyName, ['code', 'message'], true)) {
+                continue;
+            }
+
+            $nullable = $returnType = null;
+            $memberShape = $member->getShape();
+            $property = $classBuilder->addProperty($propertyName)->setPrivate();
+            if (null !== $propertyDocumentation = $memberShape->getDocumentation()) {
+                $property->setComment(GeneratorHelper::parseDocumentation($propertyDocumentation));
+            }
+            [$returnType, $parameterType, $memberClassNames] = $this->typeGenerator->getPhpType($memberShape);
+            foreach ($memberClassNames as $memberClassName) {
+                $classBuilder->addUse($memberClassName->getFqdn());
+            }
+
+            if (!empty($memberShape->getEnum())) {
+                $this->enumGenerator->generate($memberShape);
+            }
+
+            if ($memberShape instanceof StructureShape) {
+                $this->objectGenerator->generate($memberShape);
+            } elseif ($memberShape instanceof MapShape) {
+                $mapKeyShape = $memberShape->getKey()->getShape();
+                if ('string' !== $mapKeyShape->getType()) {
+                    throw new \RuntimeException('Complex maps are not supported');
+                }
+                if (!empty($mapKeyShape->getEnum())) {
+                    $this->enumGenerator->generate($mapKeyShape);
+                }
+
+                if (($valueShape = $memberShape->getValue()->getShape()) instanceof StructureShape) {
+                    $this->objectGenerator->generate($valueShape);
+                }
+                if (!empty($valueShape->getEnum())) {
+                    $this->enumGenerator->generate($valueShape);
+                }
+
+                $nullable = false;
+                $property->setValue([]);
+            } elseif ($memberShape instanceof ListShape) {
+                $memberShape->getMember()->getShape();
+
+                if (($memberShape = $memberShape->getMember()->getShape()) instanceof StructureShape) {
+                    $this->objectGenerator->generate($memberShape);
+                }
+                if (!empty($memberShape->getEnum())) {
+                    $this->enumGenerator->generate($memberShape);
+                }
+
+                $nullable = false;
+                $property->setValue([]);
+            } elseif ($member->isStreaming()) {
+                $returnType = ResultStream::class;
+                $parameterType = ResultStream::class;
+                $memberClassNames = [];
+                $nullable = false;
+            }
+
+            $method = $classBuilder->addMethod('get' . \ucfirst(GeneratorHelper::normalizeName($member->getName())))
+                ->setReturnType($returnType);
+
+            $deprecation = '';
+            if ($member->isDeprecated()) {
+                $method->addComment('@deprecated');
+                $deprecation = strtr('@trigger_error(\sprintf(\'The property "NAME" of "%s" is deprecated by AWS.\', __CLASS__), E_USER_DEPRECATED);', ['NAME' => $propertyName]);
+            }
+
+            $method->setBody($deprecation . strtr('
+                    INITIALIZER
+
+                    return $this->PROPERTY;
+                ', [
+                'PROPERTY' => $propertyName,
+                'INITIALIZER' => $forException ? '' : '$this->initialize();',
+            ]));
+
+            $nullable = $nullable ?? !$member->isRequired();
+            if ($parameterType && $parameterType !== $returnType && (empty($memberClassNames) || $memberClassNames[0]->getName() !== $parameterType)) {
+                $method->addComment('@return ' . $parameterType . ($nullable ? '|null' : ''));
+            }
+            $method->setReturnNullable($nullable);
+        }
+    }
+
+    private function generatePopulator(Operation $operation, StructureShape $shape, ClassBuilder $classBuilder, bool $forException): void
+    {
+        // Parse headers
+        $nonHeaders = [];
+        $body = '';
+        foreach ($shape->getMembers() as $member) {
+            if ('header' !== $member->getLocation()) {
+                $nonHeaders[$member->getName()] = $member;
+
+                continue;
+            }
+
+            $locationName = strtolower($member->getLocationName() ?? $member->getName());
+            $propertyName = GeneratorHelper::normalizeName($member->getName());
+            $memberShape = $member->getShape();
+            if ('timestamp' === $memberShape->getType()) {
+                $body .= strtr('$this->PROPERTY_NAME = isset($headers["LOCATION_NAME"][0]) ? new \DateTimeImmutable($headers["LOCATION_NAME"][0]) : null;' . "\n", [
+                    'PROPERTY_NAME' => $propertyName,
+                    'LOCATION_NAME' => $locationName,
+                ]);
+            } else {
+                if (null !== $constant = $this->typeGenerator->getFilterConstant($memberShape)) {
+                    $body .= strtr('$this->PROPERTY_NAME = isset($headers["LOCATION_NAME"][0]) ? filter_var($headers["LOCATION_NAME"][0], FILTER) : null;' . "\n", [
+                        'PROPERTY_NAME' => $propertyName,
+                        'LOCATION_NAME' => $locationName,
+                        'FILTER' => $constant,
+                    ]);
+                } else {
+                    $body .= strtr('$this->PROPERTY_NAME = $headers["LOCATION_NAME"][0] ?? null;' . "\n", [
+                        'PROPERTY_NAME' => $propertyName,
+                        'LOCATION_NAME' => $locationName,
+                    ]);
+                }
+            }
+        }
+
+        // This will catch arbitrary values that exists in undefined "headers"
+        foreach ($nonHeaders as $name => $member) {
+            // "headers" are not "header"
+            if ('headers' !== $member->getLocation()) {
+                continue;
+            }
+            unset($nonHeaders[$name]);
+
+            $locationName = strtolower($member->getLocationName() ?? $member->getName());
+            $propertyName = GeneratorHelper::normalizeName($member->getName());
+            $body .= strtr('
+                $this->PROPERTY_NAME = [];
+                foreach ($headers as $name => $value) {
+                    if (substr($name, 0, LENGTH) === "LOCATION_NAME") {
+                        $this->PROPERTY_NAME[substr($name, LENGTH)] = $value[0];
+                    }
+                }
+            ', [
+                'PROPERTY_NAME' => $propertyName,
+                'LENGTH' => \strlen($locationName),
+                'LOCATION_NAME' => $locationName,
+            ]);
+        }
+
+        // Prepend with $headers = ...
+        if (!empty($body)) {
+            $body = '$headers = $response->getHeaders();' . "\n\n" . $body;
+        }
+
+        // Find status code
+        foreach ($nonHeaders as $name => $member) {
+            if ('statusCode' === $member->getLocation()) {
+                $body = '$this->' . GeneratorHelper::normalizeName($member->getName()) . ' = $response->getStatusCode();' . "\n" . $body;
+            }
+        }
+
+        $body .= "\n";
+        $payloadProperty = $shape->getPayload();
+        if (null !== $payloadProperty && $shape->getMember($payloadProperty)->isStreaming()) {
+            // Make sure we can stream this.
+            $classBuilder->addUse(ResponseBodyStream::class);
+            $body .= strtr('$this->PROPERTY_NAME = $response->toStream();', ['PROPERTY_NAME' => GeneratorHelper::normalizeName($member->getName())]);
+        } else {
+            $parserResult = $this->parserProvider->get($operation->getService())->generate($shape, !$forException);
+            $body .= $parserResult->getBody();
+
+            foreach ($parserResult->getUsedClasses() as $className) {
+                $classBuilder->addUse($className->getFqdn());
+            }
+            $classBuilder->setMethods($parserResult->getExtraMethods());
+        }
+        if (empty(trim($body))) {
+            return;
+        }
+
+        $method = $classBuilder->addMethod('populateResult')
+            ->setReturnType('void')
+            ->setProtected()
+            ->setBody($body);
+        if ($forException) {
+            $method->addParameter('response')->setType(ResponseInterface::class);
+            $classBuilder->addUse(ResponseInterface::class);
+        } else {
+            $method->addParameter('response')->setType(Response::class);
+            $classBuilder->addUse(Response::class);
+        }
+    }
+}

--- a/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
@@ -248,12 +248,13 @@ class PopulatorGenerator
 
         $method = $classBuilder->addMethod('populateResult')
             ->setReturnType('void')
-            ->setProtected()
             ->setBody($body);
         if ($forException) {
+            $method->setPrivate();
             $method->addParameter('response')->setType(ResponseInterface::class);
             $classBuilder->addUse(ResponseInterface::class);
         } else {
+            $method->setProtected();
             $method->addParameter('response')->setType(Response::class);
             $classBuilder->addUse(Response::class);
         }

--- a/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
@@ -51,7 +51,7 @@ class PopulatorGenerator
      */
     private $parserProvider;
 
-    public function __construct(ClassRegistry $classRegistry, NamespaceRegistry $namespaceRegistry, ObjectGenerator $objectGenerator, ?TypeGenerator $typeGenerator = null, ?EnumGenerator $enumGenerator = null, ?ExceptionGenerator $exceptionGenerator = null)
+    public function __construct(ClassRegistry $classRegistry, NamespaceRegistry $namespaceRegistry, ObjectGenerator $objectGenerator, ?TypeGenerator $typeGenerator = null, ?EnumGenerator $enumGenerator = null)
     {
         $this->objectGenerator = $objectGenerator;
         $this->typeGenerator = $typeGenerator ?? new TypeGenerator($namespaceRegistry);

--- a/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
@@ -232,7 +232,7 @@ class PopulatorGenerator
         if (null !== $payloadProperty && $shape->getMember($payloadProperty)->isStreaming()) {
             // Make sure we can stream this.
             $classBuilder->addUse(ResponseBodyStream::class);
-            $body .= strtr('$this->PROPERTY_NAME = $response->toStream();', ['PROPERTY_NAME' => GeneratorHelper::normalizeName($member->getName())]);
+            $body .= strtr('$this->PROPERTY_NAME = $response->toStream();', ['PROPERTY_NAME' => GeneratorHelper::normalizeName($payloadProperty)]);
         } else {
             $parserResult = $this->parserProvider->get($operation->getService())->generate($shape, !$forException);
             $body .= $parserResult->getBody();

--- a/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
@@ -8,7 +8,6 @@ use AsyncAws\CodeGenerator\Definition\ListShape;
 use AsyncAws\CodeGenerator\Definition\MapShape;
 use AsyncAws\CodeGenerator\Definition\Operation;
 use AsyncAws\CodeGenerator\Definition\StructureShape;
-use AsyncAws\CodeGenerator\File\FileWriter;
 use AsyncAws\CodeGenerator\Generator\EnumGenerator;
 use AsyncAws\CodeGenerator\Generator\GeneratorHelper;
 use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;

--- a/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
@@ -248,13 +248,12 @@ class PopulatorGenerator
 
         $method = $classBuilder->addMethod('populateResult')
             ->setReturnType('void')
-            ->setBody($body);
+            ->setBody($body)
+            ->setProtected();
         if ($forException) {
-            $method->setPrivate();
             $method->addParameter('response')->setType(ResponseInterface::class);
             $classBuilder->addUse(ResponseInterface::class);
         } else {
-            $method->setProtected();
             $method->addParameter('response')->setType(Response::class);
             $classBuilder->addUse(Response::class);
         }

--- a/src/CodeGenerator/src/Generator/ExceptionGenerator.php
+++ b/src/CodeGenerator/src/Generator/ExceptionGenerator.php
@@ -11,6 +11,7 @@ use AsyncAws\CodeGenerator\Generator\Naming\ClassName;
 use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
 use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassBuilder;
 use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassRegistry;
+use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use AsyncAws\Core\Exception\Http\ServerException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
@@ -85,13 +86,15 @@ class ExceptionGenerator
     private function generateConstructor(ClassBuilder $classBuilder): void
     {
         $body = '
-            parent::__construct($response);
+            parent::__construct($response, $awsError);
             $this->populateResult($response);
         ';
 
         $method = $classBuilder->addMethod('__construct')
             ->setBody($body);
         $method->addParameter('response')->setType(ResponseInterface::class);
+        $method->addParameter('awsError')->setType(AwsError::class)->setNullable(true);
         $classBuilder->addUse(ResponseInterface::class);
+        $classBuilder->addUse(AwsError::class);
     }
 }

--- a/src/CodeGenerator/src/Generator/ExceptionGenerator.php
+++ b/src/CodeGenerator/src/Generator/ExceptionGenerator.php
@@ -9,12 +9,9 @@ use AsyncAws\CodeGenerator\Definition\Operation;
 use AsyncAws\CodeGenerator\Generator\CodeGenerator\PopulatorGenerator;
 use AsyncAws\CodeGenerator\Generator\Naming\ClassName;
 use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
-use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassBuilder;
 use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassRegistry;
-use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use AsyncAws\Core\Exception\Http\ServerException;
-use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
  * Generate API client methods and result classes.

--- a/src/CodeGenerator/src/Generator/ExceptionGenerator.php
+++ b/src/CodeGenerator/src/Generator/ExceptionGenerator.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\CodeGenerator\Generator;
+
+use AsyncAws\CodeGenerator\Definition\ExceptionShape;
+use AsyncAws\CodeGenerator\Definition\Operation;
+use AsyncAws\CodeGenerator\Generator\CodeGenerator\PopulatorGenerator;
+use AsyncAws\CodeGenerator\Generator\Naming\ClassName;
+use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
+use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassBuilder;
+use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassRegistry;
+use AsyncAws\Core\Exception\Http\ClientException;
+use AsyncAws\Core\Exception\Http\ServerException;
+use Nette\PhpGenerator\ClassType;
+use Nette\PhpGenerator\PhpNamespace;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Generate API client methods and result classes.
+ *
+ * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal
+ */
+class ExceptionGenerator
+{
+    /**
+     * @var ClassName[]
+     */
+    private $generated = [];
+
+    /**
+     * @var ClassRegistry
+     */
+    private $classRegistry;
+
+    /**
+     * @var NamespaceRegistry
+     */
+    private $namespaceRegistry;
+
+    /**
+     * @var PopulatorGenerator
+     */
+    private $populatorGenerator;
+
+    public function __construct(ClassRegistry $classRegistry, NamespaceRegistry $namespaceRegistry, PopulatorGenerator $populatorGenerator)
+    {
+        $this->classRegistry = $classRegistry;
+        $this->namespaceRegistry = $namespaceRegistry;
+        $this->populatorGenerator = $populatorGenerator;
+    }
+
+    public function generate(Operation $operation, ExceptionShape $shape): ClassName
+    {
+        if (isset($this->generated[$shape->getName()])) {
+            return $this->generated[$shape->getName()];
+        }
+
+        $this->generated[$shape->getName()] = $className = $this->namespaceRegistry->getException($shape);
+
+        $classBuilder = $this->classRegistry->register($className->getFqdn());
+        $classBuilder->setFinal();
+        if ($shape->isSenderFault()) {
+            $classBuilder->addExtend(ClientException::class);
+            $classBuilder->addUse(ClientException::class);
+        } else {
+            $classBuilder->addExtend(ServerException::class);
+            $classBuilder->addUse(ServerException::class);
+        }
+
+        if (0 < \count($members = $shape->getMembers())) {
+            $this->populatorGenerator->generate($operation, $shape, $classBuilder, true);
+            $this->generateConstructor($classBuilder);
+        }
+
+        return $className;
+    }
+
+    private function generateConstructor(ClassBuilder $classBuilder): void
+    {
+        $body = '
+            parent::__construct($response);
+            $this->populateResult($response);
+        ';
+
+        $method = $classBuilder->addMethod('__construct')
+            ->setBody($body);
+        $method->addParameter('response')->setType(ResponseInterface::class);
+        $classBuilder->addUse(ResponseInterface::class);
+    }
+}

--- a/src/CodeGenerator/src/Generator/ExceptionGenerator.php
+++ b/src/CodeGenerator/src/Generator/ExceptionGenerator.php
@@ -13,8 +13,6 @@ use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassBuilder;
 use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassRegistry;
 use AsyncAws\Core\Exception\Http\ClientException;
 use AsyncAws\Core\Exception\Http\ServerException;
-use Nette\PhpGenerator\ClassType;
-use Nette\PhpGenerator\PhpNamespace;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**

--- a/src/CodeGenerator/src/Generator/ExceptionGenerator.php
+++ b/src/CodeGenerator/src/Generator/ExceptionGenerator.php
@@ -64,6 +64,10 @@ class ExceptionGenerator
 
         $classBuilder = $this->classRegistry->register($className->getFqdn());
         $classBuilder->setFinal();
+        if (null !== $documentation = $shape->getDocumentation()) {
+            $classBuilder->addComment(GeneratorHelper::parseDocumentation($documentation, false));
+        }
+
         if ($shape->isSenderFault()) {
             $classBuilder->addExtend(ClientException::class);
             $classBuilder->addUse(ClientException::class);

--- a/src/CodeGenerator/src/Generator/ExceptionGenerator.php
+++ b/src/CodeGenerator/src/Generator/ExceptionGenerator.php
@@ -77,24 +77,8 @@ class ExceptionGenerator
 
         if (0 < \count($members = $shape->getMembers())) {
             $this->populatorGenerator->generate($operation, $shape, $classBuilder, true);
-            $this->generateConstructor($classBuilder);
         }
 
         return $className;
-    }
-
-    private function generateConstructor(ClassBuilder $classBuilder): void
-    {
-        $body = '
-            parent::__construct($response, $awsError);
-            $this->populateResult($response);
-        ';
-
-        $method = $classBuilder->addMethod('__construct')
-            ->setBody($body);
-        $method->addParameter('response')->setType(ResponseInterface::class);
-        $method->addParameter('awsError')->setType(AwsError::class)->setNullable(true);
-        $classBuilder->addUse(ResponseInterface::class);
-        $classBuilder->addUse(AwsError::class);
     }
 }

--- a/src/CodeGenerator/src/Generator/GeneratorHelper.php
+++ b/src/CodeGenerator/src/Generator/GeneratorHelper.php
@@ -30,6 +30,7 @@ class GeneratorHelper
             'AWS' => 'Aws',
             'ACL' => 'Acl',
             'ACP' => 'Acp',
+            'EC2' => 'Ec2',
             'KMS' => 'Kms',
             'ARN' => 'Arn',
             'MFA' => 'Mfa',

--- a/src/CodeGenerator/src/Generator/Naming/NamespaceRegistry.php
+++ b/src/CodeGenerator/src/Generator/Naming/NamespaceRegistry.php
@@ -44,7 +44,7 @@ final class NamespaceRegistry
      */
     private $objectNamespace;
 
-    public function __construct(string $baseNamespace, ?string $inputNamespace = '\\Input', ?string $resultNamespace = '\\Result', ?string $testNamespace = '\\Tests', ?string $enumNamespace = '\\Enum', ?string $objectNamespace = '\\ValueObject')
+    public function __construct(string $baseNamespace, ?string $inputNamespace = '\\Input', ?string $resultNamespace = '\\Result', ?string $testNamespace = '\\Tests', ?string $enumNamespace = '\\Enum', ?string $objectNamespace = '\\ValueObject', ?string $exceptionNamespace = '\\Exception')
     {
         $this->baseNamespace = $baseNamespace;
         $this->inputNamespace = '\\' === $inputNamespace[0] ? $baseNamespace . $inputNamespace : $inputNamespace;
@@ -52,6 +52,7 @@ final class NamespaceRegistry
         $this->testNamespace = '\\' === $testNamespace[0] ? implode('\\', \array_slice(\explode('\\', $baseNamespace), 0, 2)) . $testNamespace : $testNamespace;
         $this->enumNamespace = '\\' === $enumNamespace[0] ? $baseNamespace . $enumNamespace : $enumNamespace;
         $this->objectNamespace = '\\' === $objectNamespace[0] ? $baseNamespace . $objectNamespace : $objectNamespace;
+        $this->exceptionNamespace = '\\' === $exceptionNamespace[0] ? $baseNamespace . $exceptionNamespace : $exceptionNamespace;
     }
 
     public function getClient(ServiceDefinition $definition): ClassName
@@ -77,6 +78,11 @@ final class NamespaceRegistry
     public function getEnum(Shape $shape): ClassName
     {
         return ClassName::create($this->enumNamespace, $shape->getName());
+    }
+
+    public function getException(Shape $shape): ClassName
+    {
+        return ClassName::create($this->exceptionNamespace, $shape->getName() . (\substr($shape->getName(), -9) === 'Exception' ? '' : 'Exception'));
     }
 
     public function getObject(Shape $shape): ClassName

--- a/src/CodeGenerator/src/Generator/Naming/NamespaceRegistry.php
+++ b/src/CodeGenerator/src/Generator/Naming/NamespaceRegistry.php
@@ -44,6 +44,11 @@ final class NamespaceRegistry
      */
     private $objectNamespace;
 
+    /**
+     * @var string
+     */
+    private $exceptionNamespace;
+
     public function __construct(string $baseNamespace, ?string $inputNamespace = '\\Input', ?string $resultNamespace = '\\Result', ?string $testNamespace = '\\Tests', ?string $enumNamespace = '\\Enum', ?string $objectNamespace = '\\ValueObject', ?string $exceptionNamespace = '\\Exception')
     {
         $this->baseNamespace = $baseNamespace;
@@ -82,7 +87,7 @@ final class NamespaceRegistry
 
     public function getException(Shape $shape): ClassName
     {
-        return ClassName::create($this->exceptionNamespace, $shape->getName() . (\substr($shape->getName(), -9) === 'Exception' ? '' : 'Exception'));
+        return ClassName::create($this->exceptionNamespace, $shape->getName() . ('Exception' === \substr($shape->getName(), -9) ? '' : 'Exception'));
     }
 
     public function getObject(Shape $shape): ClassName

--- a/src/CodeGenerator/src/Generator/OperationGenerator.php
+++ b/src/CodeGenerator/src/Generator/OperationGenerator.php
@@ -145,18 +145,16 @@ class OperationGenerator
             $body .= '@trigger_error(\sprintf(\'The operation "%s" is deprecated by AWS.\', __FUNCTION__), E_USER_DEPRECATED);';
         }
 
+        $body .= '
+                $input = INPUT_CLASS::create($input);
+                $response = $this->getResponse($input->request(), new RequestContext(["operation" => OPERATION_NAME, "region" => $input->getRegion()EXCEPTION_MAPPING]));
+        ';
         if ((null !== $pagination = $operation->getPagination()) && !empty($pagination->getOutputToken())) {
             $body .= '
-                $input = INPUT_CLASS::create($input);
-                $response = $this->getResponse($input->request(), new RequestContext(["operation" => OPERATION_NAME, "region" => $input->getRegion(), "exceptionMapping" => ERRORS]));
-
                 return new RESULT_CLASS($response, $this, $input);
             ';
         } else {
             $body .= '
-                $input = INPUT_CLASS::create($input);
-                $response = $this->getResponse($input->request(), new RequestContext(["operation" => OPERATION_NAME, "region" => $input->getRegion(), "exceptionMapping" => ERRORS]));
-
                 return new RESULT_CLASS($response);
             ';
         }
@@ -173,7 +171,7 @@ class OperationGenerator
             'INPUT_CLASS' => $inputClass->getName(),
             'OPERATION_NAME' => \var_export($operation->getName(), true),
             'RESULT_CLASS' => $resultClass ? $resultClass->getName() : 'Result',
-            'ERRORS' => $mapping ? "[\n" . implode("\n", $mapping) . "\n]" : '[]',
+            'EXCEPTION_MAPPING' => $mapping ? ", 'exceptionMapping' => [\n" . implode("\n", $mapping) . "\n]" : '',
         ]));
     }
 }

--- a/src/CodeGenerator/src/Generator/ResponseParser/Parser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/Parser.php
@@ -13,5 +13,5 @@ use AsyncAws\CodeGenerator\Definition\StructureShape;
  */
 interface Parser
 {
-    public function generate(StructureShape $shape): ParserResult;
+    public function generate(StructureShape $shape, bool $throwOnError = true): ParserResult;
 }

--- a/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
@@ -51,10 +51,19 @@ class RestJsonParser implements Parser
                 continue;
             }
 
-            $properties[] = strtr('$this->PROPERTY_NAME = PROPERTY_ACCESSOR;', [
-                'PROPERTY_NAME' => GeneratorHelper::normalizeName($member->getName()),
-                'PROPERTY_ACCESSOR' => $this->parseElement(sprintf('$data[\'%s\']', $this->getInputAccessorName($member)), $member->getShape(), $member->isRequired()),
-            ]);
+            if (!$member->isNullable() && !$member->isRequired()) {
+                $properties[] = strtr('if (null !== $v = (PROPERTY_ACCESSOR)) {
+                        $this->PROPERTY_NAME = $v;
+                    }', [
+                    'PROPERTY_NAME' => GeneratorHelper::normalizeName($member->getName()),
+                    'PROPERTY_ACCESSOR' => $this->parseElement(sprintf('$data[\'%s\']', $this->getInputAccessorName($member)), $member->getShape(), $member->isRequired()),
+                ]);
+            } else {
+                $properties[] = strtr('$this->PROPERTY_NAME = PROPERTY_ACCESSOR;', [
+                    'PROPERTY_NAME' => GeneratorHelper::normalizeName($member->getName()),
+                    'PROPERTY_ACCESSOR' => $this->parseElement(sprintf('$data[\'%s\']', $this->getInputAccessorName($member)), $member->getShape(), $member->isRequired()),
+                ]);
+            }
         }
 
         if (empty($properties)) {

--- a/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
@@ -37,10 +37,10 @@ class RestJsonParser implements Parser
         $this->typeGenerator = $typeGenerator;
     }
 
-    public function generate(StructureShape $shape): ParserResult
+    public function generate(StructureShape $shape, bool $throwOnError = true): ParserResult
     {
         if (null !== $payloadProperty = $shape->getPayload()) {
-            return new ParserResult(strtr('$this->PROPERTY_NAME = $response->getContent();', ['PROPERTY_NAME' => GeneratorHelper::normalizeName($payloadProperty)]));
+            return new ParserResult(strtr('$this->PROPERTY_NAME = $response->getContent(THROW);', ['THROW' => $throwOnError ? '' : 'false', 'PROPERTY_NAME' => GeneratorHelper::normalizeName($payloadProperty)]));
         }
 
         $properties = [];
@@ -61,7 +61,7 @@ class RestJsonParser implements Parser
             return new ParserResult('');
         }
 
-        $body = '$data = $response->toArray();' . "\n";
+        $body = '$data = $response->toArray(' . ($throwOnError ? '' : 'false') . ');' . "\n";
         if (null !== $wrapper = $shape->getResultWrapper()) {
             $body .= strtr('$data = $data[WRAPPER];' . "\n", ['WRAPPER' => var_export($wrapper, true)]);
         }

--- a/src/CodeGenerator/src/Generator/ResponseParser/RestXmlParser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/RestXmlParser.php
@@ -13,7 +13,6 @@ use AsyncAws\CodeGenerator\Definition\StructureShape;
 use AsyncAws\CodeGenerator\Generator\CodeGenerator\TypeGenerator;
 use AsyncAws\CodeGenerator\Generator\GeneratorHelper;
 use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
-use AsyncAws\Core\AwsError\AwsError;
 use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Method;
 
@@ -55,10 +54,19 @@ class RestXmlParser implements Parser
                     continue;
                 }
 
-                $properties[] = strtr('$this->PROPERTY_NAME = PROPERTY_ACCESSOR;', [
-                    'PROPERTY_NAME' => GeneratorHelper::normalizeName($member->getName()),
-                    'PROPERTY_ACCESSOR' => $this->parseXmlElement($this->getInputAccessor('$data', $member), $member->getShape(), $member->isRequired()),
-                ]);
+                if (!$member->isNullable() && !$member->isRequired()) {
+                    $properties[] = strtr('if (null !== $v = (PROPERTY_ACCESSOR)) {
+                        $this->PROPERTY_NAME = $v;
+                    }', [
+                        'PROPERTY_NAME' => GeneratorHelper::normalizeName($member->getName()),
+                        'PROPERTY_ACCESSOR' => $this->parseXmlElement($this->getInputAccessor('$data', $member), $member->getShape(), $member->isRequired()),
+                    ]);
+                } else {
+                    $properties[] = strtr('$this->PROPERTY_NAME = PROPERTY_ACCESSOR;', [
+                        'PROPERTY_NAME' => GeneratorHelper::normalizeName($member->getName()),
+                        'PROPERTY_ACCESSOR' => $this->parseXmlElement($this->getInputAccessor('$data', $member), $member->getShape(), $member->isRequired()),
+                    ]);
+                }
             }
         }
 

--- a/src/CodeGenerator/src/Generator/ServiceGenerator.php
+++ b/src/CodeGenerator/src/Generator/ServiceGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Generator;
 
+use AsyncAws\CodeGenerator\Generator\CodeGenerator\PopulatorGenerator;
 use AsyncAws\CodeGenerator\Generator\CodeGenerator\TypeGenerator;
 use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
 use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassRegistry;
@@ -76,7 +77,20 @@ class ServiceGenerator
      */
     private $type;
 
+    /**
+     * @var ClassRegistry
+     */
     private $classRegistry;
+
+    /**
+     * @var ExceptionGenerator
+     */
+    private $exception;
+
+    /**
+     * @var PopulatorGenerator
+     */
+    private $populator;
 
     public function __construct(ClassRegistry $classRegistry, string $baseNamespace, array $managedOperations)
     {
@@ -92,7 +106,7 @@ class ServiceGenerator
 
     public function operation(): OperationGenerator
     {
-        return $this->operation ?? $this->operation = new OperationGenerator($this->classRegistry, $this->namespaceRegistry, $this->input(), $this->result(), $this->pagination(), $this->test(), $this->type());
+        return $this->operation ?? $this->operation = new OperationGenerator($this->classRegistry, $this->namespaceRegistry, $this->input(), $this->result(), $this->pagination(), $this->test(), $this->exception(), $this->type());
     }
 
     public function waiter(): WaiterGenerator
@@ -110,9 +124,19 @@ class ServiceGenerator
         return $this->test ?? $this->test = new TestGenerator($this->classRegistry, $this->namespaceRegistry);
     }
 
+    public function populator(): PopulatorGenerator
+    {
+        return $this->populator ?? $this->populator = new PopulatorGenerator($this->classRegistry, $this->namespaceRegistry, $this->object(), $this->type(), $this->enum());
+    }
+
     public function result(): ResultGenerator
     {
-        return $this->result ?? $this->result = new ResultGenerator($this->classRegistry, $this->namespaceRegistry, $this->object(), $this->type(), $this->enum());
+        return $this->result ?? $this->result = new ResultGenerator($this->classRegistry, $this->namespaceRegistry, $this->populator());
+    }
+
+    public function exception(): ExceptionGenerator
+    {
+        return $this->exception ?? $this->exception = new ExceptionGenerator($this->classRegistry, $this->namespaceRegistry, $this->populator());
     }
 
     public function input(): InputGenerator

--- a/src/CodeGenerator/src/Generator/ServiceGenerator.php
+++ b/src/CodeGenerator/src/Generator/ServiceGenerator.php
@@ -111,7 +111,7 @@ class ServiceGenerator
 
     public function waiter(): WaiterGenerator
     {
-        return $this->waiter ?? $this->waiter = new WaiterGenerator($this->classRegistry, $this->namespaceRegistry, $this->input(), $this->type());
+        return $this->waiter ?? $this->waiter = new WaiterGenerator($this->classRegistry, $this->namespaceRegistry, $this->input(), $this->exception(), $this->type());
     }
 
     public function pagination(): PaginationGenerator

--- a/src/CodeGenerator/src/Generator/WaiterGenerator.php
+++ b/src/CodeGenerator/src/Generator/WaiterGenerator.php
@@ -87,9 +87,10 @@ class WaiterGenerator
         $classBuilder->addUse($resultClass->getFqdn());
 
         [$doc, $memberClassNames] = $this->typeGenerator->generateDocblock($inputShape, $inputClass, true, false, false, ['  @region?: string,']);
-        $method = $classBuilder->addMethod(\lcfirst($waiter->getName()))
-            ->setComment('Check status of operation ' . \lcfirst($operation->getName()))
-            ->addComment('@see ' . \lcfirst($operation->getName()))
+        $method = $classBuilder->addMethod(\lcfirst(GeneratorHelper::normalizeName($waiter->getName())))
+            ->setComment('Check status of operation ' . \lcfirst(GeneratorHelper::normalizeName($operation->getName())))
+            ->setComment('')
+            ->addComment('@see ' . \lcfirst(GeneratorHelper::normalizeName($operation->getName())))
             ->addComment($doc)
             ->setReturnType($resultClass->getFqdn())
             ->setBody(strtr('

--- a/src/CodeGenerator/src/Generator/WaiterGenerator.php
+++ b/src/CodeGenerator/src/Generator/WaiterGenerator.php
@@ -110,14 +110,14 @@ class WaiterGenerator
             ->setReturnType($resultClass->getFqdn())
             ->setBody(strtr('
                 $input = INPUT_CLASS::create($input);
-                $response = $this->getResponse($input->request(), new RequestContext(["operation" => OPERATION_NAME, "region" => $input->getRegion(), "exceptionMapping" => ERRORS]));
+                $response = $this->getResponse($input->request(), new RequestContext(["operation" => OPERATION_NAME, "region" => $input->getRegion()EXCEPTION_MAPPING]));
 
                 return new RESULT_CLASS($response, $this, $input);
             ', [
                 'INPUT_CLASS' => $inputClass->getName(),
                 'OPERATION_NAME' => \var_export($operation->getName(), true),
                 'RESULT_CLASS' => $resultClass->getName(),
-                'ERRORS' => $mapping ? "[\n" . implode("\n", $mapping) . "\n]" : '[]',
+                'EXCEPTION_MAPPING' => $mapping ? ", 'exceptionMapping' => [\n" . implode("\n", $mapping) . "\n]" : '',
             ]));
         foreach ($memberClassNames as $memberClassName) {
             $classBuilder->addUse($memberClassName->getFqdn());

--- a/src/CodeGenerator/src/Generator/WaiterGenerator.php
+++ b/src/CodeGenerator/src/Generator/WaiterGenerator.php
@@ -97,7 +97,7 @@ class WaiterGenerator
         $mapping = [];
         foreach ($operation->getErrors() as $error) {
             $errorClass = $this->exceptionGenerator->generate($operation, $error);
-            $namespace->addUse($errorClass->getFqdn());
+            $classBuilder->addUse($errorClass->getFqdn());
 
             $mapping[] = sprintf('%s => %s::class,', var_export($error->getCode() ?? $error->getName(), true), $errorClass->getName());
         }

--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 - Changed case of object's properties to camelCase.
 - Added documentation in class's headers.
+- Removed `final` from `ClientException` and `ServerException`.
+- Make Responses thrown Business Exception when AwsErrorCode <-> Exception class mapping provided throught RequestContext.
+- Added Business Exception in STS.
 
 ## 1.8.0
 

--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -7,8 +7,8 @@
 - Changed case of object's properties to camelCase.
 - Added documentation in class's headers.
 - Removed `final` from `ClientException` and `ServerException`.
-- Make Responses thrown Business Exception when AwsErrorCode <-> Exception class mapping provided throught RequestContext.
-- Added Business Exception in STS.
+- Make Responses thrown Business Exception when AwsErrorCode <-> Exception class mapping provided through RequestContext.
+- Added Business Exceptions.
 
 ## 1.8.0
 

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -167,7 +167,7 @@ abstract class AbstractApi
             ]);
         }
 
-        return new Response($response, $this->httpClient, $this->logger, $this->awsErrorFactory, $debug);
+        return new Response($response, $this->httpClient, $this->logger, $this->awsErrorFactory, $debug, $context->getExceptionMapping());
     }
 
     /**

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -167,7 +167,7 @@ abstract class AbstractApi
             ]);
         }
 
-        return new Response($response, $this->httpClient, $this->logger, $this->awsErrorFactory, $debug, $context->getExceptionMapping());
+        return new Response($response, $this->httpClient, $this->logger, $this->awsErrorFactory, $debug, $context ? $context->getExceptionMapping() : []);
     }
 
     /**

--- a/src/Core/src/Exception/Http/ClientException.php
+++ b/src/Core/src/Exception/Http/ClientException.php
@@ -11,7 +11,7 @@ use Symfony\Contracts\HttpClient\Exception\ClientExceptionInterface;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-final class ClientException extends \RuntimeException implements ClientExceptionInterface, HttpException
+class ClientException extends \RuntimeException implements ClientExceptionInterface, HttpException
 {
     use HttpExceptionTrait;
 }

--- a/src/Core/src/Exception/Http/HttpExceptionTrait.php
+++ b/src/Core/src/Exception/Http/HttpExceptionTrait.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\Core\Exception\Http;
 
 use AsyncAws\Core\AwsError\AwsError;
+use AsyncAws\Core\Response;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
@@ -46,6 +47,13 @@ TEXT;
         }
 
         parent::__construct($message, $code);
+
+
+        $this->populateResult($response);
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
     }
 
     public function getResponse(): ResponseInterface

--- a/src/Core/src/Exception/Http/HttpExceptionTrait.php
+++ b/src/Core/src/Exception/Http/HttpExceptionTrait.php
@@ -3,7 +3,6 @@
 namespace AsyncAws\Core\Exception\Http;
 
 use AsyncAws\Core\AwsError\AwsError;
-use AsyncAws\Core\Response;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
@@ -48,12 +47,7 @@ TEXT;
 
         parent::__construct($message, $code);
 
-
         $this->populateResult($response);
-    }
-
-    protected function populateResult(ResponseInterface $response): void
-    {
     }
 
     public function getResponse(): ResponseInterface
@@ -79,5 +73,9 @@ TEXT;
     public function getAwsDetail(): ?string
     {
         return $this->awsError ? $this->awsError->getDetail() : null;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
     }
 }

--- a/src/Core/src/Exception/Http/ServerException.php
+++ b/src/Core/src/Exception/Http/ServerException.php
@@ -11,7 +11,7 @@ use Symfony\Contracts\HttpClient\Exception\ServerExceptionInterface;
  *
  * @author Nicolas Grekas <p@tchwork.com>
  */
-final class ServerException extends \RuntimeException implements HttpException, ServerExceptionInterface
+class ServerException extends \RuntimeException implements HttpException, ServerExceptionInterface
 {
     use HttpExceptionTrait;
 }

--- a/src/Core/src/RequestContext.php
+++ b/src/Core/src/RequestContext.php
@@ -18,6 +18,7 @@ class RequestContext
         'operation' => true,
         'expirationDate' => true,
         'currentDate' => true,
+        'exceptionMapping' => true,
     ];
 
     /**
@@ -41,11 +42,17 @@ class RequestContext
     private $currentDate;
 
     /**
+     * @var array<string, string>
+     */
+    private $exceptionMapping = [];
+
+    /**
      * @param array{
      *  operation?: null|string
      *  region?: null|string
      *  expirationDate?: null|\DateTimeImmutable
      *  currentDate?: null|\DateTimeImmutable
+     *  exceptionMapping?: string[]
      * }
      */
     public function __construct(array $options = [])
@@ -77,5 +84,10 @@ class RequestContext
     public function getCurrentDate(): ?\DateTimeImmutable
     {
         return $this->currentDate;
+    }
+
+    public function getExceptionMapping(): array
+    {
+        return $this->exceptionMapping;
     }
 }

--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -415,9 +415,13 @@ class Response
         if (\is_callable($this->resolveResult)) {
             /** @psalm-suppress PropertyTypeCoercion */
             $this->resolveResult = ($this->resolveResult)();
-            if ($this->resolveResult instanceof HttpException && isset($this->exceptionMapping[$this->resolveResult->getAwsCode()])) {
-                $class = $this->exceptionMapping[$this->resolveResult->getAwsCode()];
-                $this->resolveResult = new $class($this->httpResponse);
+            if ($this->resolveResult instanceof HttpException) {
+                $awsCode = $this->resolveResult->getAwsCode();
+                if (isset($this->exceptionMapping[$awsCode])) {
+                    $class = $this->exceptionMapping[$awsCode];
+                    /** @psalm-suppress PropertyTypeCoercion */
+                    $this->resolveResult = new $class($this->httpResponse);
+                }
             }
         }
 

--- a/src/Core/src/Result.php
+++ b/src/Core/src/Result.php
@@ -30,6 +30,11 @@ class Result
     private $response;
 
     /**
+     * @var array<string, string>
+     */
+    private $exceptionMapping;
+
+    /**
      * @var self[]
      */
     private $prefetchResults = [];

--- a/src/Core/src/Sts/Exception/ExpiredTokenException.php
+++ b/src/Core/src/Sts/Exception/ExpiredTokenException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AsyncAws\Core\Sts\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The web identity token that was passed is expired or is not valid. Get a new identity token from the identity
+ * provider and then retry the request.
+ */
+final class ExpiredTokenException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Core/src/Sts/Exception/IDPCommunicationErrorException.php
+++ b/src/Core/src/Sts/Exception/IDPCommunicationErrorException.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AsyncAws\Core\Sts\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request could not be fulfilled because the identity provider (IDP) that was asked to verify the incoming identity
+ * token could not be reached. This is often a transient error caused by network conditions. Retry the request a limited
+ * number of times so that you don't exceed the request rate. If the error persists, the identity provider might be down
+ * or not responding.
+ */
+final class IDPCommunicationErrorException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Core/src/Sts/Exception/IDPRejectedClaimException.php
+++ b/src/Core/src/Sts/Exception/IDPRejectedClaimException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace AsyncAws\Core\Sts\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The identity provider (IdP) reported that authentication failed. This might be because the claim is invalid.
+ * If this error is returned for the `AssumeRoleWithWebIdentity` operation, it can also mean that the claim has expired
+ * or has been explicitly revoked.
+ */
+final class IDPRejectedClaimException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Core/src/Sts/Exception/InvalidIdentityTokenException.php
+++ b/src/Core/src/Sts/Exception/InvalidIdentityTokenException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AsyncAws\Core\Sts\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The web identity token that was passed could not be validated by AWS. Get a new identity token from the identity
+ * provider and then retry the request.
+ */
+final class InvalidIdentityTokenException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Core/src/Sts/Exception/MalformedPolicyDocumentException.php
+++ b/src/Core/src/Sts/Exception/MalformedPolicyDocumentException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Core\Sts\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request was rejected because the policy document was malformed. The error message describes the specific error.
+ */
+final class MalformedPolicyDocumentException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Core/src/Sts/Exception/PackedPolicyTooLargeException.php
+++ b/src/Core/src/Sts/Exception/PackedPolicyTooLargeException.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace AsyncAws\Core\Sts\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request was rejected because the total packed size of the session policies and session tags combined was too
+ * large. An AWS conversion compresses the session policy document, session policy ARNs, and session tags into a packed
+ * binary format that has a separate limit. The error message indicates by percentage how close the policies and tags
+ * are to the upper size limit. For more information, see Passing Session Tags in STS in the *IAM User Guide*.
+ * You could receive this error even though you meet other defined session policy and session tag limits. For more
+ * information, see IAM and STS Entity Character Limits in the *IAM User Guide*.
+ *
+ * @see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_session-tags.html
+ * @see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html
+ */
+final class PackedPolicyTooLargeException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Core/src/Sts/Exception/RegionDisabledException.php
+++ b/src/Core/src/Sts/Exception/RegionDisabledException.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace AsyncAws\Core\Sts\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * STS is not activated in the requested region for the account that is being asked to generate credentials. The account
+ * administrator must use the IAM console to activate STS in that region. For more information, see Activating and
+ * Deactivating AWS STS in an AWS Region in the *IAM User Guide*.
+ *
+ * @see https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_enable-regions.html
+ */
+final class RegionDisabledException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Core/src/Sts/StsClient.php
+++ b/src/Core/src/Sts/StsClient.php
@@ -6,6 +6,13 @@ use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
 use AsyncAws\Core\AwsError\XmlAwsErrorFactory;
 use AsyncAws\Core\RequestContext;
+use AsyncAws\Core\Sts\Exception\ExpiredTokenException;
+use AsyncAws\Core\Sts\Exception\IDPCommunicationErrorException;
+use AsyncAws\Core\Sts\Exception\IDPRejectedClaimException;
+use AsyncAws\Core\Sts\Exception\InvalidIdentityTokenException;
+use AsyncAws\Core\Sts\Exception\MalformedPolicyDocumentException;
+use AsyncAws\Core\Sts\Exception\PackedPolicyTooLargeException;
+use AsyncAws\Core\Sts\Exception\RegionDisabledException;
 use AsyncAws\Core\Sts\Input\AssumeRoleRequest;
 use AsyncAws\Core\Sts\Input\AssumeRoleWithWebIdentityRequest;
 use AsyncAws\Core\Sts\Input\GetCallerIdentityRequest;
@@ -42,11 +49,21 @@ class StsClient extends AbstractApi
      *   TokenCode?: string,
      *   @region?: string,
      * }|AssumeRoleRequest $input
+     *
+     * @throws MalformedPolicyDocumentException
+     * @throws PackedPolicyTooLargeException
+     * @throws RegionDisabledException
+     * @throws ExpiredTokenException
      */
     public function assumeRole($input): AssumeRoleResponse
     {
         $input = AssumeRoleRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AssumeRole', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AssumeRole', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'MalformedPolicyDocument' => MalformedPolicyDocumentException::class,
+            'PackedPolicyTooLarge' => PackedPolicyTooLargeException::class,
+            'RegionDisabledException' => RegionDisabledException::class,
+            'ExpiredTokenException' => ExpiredTokenException::class,
+        ]]));
 
         return new AssumeRoleResponse($response);
     }
@@ -69,11 +86,27 @@ class StsClient extends AbstractApi
      *   DurationSeconds?: int,
      *   @region?: string,
      * }|AssumeRoleWithWebIdentityRequest $input
+     *
+     * @throws MalformedPolicyDocumentException
+     * @throws PackedPolicyTooLargeException
+     * @throws IDPRejectedClaimException
+     * @throws IDPCommunicationErrorException
+     * @throws InvalidIdentityTokenException
+     * @throws ExpiredTokenException
+     * @throws RegionDisabledException
      */
     public function assumeRoleWithWebIdentity($input): AssumeRoleWithWebIdentityResponse
     {
         $input = AssumeRoleWithWebIdentityRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AssumeRoleWithWebIdentity', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AssumeRoleWithWebIdentity', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'MalformedPolicyDocument' => MalformedPolicyDocumentException::class,
+            'PackedPolicyTooLarge' => PackedPolicyTooLargeException::class,
+            'IDPRejectedClaim' => IDPRejectedClaimException::class,
+            'IDPCommunicationError' => IDPCommunicationErrorException::class,
+            'InvalidIdentityToken' => InvalidIdentityTokenException::class,
+            'ExpiredTokenException' => ExpiredTokenException::class,
+            'RegionDisabledException' => RegionDisabledException::class,
+        ]]));
 
         return new AssumeRoleWithWebIdentityResponse($response);
     }

--- a/src/Service/CloudFront/CHANGELOG.md
+++ b/src/Service/CloudFront/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Changed case of object's properties to camelCase.
 - Added documentation in class's headers.
+- Added Business Exceptions.
 
 ## 0.1.1
 

--- a/src/Service/CloudFront/composer.json
+++ b/src/Service/CloudFront/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-SimpleXML": "*",
-        "async-aws/core": "^1.2"
+        "async-aws/core": "^1.9"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/CloudFront/src/CloudFrontClient.php
+++ b/src/Service/CloudFront/src/CloudFrontClient.php
@@ -2,6 +2,13 @@
 
 namespace AsyncAws\CloudFront;
 
+use AsyncAws\CloudFront\Exception\AccessDeniedException;
+use AsyncAws\CloudFront\Exception\BatchTooLargeException;
+use AsyncAws\CloudFront\Exception\InconsistentQuantitiesException;
+use AsyncAws\CloudFront\Exception\InvalidArgumentException;
+use AsyncAws\CloudFront\Exception\MissingBodyException;
+use AsyncAws\CloudFront\Exception\NoSuchDistributionException;
+use AsyncAws\CloudFront\Exception\TooManyInvalidationsInProgressException;
 use AsyncAws\CloudFront\Input\CreateInvalidationRequest;
 use AsyncAws\CloudFront\Result\CreateInvalidationResult;
 use AsyncAws\CloudFront\ValueObject\InvalidationBatch;
@@ -23,11 +30,27 @@ class CloudFrontClient extends AbstractApi
      *   InvalidationBatch: InvalidationBatch|array,
      *   @region?: string,
      * }|CreateInvalidationRequest $input
+     *
+     * @throws AccessDeniedException
+     * @throws MissingBodyException
+     * @throws InvalidArgumentException
+     * @throws NoSuchDistributionException
+     * @throws BatchTooLargeException
+     * @throws TooManyInvalidationsInProgressException
+     * @throws InconsistentQuantitiesException
      */
     public function createInvalidation($input): CreateInvalidationResult
     {
         $input = CreateInvalidationRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateInvalidation2019_03_26', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateInvalidation2019_03_26', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'AccessDenied' => 'AsyncAws\\CloudFront\\Exception\\AccessDeniedException',
+            'MissingBody' => 'AsyncAws\\CloudFront\\Exception\\MissingBodyException',
+            'InvalidArgument' => 'AsyncAws\\CloudFront\\Exception\\InvalidArgumentException',
+            'NoSuchDistribution' => 'AsyncAws\\CloudFront\\Exception\\NoSuchDistributionException',
+            'BatchTooLarge' => 'AsyncAws\\CloudFront\\Exception\\BatchTooLargeException',
+            'TooManyInvalidationsInProgress' => 'AsyncAws\\CloudFront\\Exception\\TooManyInvalidationsInProgressException',
+            'InconsistentQuantities' => 'AsyncAws\\CloudFront\\Exception\\InconsistentQuantitiesException',
+        ]]));
 
         return new CreateInvalidationResult($response);
     }

--- a/src/Service/CloudFront/src/CloudFrontClient.php
+++ b/src/Service/CloudFront/src/CloudFrontClient.php
@@ -43,13 +43,13 @@ class CloudFrontClient extends AbstractApi
     {
         $input = CreateInvalidationRequest::create($input);
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateInvalidation2019_03_26', 'region' => $input->getRegion(), 'exceptionMapping' => [
-            'AccessDenied' => 'AsyncAws\\CloudFront\\Exception\\AccessDeniedException',
-            'MissingBody' => 'AsyncAws\\CloudFront\\Exception\\MissingBodyException',
-            'InvalidArgument' => 'AsyncAws\\CloudFront\\Exception\\InvalidArgumentException',
-            'NoSuchDistribution' => 'AsyncAws\\CloudFront\\Exception\\NoSuchDistributionException',
-            'BatchTooLarge' => 'AsyncAws\\CloudFront\\Exception\\BatchTooLargeException',
-            'TooManyInvalidationsInProgress' => 'AsyncAws\\CloudFront\\Exception\\TooManyInvalidationsInProgressException',
-            'InconsistentQuantities' => 'AsyncAws\\CloudFront\\Exception\\InconsistentQuantitiesException',
+            'AccessDenied' => AccessDeniedException::class,
+            'MissingBody' => MissingBodyException::class,
+            'InvalidArgument' => InvalidArgumentException::class,
+            'NoSuchDistribution' => NoSuchDistributionException::class,
+            'BatchTooLarge' => BatchTooLargeException::class,
+            'TooManyInvalidationsInProgress' => TooManyInvalidationsInProgressException::class,
+            'InconsistentQuantities' => InconsistentQuantitiesException::class,
         ]]));
 
         return new CreateInvalidationResult($response);

--- a/src/Service/CloudFront/src/Exception/AccessDeniedException.php
+++ b/src/Service/CloudFront/src/Exception/AccessDeniedException.php
@@ -2,7 +2,6 @@
 
 namespace AsyncAws\CloudFront\Exception;
 
-use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -11,13 +10,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class AccessDeniedException extends ClientException
 {
-    public function __construct(ResponseInterface $response, ?AwsError $awsError)
-    {
-        parent::__construct($response, $awsError);
-        $this->populateResult($response);
-    }
-
-    private function populateResult(ResponseInterface $response): void
+    protected function populateResult(ResponseInterface $response): void
     {
         $data = new \SimpleXMLElement($response->getContent(false));
         if (0 < $data->Error->count()) {

--- a/src/Service/CloudFront/src/Exception/AccessDeniedException.php
+++ b/src/Service/CloudFront/src/Exception/AccessDeniedException.php
@@ -17,7 +17,7 @@ final class AccessDeniedException extends ClientException
         $this->populateResult($response);
     }
 
-    protected function populateResult(ResponseInterface $response): void
+    private function populateResult(ResponseInterface $response): void
     {
         $data = new \SimpleXMLElement($response->getContent(false));
         if (0 < $data->Error->count()) {

--- a/src/Service/CloudFront/src/Exception/AccessDeniedException.php
+++ b/src/Service/CloudFront/src/Exception/AccessDeniedException.php
@@ -5,6 +5,9 @@ namespace AsyncAws\CloudFront\Exception;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
+/**
+ * Access denied.
+ */
 final class AccessDeniedException extends ClientException
 {
     public function __construct(ResponseInterface $response)
@@ -19,6 +22,8 @@ final class AccessDeniedException extends ClientException
         if (0 < $data->Error->count()) {
             $data = $data->Error;
         }
-        $this->message = ($v = $data->Message) ? (string) $v : null;
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
     }
 }

--- a/src/Service/CloudFront/src/Exception/AccessDeniedException.php
+++ b/src/Service/CloudFront/src/Exception/AccessDeniedException.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\CloudFront\Exception;
 
+use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -10,9 +11,9 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class AccessDeniedException extends ClientException
 {
-    public function __construct(ResponseInterface $response)
+    public function __construct(ResponseInterface $response, ?AwsError $awsError)
     {
-        parent::__construct($response);
+        parent::__construct($response, $awsError);
         $this->populateResult($response);
     }
 

--- a/src/Service/CloudFront/src/Exception/AccessDeniedException.php
+++ b/src/Service/CloudFront/src/Exception/AccessDeniedException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AsyncAws\CloudFront\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class AccessDeniedException extends ClientException
+{
+    public function __construct(ResponseInterface $response)
+    {
+        parent::__construct($response);
+        $this->populateResult($response);
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        $this->message = ($v = $data->Message) ? (string) $v : null;
+    }
+}

--- a/src/Service/CloudFront/src/Exception/BatchTooLargeException.php
+++ b/src/Service/CloudFront/src/Exception/BatchTooLargeException.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\CloudFront\Exception;
 
+use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -10,9 +11,9 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class BatchTooLargeException extends ClientException
 {
-    public function __construct(ResponseInterface $response)
+    public function __construct(ResponseInterface $response, ?AwsError $awsError)
     {
-        parent::__construct($response);
+        parent::__construct($response, $awsError);
         $this->populateResult($response);
     }
 

--- a/src/Service/CloudFront/src/Exception/BatchTooLargeException.php
+++ b/src/Service/CloudFront/src/Exception/BatchTooLargeException.php
@@ -2,7 +2,6 @@
 
 namespace AsyncAws\CloudFront\Exception;
 
-use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -11,13 +10,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class BatchTooLargeException extends ClientException
 {
-    public function __construct(ResponseInterface $response, ?AwsError $awsError)
-    {
-        parent::__construct($response, $awsError);
-        $this->populateResult($response);
-    }
-
-    private function populateResult(ResponseInterface $response): void
+    protected function populateResult(ResponseInterface $response): void
     {
         $data = new \SimpleXMLElement($response->getContent(false));
         if (0 < $data->Error->count()) {

--- a/src/Service/CloudFront/src/Exception/BatchTooLargeException.php
+++ b/src/Service/CloudFront/src/Exception/BatchTooLargeException.php
@@ -5,6 +5,9 @@ namespace AsyncAws\CloudFront\Exception;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
+/**
+ * Invalidation batch specified is too large.
+ */
 final class BatchTooLargeException extends ClientException
 {
     public function __construct(ResponseInterface $response)
@@ -19,6 +22,8 @@ final class BatchTooLargeException extends ClientException
         if (0 < $data->Error->count()) {
             $data = $data->Error;
         }
-        $this->message = ($v = $data->Message) ? (string) $v : null;
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
     }
 }

--- a/src/Service/CloudFront/src/Exception/BatchTooLargeException.php
+++ b/src/Service/CloudFront/src/Exception/BatchTooLargeException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AsyncAws\CloudFront\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class BatchTooLargeException extends ClientException
+{
+    public function __construct(ResponseInterface $response)
+    {
+        parent::__construct($response);
+        $this->populateResult($response);
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        $this->message = ($v = $data->Message) ? (string) $v : null;
+    }
+}

--- a/src/Service/CloudFront/src/Exception/BatchTooLargeException.php
+++ b/src/Service/CloudFront/src/Exception/BatchTooLargeException.php
@@ -17,7 +17,7 @@ final class BatchTooLargeException extends ClientException
         $this->populateResult($response);
     }
 
-    protected function populateResult(ResponseInterface $response): void
+    private function populateResult(ResponseInterface $response): void
     {
         $data = new \SimpleXMLElement($response->getContent(false));
         if (0 < $data->Error->count()) {

--- a/src/Service/CloudFront/src/Exception/InconsistentQuantitiesException.php
+++ b/src/Service/CloudFront/src/Exception/InconsistentQuantitiesException.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\CloudFront\Exception;
 
+use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -10,9 +11,9 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class InconsistentQuantitiesException extends ClientException
 {
-    public function __construct(ResponseInterface $response)
+    public function __construct(ResponseInterface $response, ?AwsError $awsError)
     {
-        parent::__construct($response);
+        parent::__construct($response, $awsError);
         $this->populateResult($response);
     }
 

--- a/src/Service/CloudFront/src/Exception/InconsistentQuantitiesException.php
+++ b/src/Service/CloudFront/src/Exception/InconsistentQuantitiesException.php
@@ -17,7 +17,7 @@ final class InconsistentQuantitiesException extends ClientException
         $this->populateResult($response);
     }
 
-    protected function populateResult(ResponseInterface $response): void
+    private function populateResult(ResponseInterface $response): void
     {
         $data = new \SimpleXMLElement($response->getContent(false));
         if (0 < $data->Error->count()) {

--- a/src/Service/CloudFront/src/Exception/InconsistentQuantitiesException.php
+++ b/src/Service/CloudFront/src/Exception/InconsistentQuantitiesException.php
@@ -5,6 +5,9 @@ namespace AsyncAws\CloudFront\Exception;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
+/**
+ * The value of `Quantity` and the size of `Items` don't match.
+ */
 final class InconsistentQuantitiesException extends ClientException
 {
     public function __construct(ResponseInterface $response)
@@ -19,6 +22,8 @@ final class InconsistentQuantitiesException extends ClientException
         if (0 < $data->Error->count()) {
             $data = $data->Error;
         }
-        $this->message = ($v = $data->Message) ? (string) $v : null;
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
     }
 }

--- a/src/Service/CloudFront/src/Exception/InconsistentQuantitiesException.php
+++ b/src/Service/CloudFront/src/Exception/InconsistentQuantitiesException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AsyncAws\CloudFront\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class InconsistentQuantitiesException extends ClientException
+{
+    public function __construct(ResponseInterface $response)
+    {
+        parent::__construct($response);
+        $this->populateResult($response);
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        $this->message = ($v = $data->Message) ? (string) $v : null;
+    }
+}

--- a/src/Service/CloudFront/src/Exception/InconsistentQuantitiesException.php
+++ b/src/Service/CloudFront/src/Exception/InconsistentQuantitiesException.php
@@ -2,7 +2,6 @@
 
 namespace AsyncAws\CloudFront\Exception;
 
-use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -11,13 +10,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class InconsistentQuantitiesException extends ClientException
 {
-    public function __construct(ResponseInterface $response, ?AwsError $awsError)
-    {
-        parent::__construct($response, $awsError);
-        $this->populateResult($response);
-    }
-
-    private function populateResult(ResponseInterface $response): void
+    protected function populateResult(ResponseInterface $response): void
     {
         $data = new \SimpleXMLElement($response->getContent(false));
         if (0 < $data->Error->count()) {

--- a/src/Service/CloudFront/src/Exception/InvalidArgumentException.php
+++ b/src/Service/CloudFront/src/Exception/InvalidArgumentException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AsyncAws\CloudFront\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class InvalidArgumentException extends ClientException
+{
+    public function __construct(ResponseInterface $response)
+    {
+        parent::__construct($response);
+        $this->populateResult($response);
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        $this->message = ($v = $data->Message) ? (string) $v : null;
+    }
+}

--- a/src/Service/CloudFront/src/Exception/InvalidArgumentException.php
+++ b/src/Service/CloudFront/src/Exception/InvalidArgumentException.php
@@ -5,6 +5,9 @@ namespace AsyncAws\CloudFront\Exception;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
+/**
+ * An argument is invalid.
+ */
 final class InvalidArgumentException extends ClientException
 {
     public function __construct(ResponseInterface $response)
@@ -19,6 +22,8 @@ final class InvalidArgumentException extends ClientException
         if (0 < $data->Error->count()) {
             $data = $data->Error;
         }
-        $this->message = ($v = $data->Message) ? (string) $v : null;
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
     }
 }

--- a/src/Service/CloudFront/src/Exception/InvalidArgumentException.php
+++ b/src/Service/CloudFront/src/Exception/InvalidArgumentException.php
@@ -17,7 +17,7 @@ final class InvalidArgumentException extends ClientException
         $this->populateResult($response);
     }
 
-    protected function populateResult(ResponseInterface $response): void
+    private function populateResult(ResponseInterface $response): void
     {
         $data = new \SimpleXMLElement($response->getContent(false));
         if (0 < $data->Error->count()) {

--- a/src/Service/CloudFront/src/Exception/InvalidArgumentException.php
+++ b/src/Service/CloudFront/src/Exception/InvalidArgumentException.php
@@ -2,7 +2,6 @@
 
 namespace AsyncAws\CloudFront\Exception;
 
-use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -11,13 +10,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class InvalidArgumentException extends ClientException
 {
-    public function __construct(ResponseInterface $response, ?AwsError $awsError)
-    {
-        parent::__construct($response, $awsError);
-        $this->populateResult($response);
-    }
-
-    private function populateResult(ResponseInterface $response): void
+    protected function populateResult(ResponseInterface $response): void
     {
         $data = new \SimpleXMLElement($response->getContent(false));
         if (0 < $data->Error->count()) {

--- a/src/Service/CloudFront/src/Exception/InvalidArgumentException.php
+++ b/src/Service/CloudFront/src/Exception/InvalidArgumentException.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\CloudFront\Exception;
 
+use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -10,9 +11,9 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class InvalidArgumentException extends ClientException
 {
-    public function __construct(ResponseInterface $response)
+    public function __construct(ResponseInterface $response, ?AwsError $awsError)
     {
-        parent::__construct($response);
+        parent::__construct($response, $awsError);
         $this->populateResult($response);
     }
 

--- a/src/Service/CloudFront/src/Exception/MissingBodyException.php
+++ b/src/Service/CloudFront/src/Exception/MissingBodyException.php
@@ -5,6 +5,9 @@ namespace AsyncAws\CloudFront\Exception;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
+/**
+ * This operation requires a body. Ensure that the body is present and the `Content-Type` header is set.
+ */
 final class MissingBodyException extends ClientException
 {
     public function __construct(ResponseInterface $response)
@@ -19,6 +22,8 @@ final class MissingBodyException extends ClientException
         if (0 < $data->Error->count()) {
             $data = $data->Error;
         }
-        $this->message = ($v = $data->Message) ? (string) $v : null;
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
     }
 }

--- a/src/Service/CloudFront/src/Exception/MissingBodyException.php
+++ b/src/Service/CloudFront/src/Exception/MissingBodyException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AsyncAws\CloudFront\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class MissingBodyException extends ClientException
+{
+    public function __construct(ResponseInterface $response)
+    {
+        parent::__construct($response);
+        $this->populateResult($response);
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        $this->message = ($v = $data->Message) ? (string) $v : null;
+    }
+}

--- a/src/Service/CloudFront/src/Exception/MissingBodyException.php
+++ b/src/Service/CloudFront/src/Exception/MissingBodyException.php
@@ -2,7 +2,6 @@
 
 namespace AsyncAws\CloudFront\Exception;
 
-use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -11,13 +10,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class MissingBodyException extends ClientException
 {
-    public function __construct(ResponseInterface $response, ?AwsError $awsError)
-    {
-        parent::__construct($response, $awsError);
-        $this->populateResult($response);
-    }
-
-    private function populateResult(ResponseInterface $response): void
+    protected function populateResult(ResponseInterface $response): void
     {
         $data = new \SimpleXMLElement($response->getContent(false));
         if (0 < $data->Error->count()) {

--- a/src/Service/CloudFront/src/Exception/MissingBodyException.php
+++ b/src/Service/CloudFront/src/Exception/MissingBodyException.php
@@ -17,7 +17,7 @@ final class MissingBodyException extends ClientException
         $this->populateResult($response);
     }
 
-    protected function populateResult(ResponseInterface $response): void
+    private function populateResult(ResponseInterface $response): void
     {
         $data = new \SimpleXMLElement($response->getContent(false));
         if (0 < $data->Error->count()) {

--- a/src/Service/CloudFront/src/Exception/MissingBodyException.php
+++ b/src/Service/CloudFront/src/Exception/MissingBodyException.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\CloudFront\Exception;
 
+use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -10,9 +11,9 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class MissingBodyException extends ClientException
 {
-    public function __construct(ResponseInterface $response)
+    public function __construct(ResponseInterface $response, ?AwsError $awsError)
     {
-        parent::__construct($response);
+        parent::__construct($response, $awsError);
         $this->populateResult($response);
     }
 

--- a/src/Service/CloudFront/src/Exception/NoSuchDistributionException.php
+++ b/src/Service/CloudFront/src/Exception/NoSuchDistributionException.php
@@ -2,7 +2,6 @@
 
 namespace AsyncAws\CloudFront\Exception;
 
-use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -11,13 +10,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class NoSuchDistributionException extends ClientException
 {
-    public function __construct(ResponseInterface $response, ?AwsError $awsError)
-    {
-        parent::__construct($response, $awsError);
-        $this->populateResult($response);
-    }
-
-    private function populateResult(ResponseInterface $response): void
+    protected function populateResult(ResponseInterface $response): void
     {
         $data = new \SimpleXMLElement($response->getContent(false));
         if (0 < $data->Error->count()) {

--- a/src/Service/CloudFront/src/Exception/NoSuchDistributionException.php
+++ b/src/Service/CloudFront/src/Exception/NoSuchDistributionException.php
@@ -5,6 +5,9 @@ namespace AsyncAws\CloudFront\Exception;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
+/**
+ * The specified distribution does not exist.
+ */
 final class NoSuchDistributionException extends ClientException
 {
     public function __construct(ResponseInterface $response)
@@ -19,6 +22,8 @@ final class NoSuchDistributionException extends ClientException
         if (0 < $data->Error->count()) {
             $data = $data->Error;
         }
-        $this->message = ($v = $data->Message) ? (string) $v : null;
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
     }
 }

--- a/src/Service/CloudFront/src/Exception/NoSuchDistributionException.php
+++ b/src/Service/CloudFront/src/Exception/NoSuchDistributionException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AsyncAws\CloudFront\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class NoSuchDistributionException extends ClientException
+{
+    public function __construct(ResponseInterface $response)
+    {
+        parent::__construct($response);
+        $this->populateResult($response);
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        $this->message = ($v = $data->Message) ? (string) $v : null;
+    }
+}

--- a/src/Service/CloudFront/src/Exception/NoSuchDistributionException.php
+++ b/src/Service/CloudFront/src/Exception/NoSuchDistributionException.php
@@ -17,7 +17,7 @@ final class NoSuchDistributionException extends ClientException
         $this->populateResult($response);
     }
 
-    protected function populateResult(ResponseInterface $response): void
+    private function populateResult(ResponseInterface $response): void
     {
         $data = new \SimpleXMLElement($response->getContent(false));
         if (0 < $data->Error->count()) {

--- a/src/Service/CloudFront/src/Exception/NoSuchDistributionException.php
+++ b/src/Service/CloudFront/src/Exception/NoSuchDistributionException.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\CloudFront\Exception;
 
+use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -10,9 +11,9 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class NoSuchDistributionException extends ClientException
 {
-    public function __construct(ResponseInterface $response)
+    public function __construct(ResponseInterface $response, ?AwsError $awsError)
     {
-        parent::__construct($response);
+        parent::__construct($response, $awsError);
         $this->populateResult($response);
     }
 

--- a/src/Service/CloudFront/src/Exception/TooManyInvalidationsInProgressException.php
+++ b/src/Service/CloudFront/src/Exception/TooManyInvalidationsInProgressException.php
@@ -5,6 +5,9 @@ namespace AsyncAws\CloudFront\Exception;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
+/**
+ * You have exceeded the maximum number of allowable InProgress invalidation batch requests, or invalidation objects.
+ */
 final class TooManyInvalidationsInProgressException extends ClientException
 {
     public function __construct(ResponseInterface $response)
@@ -19,6 +22,8 @@ final class TooManyInvalidationsInProgressException extends ClientException
         if (0 < $data->Error->count()) {
             $data = $data->Error;
         }
-        $this->message = ($v = $data->Message) ? (string) $v : null;
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
     }
 }

--- a/src/Service/CloudFront/src/Exception/TooManyInvalidationsInProgressException.php
+++ b/src/Service/CloudFront/src/Exception/TooManyInvalidationsInProgressException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AsyncAws\CloudFront\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class TooManyInvalidationsInProgressException extends ClientException
+{
+    public function __construct(ResponseInterface $response)
+    {
+        parent::__construct($response);
+        $this->populateResult($response);
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        $this->message = ($v = $data->Message) ? (string) $v : null;
+    }
+}

--- a/src/Service/CloudFront/src/Exception/TooManyInvalidationsInProgressException.php
+++ b/src/Service/CloudFront/src/Exception/TooManyInvalidationsInProgressException.php
@@ -17,7 +17,7 @@ final class TooManyInvalidationsInProgressException extends ClientException
         $this->populateResult($response);
     }
 
-    protected function populateResult(ResponseInterface $response): void
+    private function populateResult(ResponseInterface $response): void
     {
         $data = new \SimpleXMLElement($response->getContent(false));
         if (0 < $data->Error->count()) {

--- a/src/Service/CloudFront/src/Exception/TooManyInvalidationsInProgressException.php
+++ b/src/Service/CloudFront/src/Exception/TooManyInvalidationsInProgressException.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\CloudFront\Exception;
 
+use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -10,9 +11,9 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class TooManyInvalidationsInProgressException extends ClientException
 {
-    public function __construct(ResponseInterface $response)
+    public function __construct(ResponseInterface $response, ?AwsError $awsError)
     {
-        parent::__construct($response);
+        parent::__construct($response, $awsError);
         $this->populateResult($response);
     }
 

--- a/src/Service/CloudFront/src/Exception/TooManyInvalidationsInProgressException.php
+++ b/src/Service/CloudFront/src/Exception/TooManyInvalidationsInProgressException.php
@@ -2,7 +2,6 @@
 
 namespace AsyncAws\CloudFront\Exception;
 
-use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -11,13 +10,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class TooManyInvalidationsInProgressException extends ClientException
 {
-    public function __construct(ResponseInterface $response, ?AwsError $awsError)
-    {
-        parent::__construct($response, $awsError);
-        $this->populateResult($response);
-    }
-
-    private function populateResult(ResponseInterface $response): void
+    protected function populateResult(ResponseInterface $response): void
     {
         $data = new \SimpleXMLElement($response->getContent(false));
         if (0 < $data->Error->count()) {

--- a/src/Service/CloudWatchLogs/CHANGELOG.md
+++ b/src/Service/CloudWatchLogs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Changed case of object's properties to camelCase.
 - Added documentation in class's headers.
+- Added Business Exceptions.
 
 ## 1.0.2
 

--- a/src/Service/CloudWatchLogs/composer.json
+++ b/src/Service/CloudWatchLogs/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
-        "async-aws/core": "^1.2"
+        "async-aws/core": "^1.9"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
+++ b/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
@@ -72,12 +72,12 @@ class CloudWatchLogsClient extends AbstractApi
     {
         $input = PutLogEventsRequest::create($input);
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PutLogEvents', 'region' => $input->getRegion(), 'exceptionMapping' => [
-            'InvalidParameterException' => 'AsyncAws\\CloudWatchLogs\\Exception\\InvalidParameterException',
-            'InvalidSequenceTokenException' => 'AsyncAws\\CloudWatchLogs\\Exception\\InvalidSequenceTokenException',
-            'DataAlreadyAcceptedException' => 'AsyncAws\\CloudWatchLogs\\Exception\\DataAlreadyAcceptedException',
-            'ResourceNotFoundException' => 'AsyncAws\\CloudWatchLogs\\Exception\\ResourceNotFoundException',
-            'ServiceUnavailableException' => 'AsyncAws\\CloudWatchLogs\\Exception\\ServiceUnavailableException',
-            'UnrecognizedClientException' => 'AsyncAws\\CloudWatchLogs\\Exception\\UnrecognizedClientException',
+            'InvalidParameterException' => InvalidParameterException::class,
+            'InvalidSequenceTokenException' => InvalidSequenceTokenException::class,
+            'DataAlreadyAcceptedException' => DataAlreadyAcceptedException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'ServiceUnavailableException' => ServiceUnavailableException::class,
+            'UnrecognizedClientException' => UnrecognizedClientException::class,
         ]]));
 
         return new PutLogEventsResponse($response);

--- a/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
+++ b/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
@@ -3,6 +3,12 @@
 namespace AsyncAws\CloudWatchLogs;
 
 use AsyncAws\CloudWatchLogs\Enum\OrderBy;
+use AsyncAws\CloudWatchLogs\Exception\DataAlreadyAcceptedException;
+use AsyncAws\CloudWatchLogs\Exception\InvalidParameterException;
+use AsyncAws\CloudWatchLogs\Exception\InvalidSequenceTokenException;
+use AsyncAws\CloudWatchLogs\Exception\ResourceNotFoundException;
+use AsyncAws\CloudWatchLogs\Exception\ServiceUnavailableException;
+use AsyncAws\CloudWatchLogs\Exception\UnrecognizedClientException;
 use AsyncAws\CloudWatchLogs\Input\DescribeLogStreamsRequest;
 use AsyncAws\CloudWatchLogs\Input\PutLogEventsRequest;
 use AsyncAws\CloudWatchLogs\Result\DescribeLogStreamsResponse;
@@ -54,11 +60,25 @@ class CloudWatchLogsClient extends AbstractApi
      *   sequenceToken?: string,
      *   @region?: string,
      * }|PutLogEventsRequest $input
+     *
+     * @throws InvalidParameterException
+     * @throws InvalidSequenceTokenException
+     * @throws DataAlreadyAcceptedException
+     * @throws ResourceNotFoundException
+     * @throws ServiceUnavailableException
+     * @throws UnrecognizedClientException
      */
     public function putLogEvents($input): PutLogEventsResponse
     {
         $input = PutLogEventsRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PutLogEvents', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PutLogEvents', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidParameterException' => 'AsyncAws\\CloudWatchLogs\\Exception\\InvalidParameterException',
+            'InvalidSequenceTokenException' => 'AsyncAws\\CloudWatchLogs\\Exception\\InvalidSequenceTokenException',
+            'DataAlreadyAcceptedException' => 'AsyncAws\\CloudWatchLogs\\Exception\\DataAlreadyAcceptedException',
+            'ResourceNotFoundException' => 'AsyncAws\\CloudWatchLogs\\Exception\\ResourceNotFoundException',
+            'ServiceUnavailableException' => 'AsyncAws\\CloudWatchLogs\\Exception\\ServiceUnavailableException',
+            'UnrecognizedClientException' => 'AsyncAws\\CloudWatchLogs\\Exception\\UnrecognizedClientException',
+        ]]));
 
         return new PutLogEventsResponse($response);
     }

--- a/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
+++ b/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
@@ -38,11 +38,19 @@ class CloudWatchLogsClient extends AbstractApi
      *   limit?: int,
      *   @region?: string,
      * }|DescribeLogStreamsRequest $input
+     *
+     * @throws InvalidParameterException
+     * @throws ResourceNotFoundException
+     * @throws ServiceUnavailableException
      */
     public function describeLogStreams($input): DescribeLogStreamsResponse
     {
         $input = DescribeLogStreamsRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DescribeLogStreams', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DescribeLogStreams', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidParameterException' => InvalidParameterException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'ServiceUnavailableException' => ServiceUnavailableException::class,
+        ]]));
 
         return new DescribeLogStreamsResponse($response, $this, $input);
     }

--- a/src/Service/CloudWatchLogs/src/Exception/DataAlreadyAcceptedException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/DataAlreadyAcceptedException.php
@@ -2,7 +2,6 @@
 
 namespace AsyncAws\CloudWatchLogs\Exception;
 
-use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -13,18 +12,12 @@ final class DataAlreadyAcceptedException extends ClientException
 {
     private $expectedSequenceToken;
 
-    public function __construct(ResponseInterface $response, ?AwsError $awsError)
-    {
-        parent::__construct($response, $awsError);
-        $this->populateResult($response);
-    }
-
     public function getExpectedSequenceToken(): ?string
     {
         return $this->expectedSequenceToken;
     }
 
-    private function populateResult(ResponseInterface $response): void
+    protected function populateResult(ResponseInterface $response): void
     {
         $data = $response->toArray(false);
 

--- a/src/Service/CloudWatchLogs/src/Exception/DataAlreadyAcceptedException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/DataAlreadyAcceptedException.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\CloudWatchLogs\Exception;
 
+use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -12,9 +13,9 @@ final class DataAlreadyAcceptedException extends ClientException
 {
     private $expectedSequenceToken;
 
-    public function __construct(ResponseInterface $response)
+    public function __construct(ResponseInterface $response, ?AwsError $awsError)
     {
-        parent::__construct($response);
+        parent::__construct($response, $awsError);
         $this->populateResult($response);
     }
 

--- a/src/Service/CloudWatchLogs/src/Exception/DataAlreadyAcceptedException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/DataAlreadyAcceptedException.php
@@ -5,6 +5,9 @@ namespace AsyncAws\CloudWatchLogs\Exception;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
+/**
+ * The event was already logged.
+ */
 final class DataAlreadyAcceptedException extends ClientException
 {
     private $expectedSequenceToken;

--- a/src/Service/CloudWatchLogs/src/Exception/DataAlreadyAcceptedException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/DataAlreadyAcceptedException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AsyncAws\CloudWatchLogs\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class DataAlreadyAcceptedException extends ClientException
+{
+    private $expectedSequenceToken;
+
+    public function __construct(ResponseInterface $response)
+    {
+        parent::__construct($response);
+        $this->populateResult($response);
+    }
+
+    public function getExpectedSequenceToken(): ?string
+    {
+        return $this->expectedSequenceToken;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->expectedSequenceToken = isset($data['expectedSequenceToken']) ? (string) $data['expectedSequenceToken'] : null;
+    }
+}

--- a/src/Service/CloudWatchLogs/src/Exception/DataAlreadyAcceptedException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/DataAlreadyAcceptedException.php
@@ -24,7 +24,7 @@ final class DataAlreadyAcceptedException extends ClientException
         return $this->expectedSequenceToken;
     }
 
-    protected function populateResult(ResponseInterface $response): void
+    private function populateResult(ResponseInterface $response): void
     {
         $data = $response->toArray(false);
 

--- a/src/Service/CloudWatchLogs/src/Exception/InvalidParameterException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/InvalidParameterException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace AsyncAws\CloudWatchLogs\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+final class InvalidParameterException extends ClientException
+{
+}

--- a/src/Service/CloudWatchLogs/src/Exception/InvalidParameterException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/InvalidParameterException.php
@@ -4,6 +4,9 @@ namespace AsyncAws\CloudWatchLogs\Exception;
 
 use AsyncAws\Core\Exception\Http\ClientException;
 
+/**
+ * A parameter is specified incorrectly.
+ */
 final class InvalidParameterException extends ClientException
 {
 }

--- a/src/Service/CloudWatchLogs/src/Exception/InvalidSequenceTokenException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/InvalidSequenceTokenException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AsyncAws\CloudWatchLogs\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+final class InvalidSequenceTokenException extends ClientException
+{
+    private $expectedSequenceToken;
+
+    public function __construct(ResponseInterface $response)
+    {
+        parent::__construct($response);
+        $this->populateResult($response);
+    }
+
+    public function getExpectedSequenceToken(): ?string
+    {
+        return $this->expectedSequenceToken;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->expectedSequenceToken = isset($data['expectedSequenceToken']) ? (string) $data['expectedSequenceToken'] : null;
+    }
+}

--- a/src/Service/CloudWatchLogs/src/Exception/InvalidSequenceTokenException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/InvalidSequenceTokenException.php
@@ -2,7 +2,6 @@
 
 namespace AsyncAws\CloudWatchLogs\Exception;
 
-use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -14,18 +13,12 @@ final class InvalidSequenceTokenException extends ClientException
 {
     private $expectedSequenceToken;
 
-    public function __construct(ResponseInterface $response, ?AwsError $awsError)
-    {
-        parent::__construct($response, $awsError);
-        $this->populateResult($response);
-    }
-
     public function getExpectedSequenceToken(): ?string
     {
         return $this->expectedSequenceToken;
     }
 
-    private function populateResult(ResponseInterface $response): void
+    protected function populateResult(ResponseInterface $response): void
     {
         $data = $response->toArray(false);
 

--- a/src/Service/CloudWatchLogs/src/Exception/InvalidSequenceTokenException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/InvalidSequenceTokenException.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\CloudWatchLogs\Exception;
 
+use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -13,9 +14,9 @@ final class InvalidSequenceTokenException extends ClientException
 {
     private $expectedSequenceToken;
 
-    public function __construct(ResponseInterface $response)
+    public function __construct(ResponseInterface $response, ?AwsError $awsError)
     {
-        parent::__construct($response);
+        parent::__construct($response, $awsError);
         $this->populateResult($response);
     }
 

--- a/src/Service/CloudWatchLogs/src/Exception/InvalidSequenceTokenException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/InvalidSequenceTokenException.php
@@ -5,6 +5,10 @@ namespace AsyncAws\CloudWatchLogs\Exception;
 use AsyncAws\Core\Exception\Http\ClientException;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
+/**
+ * The sequence token is not valid. You can get the correct sequence token in the `expectedSequenceToken` field in the
+ * `InvalidSequenceTokenException` message.
+ */
 final class InvalidSequenceTokenException extends ClientException
 {
     private $expectedSequenceToken;

--- a/src/Service/CloudWatchLogs/src/Exception/InvalidSequenceTokenException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/InvalidSequenceTokenException.php
@@ -25,7 +25,7 @@ final class InvalidSequenceTokenException extends ClientException
         return $this->expectedSequenceToken;
     }
 
-    protected function populateResult(ResponseInterface $response): void
+    private function populateResult(ResponseInterface $response): void
     {
         $data = $response->toArray(false);
 

--- a/src/Service/CloudWatchLogs/src/Exception/ResourceNotFoundException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/ResourceNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace AsyncAws\CloudWatchLogs\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+final class ResourceNotFoundException extends ClientException
+{
+}

--- a/src/Service/CloudWatchLogs/src/Exception/ResourceNotFoundException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/ResourceNotFoundException.php
@@ -4,6 +4,9 @@ namespace AsyncAws\CloudWatchLogs\Exception;
 
 use AsyncAws\Core\Exception\Http\ClientException;
 
+/**
+ * The specified resource does not exist.
+ */
 final class ResourceNotFoundException extends ClientException
 {
 }

--- a/src/Service/CloudWatchLogs/src/Exception/ServiceUnavailableException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/ServiceUnavailableException.php
@@ -4,6 +4,9 @@ namespace AsyncAws\CloudWatchLogs\Exception;
 
 use AsyncAws\Core\Exception\Http\ClientException;
 
+/**
+ * The service cannot complete the request.
+ */
 final class ServiceUnavailableException extends ClientException
 {
 }

--- a/src/Service/CloudWatchLogs/src/Exception/ServiceUnavailableException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/ServiceUnavailableException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace AsyncAws\CloudWatchLogs\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+final class ServiceUnavailableException extends ClientException
+{
+}

--- a/src/Service/CloudWatchLogs/src/Exception/UnrecognizedClientException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/UnrecognizedClientException.php
@@ -4,6 +4,9 @@ namespace AsyncAws\CloudWatchLogs\Exception;
 
 use AsyncAws\Core\Exception\Http\ClientException;
 
+/**
+ * The most likely cause is an invalid AWS access key ID or secret key.
+ */
 final class UnrecognizedClientException extends ClientException
 {
 }

--- a/src/Service/CloudWatchLogs/src/Exception/UnrecognizedClientException.php
+++ b/src/Service/CloudWatchLogs/src/Exception/UnrecognizedClientException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace AsyncAws\CloudWatchLogs\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+final class UnrecognizedClientException extends ClientException
+{
+}

--- a/src/Service/CodeDeploy/CHANGELOG.md
+++ b/src/Service/CodeDeploy/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added documentation in class's headers.
+- Added Business Exceptions.
 
 ## 1.1.1
 

--- a/src/Service/CodeDeploy/composer.json
+++ b/src/Service/CodeDeploy/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
-        "async-aws/core": "^1.2"
+        "async-aws/core": "^1.9"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/CodeDeploy/src/CodeDeployClient.php
+++ b/src/Service/CodeDeploy/src/CodeDeployClient.php
@@ -3,6 +3,13 @@
 namespace AsyncAws\CodeDeploy;
 
 use AsyncAws\CodeDeploy\Enum\LifecycleEventStatus;
+use AsyncAws\CodeDeploy\Exception\DeploymentDoesNotExistException;
+use AsyncAws\CodeDeploy\Exception\DeploymentIdRequiredException;
+use AsyncAws\CodeDeploy\Exception\InvalidDeploymentIdException;
+use AsyncAws\CodeDeploy\Exception\InvalidLifecycleEventHookExecutionIdException;
+use AsyncAws\CodeDeploy\Exception\InvalidLifecycleEventHookExecutionStatusException;
+use AsyncAws\CodeDeploy\Exception\LifecycleEventAlreadyCompletedException;
+use AsyncAws\CodeDeploy\Exception\UnsupportedActionForDeploymentTypeException;
 use AsyncAws\CodeDeploy\Input\PutLifecycleEventHookExecutionStatusInput;
 use AsyncAws\CodeDeploy\Result\PutLifecycleEventHookExecutionStatusOutput;
 use AsyncAws\Core\AbstractApi;
@@ -32,11 +39,27 @@ class CodeDeployClient extends AbstractApi
      *   status?: LifecycleEventStatus::*,
      *   @region?: string,
      * }|PutLifecycleEventHookExecutionStatusInput $input
+     *
+     * @throws InvalidLifecycleEventHookExecutionStatusException
+     * @throws InvalidLifecycleEventHookExecutionIdException
+     * @throws LifecycleEventAlreadyCompletedException
+     * @throws DeploymentIdRequiredException
+     * @throws DeploymentDoesNotExistException
+     * @throws InvalidDeploymentIdException
+     * @throws UnsupportedActionForDeploymentTypeException
      */
     public function putLifecycleEventHookExecutionStatus($input = []): PutLifecycleEventHookExecutionStatusOutput
     {
         $input = PutLifecycleEventHookExecutionStatusInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PutLifecycleEventHookExecutionStatus', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PutLifecycleEventHookExecutionStatus', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidLifecycleEventHookExecutionStatusException' => InvalidLifecycleEventHookExecutionStatusException::class,
+            'InvalidLifecycleEventHookExecutionIdException' => InvalidLifecycleEventHookExecutionIdException::class,
+            'LifecycleEventAlreadyCompletedException' => LifecycleEventAlreadyCompletedException::class,
+            'DeploymentIdRequiredException' => DeploymentIdRequiredException::class,
+            'DeploymentDoesNotExistException' => DeploymentDoesNotExistException::class,
+            'InvalidDeploymentIdException' => InvalidDeploymentIdException::class,
+            'UnsupportedActionForDeploymentTypeException' => UnsupportedActionForDeploymentTypeException::class,
+        ]]));
 
         return new PutLifecycleEventHookExecutionStatusOutput($response);
     }

--- a/src/Service/CodeDeploy/src/Exception/DeploymentDoesNotExistException.php
+++ b/src/Service/CodeDeploy/src/Exception/DeploymentDoesNotExistException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\CodeDeploy\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The deployment with the IAM user or AWS account does not exist.
+ */
+final class DeploymentDoesNotExistException extends ClientException
+{
+}

--- a/src/Service/CodeDeploy/src/Exception/DeploymentIdRequiredException.php
+++ b/src/Service/CodeDeploy/src/Exception/DeploymentIdRequiredException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\CodeDeploy\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * At least one deployment ID must be specified.
+ */
+final class DeploymentIdRequiredException extends ClientException
+{
+}

--- a/src/Service/CodeDeploy/src/Exception/InvalidDeploymentIdException.php
+++ b/src/Service/CodeDeploy/src/Exception/InvalidDeploymentIdException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\CodeDeploy\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * At least one of the deployment IDs was specified in an invalid format.
+ */
+final class InvalidDeploymentIdException extends ClientException
+{
+}

--- a/src/Service/CodeDeploy/src/Exception/InvalidLifecycleEventHookExecutionIdException.php
+++ b/src/Service/CodeDeploy/src/Exception/InvalidLifecycleEventHookExecutionIdException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace AsyncAws\CodeDeploy\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * A lifecycle event hook is invalid. Review the `hooks` section in your AppSpec file to ensure the lifecycle events and
+ * `hooks` functions are valid.
+ */
+final class InvalidLifecycleEventHookExecutionIdException extends ClientException
+{
+}

--- a/src/Service/CodeDeploy/src/Exception/InvalidLifecycleEventHookExecutionStatusException.php
+++ b/src/Service/CodeDeploy/src/Exception/InvalidLifecycleEventHookExecutionStatusException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace AsyncAws\CodeDeploy\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The result of a Lambda validation function that verifies a lifecycle event is invalid. It should return `Succeeded`
+ * or `Failed`.
+ */
+final class InvalidLifecycleEventHookExecutionStatusException extends ClientException
+{
+}

--- a/src/Service/CodeDeploy/src/Exception/LifecycleEventAlreadyCompletedException.php
+++ b/src/Service/CodeDeploy/src/Exception/LifecycleEventAlreadyCompletedException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\CodeDeploy\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * An attempt to return the status of an already completed lifecycle event occurred.
+ */
+final class LifecycleEventAlreadyCompletedException extends ClientException
+{
+}

--- a/src/Service/CodeDeploy/src/Exception/UnsupportedActionForDeploymentTypeException.php
+++ b/src/Service/CodeDeploy/src/Exception/UnsupportedActionForDeploymentTypeException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\CodeDeploy\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * A call was submitted that is not supported for the specified deployment type.
+ */
+final class UnsupportedActionForDeploymentTypeException extends ClientException
+{
+}

--- a/src/Service/CognitoIdentityProvider/CHANGELOG.md
+++ b/src/Service/CognitoIdentityProvider/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Changed case of object's properties to camelCase.
 - Added documentation in class's headers.
+- Added Business Exceptions.
 
 ## 1.1.0
 

--- a/src/Service/CognitoIdentityProvider/composer.json
+++ b/src/Service/CognitoIdentityProvider/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
-        "async-aws/core": "^1.2"
+        "async-aws/core": "^1.9"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
+++ b/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
@@ -6,6 +6,35 @@ use AsyncAws\CognitoIdentityProvider\Enum\AuthFlowType;
 use AsyncAws\CognitoIdentityProvider\Enum\ChallengeNameType;
 use AsyncAws\CognitoIdentityProvider\Enum\DeliveryMediumType;
 use AsyncAws\CognitoIdentityProvider\Enum\MessageActionType;
+use AsyncAws\CognitoIdentityProvider\Exception\AliasExistsException;
+use AsyncAws\CognitoIdentityProvider\Exception\CodeDeliveryFailureException;
+use AsyncAws\CognitoIdentityProvider\Exception\CodeMismatchException;
+use AsyncAws\CognitoIdentityProvider\Exception\ConcurrentModificationException;
+use AsyncAws\CognitoIdentityProvider\Exception\EnableSoftwareTokenMFAException;
+use AsyncAws\CognitoIdentityProvider\Exception\ExpiredCodeException;
+use AsyncAws\CognitoIdentityProvider\Exception\InternalErrorException;
+use AsyncAws\CognitoIdentityProvider\Exception\InvalidEmailRoleAccessPolicyException;
+use AsyncAws\CognitoIdentityProvider\Exception\InvalidLambdaResponseException;
+use AsyncAws\CognitoIdentityProvider\Exception\InvalidParameterException;
+use AsyncAws\CognitoIdentityProvider\Exception\InvalidPasswordException;
+use AsyncAws\CognitoIdentityProvider\Exception\InvalidSmsRoleAccessPolicyException;
+use AsyncAws\CognitoIdentityProvider\Exception\InvalidSmsRoleTrustRelationshipException;
+use AsyncAws\CognitoIdentityProvider\Exception\InvalidUserPoolConfigurationException;
+use AsyncAws\CognitoIdentityProvider\Exception\LimitExceededException;
+use AsyncAws\CognitoIdentityProvider\Exception\MFAMethodNotFoundException;
+use AsyncAws\CognitoIdentityProvider\Exception\NotAuthorizedException;
+use AsyncAws\CognitoIdentityProvider\Exception\PasswordResetRequiredException;
+use AsyncAws\CognitoIdentityProvider\Exception\PreconditionNotMetException;
+use AsyncAws\CognitoIdentityProvider\Exception\ResourceNotFoundException;
+use AsyncAws\CognitoIdentityProvider\Exception\SoftwareTokenMFANotFoundException;
+use AsyncAws\CognitoIdentityProvider\Exception\TooManyFailedAttemptsException;
+use AsyncAws\CognitoIdentityProvider\Exception\TooManyRequestsException;
+use AsyncAws\CognitoIdentityProvider\Exception\UnexpectedLambdaException;
+use AsyncAws\CognitoIdentityProvider\Exception\UnsupportedUserStateException;
+use AsyncAws\CognitoIdentityProvider\Exception\UserLambdaValidationException;
+use AsyncAws\CognitoIdentityProvider\Exception\UsernameExistsException;
+use AsyncAws\CognitoIdentityProvider\Exception\UserNotConfirmedException;
+use AsyncAws\CognitoIdentityProvider\Exception\UserNotFoundException;
 use AsyncAws\CognitoIdentityProvider\Input\AdminConfirmSignUpRequest;
 use AsyncAws\CognitoIdentityProvider\Input\AdminCreateUserRequest;
 use AsyncAws\CognitoIdentityProvider\Input\AdminDeleteUserRequest;
@@ -68,11 +97,35 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   ClientMetadata?: array<string, string>,
      *   @region?: string,
      * }|AdminConfirmSignUpRequest $input
+     *
+     * @throws ResourceNotFoundException
+     * @throws InvalidParameterException
+     * @throws UnexpectedLambdaException
+     * @throws UserLambdaValidationException
+     * @throws NotAuthorizedException
+     * @throws TooManyFailedAttemptsException
+     * @throws InvalidLambdaResponseException
+     * @throws TooManyRequestsException
+     * @throws LimitExceededException
+     * @throws UserNotFoundException
+     * @throws InternalErrorException
      */
     public function adminConfirmSignUp($input): AdminConfirmSignUpResponse
     {
         $input = AdminConfirmSignUpRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AdminConfirmSignUp', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AdminConfirmSignUp', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'UnexpectedLambdaException' => UnexpectedLambdaException::class,
+            'UserLambdaValidationException' => UserLambdaValidationException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'TooManyFailedAttemptsException' => TooManyFailedAttemptsException::class,
+            'InvalidLambdaResponseException' => InvalidLambdaResponseException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'LimitExceededException' => LimitExceededException::class,
+            'UserNotFoundException' => UserNotFoundException::class,
+            'InternalErrorException' => InternalErrorException::class,
+        ]]));
 
         return new AdminConfirmSignUpResponse($response);
     }
@@ -95,11 +148,45 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   ClientMetadata?: array<string, string>,
      *   @region?: string,
      * }|AdminCreateUserRequest $input
+     *
+     * @throws ResourceNotFoundException
+     * @throws InvalidParameterException
+     * @throws UserNotFoundException
+     * @throws UsernameExistsException
+     * @throws InvalidPasswordException
+     * @throws CodeDeliveryFailureException
+     * @throws UnexpectedLambdaException
+     * @throws UserLambdaValidationException
+     * @throws InvalidLambdaResponseException
+     * @throws PreconditionNotMetException
+     * @throws InvalidSmsRoleAccessPolicyException
+     * @throws InvalidSmsRoleTrustRelationshipException
+     * @throws TooManyRequestsException
+     * @throws NotAuthorizedException
+     * @throws UnsupportedUserStateException
+     * @throws InternalErrorException
      */
     public function adminCreateUser($input): AdminCreateUserResponse
     {
         $input = AdminCreateUserRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AdminCreateUser', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AdminCreateUser', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'UserNotFoundException' => UserNotFoundException::class,
+            'UsernameExistsException' => UsernameExistsException::class,
+            'InvalidPasswordException' => InvalidPasswordException::class,
+            'CodeDeliveryFailureException' => CodeDeliveryFailureException::class,
+            'UnexpectedLambdaException' => UnexpectedLambdaException::class,
+            'UserLambdaValidationException' => UserLambdaValidationException::class,
+            'InvalidLambdaResponseException' => InvalidLambdaResponseException::class,
+            'PreconditionNotMetException' => PreconditionNotMetException::class,
+            'InvalidSmsRoleAccessPolicyException' => InvalidSmsRoleAccessPolicyException::class,
+            'InvalidSmsRoleTrustRelationshipException' => InvalidSmsRoleTrustRelationshipException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'UnsupportedUserStateException' => UnsupportedUserStateException::class,
+            'InternalErrorException' => InternalErrorException::class,
+        ]]));
 
         return new AdminCreateUserResponse($response);
     }
@@ -115,11 +202,25 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   Username: string,
      *   @region?: string,
      * }|AdminDeleteUserRequest $input
+     *
+     * @throws ResourceNotFoundException
+     * @throws InvalidParameterException
+     * @throws TooManyRequestsException
+     * @throws NotAuthorizedException
+     * @throws UserNotFoundException
+     * @throws InternalErrorException
      */
     public function adminDeleteUser($input): Result
     {
         $input = AdminDeleteUserRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AdminDeleteUser', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AdminDeleteUser', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'UserNotFoundException' => UserNotFoundException::class,
+            'InternalErrorException' => InternalErrorException::class,
+        ]]));
 
         return new Result($response);
     }
@@ -135,11 +236,25 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   Username: string,
      *   @region?: string,
      * }|AdminGetUserRequest $input
+     *
+     * @throws ResourceNotFoundException
+     * @throws InvalidParameterException
+     * @throws TooManyRequestsException
+     * @throws NotAuthorizedException
+     * @throws UserNotFoundException
+     * @throws InternalErrorException
      */
     public function adminGetUser($input): AdminGetUserResponse
     {
         $input = AdminGetUserRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AdminGetUser', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AdminGetUser', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'UserNotFoundException' => UserNotFoundException::class,
+            'InternalErrorException' => InternalErrorException::class,
+        ]]));
 
         return new AdminGetUserResponse($response);
     }
@@ -160,11 +275,43 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   ContextData?: ContextDataType|array,
      *   @region?: string,
      * }|AdminInitiateAuthRequest $input
+     *
+     * @throws ResourceNotFoundException
+     * @throws InvalidParameterException
+     * @throws NotAuthorizedException
+     * @throws TooManyRequestsException
+     * @throws InternalErrorException
+     * @throws UnexpectedLambdaException
+     * @throws InvalidUserPoolConfigurationException
+     * @throws UserLambdaValidationException
+     * @throws InvalidLambdaResponseException
+     * @throws MFAMethodNotFoundException
+     * @throws InvalidSmsRoleAccessPolicyException
+     * @throws InvalidSmsRoleTrustRelationshipException
+     * @throws PasswordResetRequiredException
+     * @throws UserNotFoundException
+     * @throws UserNotConfirmedException
      */
     public function adminInitiateAuth($input): AdminInitiateAuthResponse
     {
         $input = AdminInitiateAuthRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AdminInitiateAuth', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AdminInitiateAuth', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'InternalErrorException' => InternalErrorException::class,
+            'UnexpectedLambdaException' => UnexpectedLambdaException::class,
+            'InvalidUserPoolConfigurationException' => InvalidUserPoolConfigurationException::class,
+            'UserLambdaValidationException' => UserLambdaValidationException::class,
+            'InvalidLambdaResponseException' => InvalidLambdaResponseException::class,
+            'MFAMethodNotFoundException' => MFAMethodNotFoundException::class,
+            'InvalidSmsRoleAccessPolicyException' => InvalidSmsRoleAccessPolicyException::class,
+            'InvalidSmsRoleTrustRelationshipException' => InvalidSmsRoleTrustRelationshipException::class,
+            'PasswordResetRequiredException' => PasswordResetRequiredException::class,
+            'UserNotFoundException' => UserNotFoundException::class,
+            'UserNotConfirmedException' => UserNotConfirmedException::class,
+        ]]));
 
         return new AdminInitiateAuthResponse($response);
     }
@@ -182,11 +329,27 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   Permanent?: bool,
      *   @region?: string,
      * }|AdminSetUserPasswordRequest $input
+     *
+     * @throws ResourceNotFoundException
+     * @throws NotAuthorizedException
+     * @throws UserNotFoundException
+     * @throws InternalErrorException
+     * @throws TooManyRequestsException
+     * @throws InvalidParameterException
+     * @throws InvalidPasswordException
      */
     public function adminSetUserPassword($input): AdminSetUserPasswordResponse
     {
         $input = AdminSetUserPasswordRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AdminSetUserPassword', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AdminSetUserPassword', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'UserNotFoundException' => UserNotFoundException::class,
+            'InternalErrorException' => InternalErrorException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'InvalidPasswordException' => InvalidPasswordException::class,
+        ]]));
 
         return new AdminSetUserPasswordResponse($response);
     }
@@ -204,11 +367,39 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   ClientMetadata?: array<string, string>,
      *   @region?: string,
      * }|AdminUpdateUserAttributesRequest $input
+     *
+     * @throws ResourceNotFoundException
+     * @throws InvalidParameterException
+     * @throws UnexpectedLambdaException
+     * @throws UserLambdaValidationException
+     * @throws InvalidLambdaResponseException
+     * @throws AliasExistsException
+     * @throws TooManyRequestsException
+     * @throws NotAuthorizedException
+     * @throws UserNotFoundException
+     * @throws InternalErrorException
+     * @throws InvalidSmsRoleAccessPolicyException
+     * @throws InvalidEmailRoleAccessPolicyException
+     * @throws InvalidSmsRoleTrustRelationshipException
      */
     public function adminUpdateUserAttributes($input): AdminUpdateUserAttributesResponse
     {
         $input = AdminUpdateUserAttributesRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AdminUpdateUserAttributes', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AdminUpdateUserAttributes', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'UnexpectedLambdaException' => UnexpectedLambdaException::class,
+            'UserLambdaValidationException' => UserLambdaValidationException::class,
+            'InvalidLambdaResponseException' => InvalidLambdaResponseException::class,
+            'AliasExistsException' => AliasExistsException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'UserNotFoundException' => UserNotFoundException::class,
+            'InternalErrorException' => InternalErrorException::class,
+            'InvalidSmsRoleAccessPolicyException' => InvalidSmsRoleAccessPolicyException::class,
+            'InvalidEmailRoleAccessPolicyException' => InvalidEmailRoleAccessPolicyException::class,
+            'InvalidSmsRoleTrustRelationshipException' => InvalidSmsRoleTrustRelationshipException::class,
+        ]]));
 
         return new AdminUpdateUserAttributesResponse($response);
     }
@@ -225,11 +416,25 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   Session?: string,
      *   @region?: string,
      * }|AssociateSoftwareTokenRequest $input
+     *
+     * @throws ConcurrentModificationException
+     * @throws InvalidParameterException
+     * @throws NotAuthorizedException
+     * @throws ResourceNotFoundException
+     * @throws InternalErrorException
+     * @throws SoftwareTokenMFANotFoundException
      */
     public function associateSoftwareToken($input = []): AssociateSoftwareTokenResponse
     {
         $input = AssociateSoftwareTokenRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AssociateSoftwareToken', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AssociateSoftwareToken', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ConcurrentModificationException' => ConcurrentModificationException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InternalErrorException' => InternalErrorException::class,
+            'SoftwareTokenMFANotFoundException' => SoftwareTokenMFANotFoundException::class,
+        ]]));
 
         return new AssociateSoftwareTokenResponse($response);
     }
@@ -246,11 +451,33 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   AccessToken: string,
      *   @region?: string,
      * }|ChangePasswordRequest $input
+     *
+     * @throws ResourceNotFoundException
+     * @throws InvalidParameterException
+     * @throws InvalidPasswordException
+     * @throws NotAuthorizedException
+     * @throws TooManyRequestsException
+     * @throws LimitExceededException
+     * @throws PasswordResetRequiredException
+     * @throws UserNotFoundException
+     * @throws UserNotConfirmedException
+     * @throws InternalErrorException
      */
     public function changePassword($input): ChangePasswordResponse
     {
         $input = ChangePasswordRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ChangePassword', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ChangePassword', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'InvalidPasswordException' => InvalidPasswordException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'LimitExceededException' => LimitExceededException::class,
+            'PasswordResetRequiredException' => PasswordResetRequiredException::class,
+            'UserNotFoundException' => UserNotFoundException::class,
+            'UserNotConfirmedException' => UserNotConfirmedException::class,
+            'InternalErrorException' => InternalErrorException::class,
+        ]]));
 
         return new ChangePasswordResponse($response);
     }
@@ -272,11 +499,43 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   ClientMetadata?: array<string, string>,
      *   @region?: string,
      * }|ConfirmForgotPasswordRequest $input
+     *
+     * @throws ResourceNotFoundException
+     * @throws UnexpectedLambdaException
+     * @throws UserLambdaValidationException
+     * @throws InvalidParameterException
+     * @throws InvalidPasswordException
+     * @throws NotAuthorizedException
+     * @throws CodeMismatchException
+     * @throws ExpiredCodeException
+     * @throws TooManyFailedAttemptsException
+     * @throws InvalidLambdaResponseException
+     * @throws TooManyRequestsException
+     * @throws LimitExceededException
+     * @throws UserNotFoundException
+     * @throws UserNotConfirmedException
+     * @throws InternalErrorException
      */
     public function confirmForgotPassword($input): ConfirmForgotPasswordResponse
     {
         $input = ConfirmForgotPasswordRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ConfirmForgotPassword', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ConfirmForgotPassword', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'UnexpectedLambdaException' => UnexpectedLambdaException::class,
+            'UserLambdaValidationException' => UserLambdaValidationException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'InvalidPasswordException' => InvalidPasswordException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'CodeMismatchException' => CodeMismatchException::class,
+            'ExpiredCodeException' => ExpiredCodeException::class,
+            'TooManyFailedAttemptsException' => TooManyFailedAttemptsException::class,
+            'InvalidLambdaResponseException' => InvalidLambdaResponseException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'LimitExceededException' => LimitExceededException::class,
+            'UserNotFoundException' => UserNotFoundException::class,
+            'UserNotConfirmedException' => UserNotConfirmedException::class,
+            'InternalErrorException' => InternalErrorException::class,
+        ]]));
 
         return new ConfirmForgotPasswordResponse($response);
     }
@@ -303,11 +562,43 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   ClientMetadata?: array<string, string>,
      *   @region?: string,
      * }|ForgotPasswordRequest $input
+     *
+     * @throws ResourceNotFoundException
+     * @throws InvalidParameterException
+     * @throws UnexpectedLambdaException
+     * @throws UserLambdaValidationException
+     * @throws NotAuthorizedException
+     * @throws InvalidLambdaResponseException
+     * @throws TooManyRequestsException
+     * @throws LimitExceededException
+     * @throws InvalidSmsRoleAccessPolicyException
+     * @throws InvalidSmsRoleTrustRelationshipException
+     * @throws InvalidEmailRoleAccessPolicyException
+     * @throws CodeDeliveryFailureException
+     * @throws UserNotFoundException
+     * @throws UserNotConfirmedException
+     * @throws InternalErrorException
      */
     public function forgotPassword($input): ForgotPasswordResponse
     {
         $input = ForgotPasswordRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ForgotPassword', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ForgotPassword', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'UnexpectedLambdaException' => UnexpectedLambdaException::class,
+            'UserLambdaValidationException' => UserLambdaValidationException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'InvalidLambdaResponseException' => InvalidLambdaResponseException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'LimitExceededException' => LimitExceededException::class,
+            'InvalidSmsRoleAccessPolicyException' => InvalidSmsRoleAccessPolicyException::class,
+            'InvalidSmsRoleTrustRelationshipException' => InvalidSmsRoleTrustRelationshipException::class,
+            'InvalidEmailRoleAccessPolicyException' => InvalidEmailRoleAccessPolicyException::class,
+            'CodeDeliveryFailureException' => CodeDeliveryFailureException::class,
+            'UserNotFoundException' => UserNotFoundException::class,
+            'UserNotConfirmedException' => UserNotConfirmedException::class,
+            'InternalErrorException' => InternalErrorException::class,
+        ]]));
 
         return new ForgotPasswordResponse($response);
     }
@@ -327,11 +618,41 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   UserContextData?: UserContextDataType|array,
      *   @region?: string,
      * }|InitiateAuthRequest $input
+     *
+     * @throws ResourceNotFoundException
+     * @throws InvalidParameterException
+     * @throws NotAuthorizedException
+     * @throws TooManyRequestsException
+     * @throws UnexpectedLambdaException
+     * @throws InvalidUserPoolConfigurationException
+     * @throws UserLambdaValidationException
+     * @throws InvalidLambdaResponseException
+     * @throws PasswordResetRequiredException
+     * @throws UserNotFoundException
+     * @throws UserNotConfirmedException
+     * @throws InternalErrorException
+     * @throws InvalidSmsRoleAccessPolicyException
+     * @throws InvalidSmsRoleTrustRelationshipException
      */
     public function initiateAuth($input): InitiateAuthResponse
     {
         $input = InitiateAuthRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'InitiateAuth', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'InitiateAuth', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'UnexpectedLambdaException' => UnexpectedLambdaException::class,
+            'InvalidUserPoolConfigurationException' => InvalidUserPoolConfigurationException::class,
+            'UserLambdaValidationException' => UserLambdaValidationException::class,
+            'InvalidLambdaResponseException' => InvalidLambdaResponseException::class,
+            'PasswordResetRequiredException' => PasswordResetRequiredException::class,
+            'UserNotFoundException' => UserNotFoundException::class,
+            'UserNotConfirmedException' => UserNotConfirmedException::class,
+            'InternalErrorException' => InternalErrorException::class,
+            'InvalidSmsRoleAccessPolicyException' => InvalidSmsRoleAccessPolicyException::class,
+            'InvalidSmsRoleTrustRelationshipException' => InvalidSmsRoleTrustRelationshipException::class,
+        ]]));
 
         return new InitiateAuthResponse($response);
     }
@@ -350,11 +671,23 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   Filter?: string,
      *   @region?: string,
      * }|ListUsersRequest $input
+     *
+     * @throws InvalidParameterException
+     * @throws ResourceNotFoundException
+     * @throws TooManyRequestsException
+     * @throws NotAuthorizedException
+     * @throws InternalErrorException
      */
     public function listUsers($input): ListUsersResponse
     {
         $input = ListUsersRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ListUsers', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ListUsers', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidParameterException' => InvalidParameterException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'InternalErrorException' => InternalErrorException::class,
+        ]]));
 
         return new ListUsersResponse($response, $this, $input);
     }
@@ -374,11 +707,41 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   ClientMetadata?: array<string, string>,
      *   @region?: string,
      * }|ResendConfirmationCodeRequest $input
+     *
+     * @throws ResourceNotFoundException
+     * @throws InvalidParameterException
+     * @throws UnexpectedLambdaException
+     * @throws UserLambdaValidationException
+     * @throws NotAuthorizedException
+     * @throws InvalidLambdaResponseException
+     * @throws TooManyRequestsException
+     * @throws LimitExceededException
+     * @throws InvalidSmsRoleAccessPolicyException
+     * @throws InvalidSmsRoleTrustRelationshipException
+     * @throws InvalidEmailRoleAccessPolicyException
+     * @throws CodeDeliveryFailureException
+     * @throws UserNotFoundException
+     * @throws InternalErrorException
      */
     public function resendConfirmationCode($input): ResendConfirmationCodeResponse
     {
         $input = ResendConfirmationCodeRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ResendConfirmationCode', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ResendConfirmationCode', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'UnexpectedLambdaException' => UnexpectedLambdaException::class,
+            'UserLambdaValidationException' => UserLambdaValidationException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'InvalidLambdaResponseException' => InvalidLambdaResponseException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'LimitExceededException' => LimitExceededException::class,
+            'InvalidSmsRoleAccessPolicyException' => InvalidSmsRoleAccessPolicyException::class,
+            'InvalidSmsRoleTrustRelationshipException' => InvalidSmsRoleTrustRelationshipException::class,
+            'InvalidEmailRoleAccessPolicyException' => InvalidEmailRoleAccessPolicyException::class,
+            'CodeDeliveryFailureException' => CodeDeliveryFailureException::class,
+            'UserNotFoundException' => UserNotFoundException::class,
+            'InternalErrorException' => InternalErrorException::class,
+        ]]));
 
         return new ResendConfirmationCodeResponse($response);
     }
@@ -399,11 +762,53 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   ClientMetadata?: array<string, string>,
      *   @region?: string,
      * }|RespondToAuthChallengeRequest $input
+     *
+     * @throws ResourceNotFoundException
+     * @throws InvalidParameterException
+     * @throws NotAuthorizedException
+     * @throws CodeMismatchException
+     * @throws ExpiredCodeException
+     * @throws UnexpectedLambdaException
+     * @throws UserLambdaValidationException
+     * @throws InvalidPasswordException
+     * @throws InvalidLambdaResponseException
+     * @throws TooManyRequestsException
+     * @throws InvalidUserPoolConfigurationException
+     * @throws MFAMethodNotFoundException
+     * @throws PasswordResetRequiredException
+     * @throws UserNotFoundException
+     * @throws UserNotConfirmedException
+     * @throws InvalidSmsRoleAccessPolicyException
+     * @throws InvalidSmsRoleTrustRelationshipException
+     * @throws AliasExistsException
+     * @throws InternalErrorException
+     * @throws SoftwareTokenMFANotFoundException
      */
     public function respondToAuthChallenge($input): RespondToAuthChallengeResponse
     {
         $input = RespondToAuthChallengeRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'RespondToAuthChallenge', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'RespondToAuthChallenge', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'CodeMismatchException' => CodeMismatchException::class,
+            'ExpiredCodeException' => ExpiredCodeException::class,
+            'UnexpectedLambdaException' => UnexpectedLambdaException::class,
+            'UserLambdaValidationException' => UserLambdaValidationException::class,
+            'InvalidPasswordException' => InvalidPasswordException::class,
+            'InvalidLambdaResponseException' => InvalidLambdaResponseException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'InvalidUserPoolConfigurationException' => InvalidUserPoolConfigurationException::class,
+            'MFAMethodNotFoundException' => MFAMethodNotFoundException::class,
+            'PasswordResetRequiredException' => PasswordResetRequiredException::class,
+            'UserNotFoundException' => UserNotFoundException::class,
+            'UserNotConfirmedException' => UserNotConfirmedException::class,
+            'InvalidSmsRoleAccessPolicyException' => InvalidSmsRoleAccessPolicyException::class,
+            'InvalidSmsRoleTrustRelationshipException' => InvalidSmsRoleTrustRelationshipException::class,
+            'AliasExistsException' => AliasExistsException::class,
+            'InternalErrorException' => InternalErrorException::class,
+            'SoftwareTokenMFANotFoundException' => SoftwareTokenMFANotFoundException::class,
+        ]]));
 
         return new RespondToAuthChallengeResponse($response);
     }
@@ -426,11 +831,27 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   AccessToken: string,
      *   @region?: string,
      * }|SetUserMFAPreferenceRequest $input
+     *
+     * @throws ResourceNotFoundException
+     * @throws InvalidParameterException
+     * @throws NotAuthorizedException
+     * @throws PasswordResetRequiredException
+     * @throws UserNotFoundException
+     * @throws UserNotConfirmedException
+     * @throws InternalErrorException
      */
     public function setUserMfaPreference($input): SetUserMFAPreferenceResponse
     {
         $input = SetUserMFAPreferenceRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'SetUserMFAPreference', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'SetUserMFAPreference', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'PasswordResetRequiredException' => PasswordResetRequiredException::class,
+            'UserNotFoundException' => UserNotFoundException::class,
+            'UserNotConfirmedException' => UserNotConfirmedException::class,
+            'InternalErrorException' => InternalErrorException::class,
+        ]]));
 
         return new SetUserMFAPreferenceResponse($response);
     }
@@ -453,11 +874,41 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   ClientMetadata?: array<string, string>,
      *   @region?: string,
      * }|SignUpRequest $input
+     *
+     * @throws ResourceNotFoundException
+     * @throws InvalidParameterException
+     * @throws UnexpectedLambdaException
+     * @throws UserLambdaValidationException
+     * @throws NotAuthorizedException
+     * @throws InvalidPasswordException
+     * @throws InvalidLambdaResponseException
+     * @throws UsernameExistsException
+     * @throws TooManyRequestsException
+     * @throws InternalErrorException
+     * @throws InvalidSmsRoleAccessPolicyException
+     * @throws InvalidSmsRoleTrustRelationshipException
+     * @throws InvalidEmailRoleAccessPolicyException
+     * @throws CodeDeliveryFailureException
      */
     public function signUp($input): SignUpResponse
     {
         $input = SignUpRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'SignUp', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'SignUp', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'UnexpectedLambdaException' => UnexpectedLambdaException::class,
+            'UserLambdaValidationException' => UserLambdaValidationException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'InvalidPasswordException' => InvalidPasswordException::class,
+            'InvalidLambdaResponseException' => InvalidLambdaResponseException::class,
+            'UsernameExistsException' => UsernameExistsException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'InternalErrorException' => InternalErrorException::class,
+            'InvalidSmsRoleAccessPolicyException' => InvalidSmsRoleAccessPolicyException::class,
+            'InvalidSmsRoleTrustRelationshipException' => InvalidSmsRoleTrustRelationshipException::class,
+            'InvalidEmailRoleAccessPolicyException' => InvalidEmailRoleAccessPolicyException::class,
+            'CodeDeliveryFailureException' => CodeDeliveryFailureException::class,
+        ]]));
 
         return new SignUpResponse($response);
     }
@@ -476,11 +927,39 @@ class CognitoIdentityProviderClient extends AbstractApi
      *   FriendlyDeviceName?: string,
      *   @region?: string,
      * }|VerifySoftwareTokenRequest $input
+     *
+     * @throws InvalidParameterException
+     * @throws ResourceNotFoundException
+     * @throws InvalidUserPoolConfigurationException
+     * @throws NotAuthorizedException
+     * @throws TooManyRequestsException
+     * @throws PasswordResetRequiredException
+     * @throws UserNotFoundException
+     * @throws UserNotConfirmedException
+     * @throws InternalErrorException
+     * @throws EnableSoftwareTokenMFAException
+     * @throws NotAuthorizedException
+     * @throws SoftwareTokenMFANotFoundException
+     * @throws CodeMismatchException
      */
     public function verifySoftwareToken($input): VerifySoftwareTokenResponse
     {
         $input = VerifySoftwareTokenRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'VerifySoftwareToken', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'VerifySoftwareToken', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidParameterException' => InvalidParameterException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidUserPoolConfigurationException' => InvalidUserPoolConfigurationException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'PasswordResetRequiredException' => PasswordResetRequiredException::class,
+            'UserNotFoundException' => UserNotFoundException::class,
+            'UserNotConfirmedException' => UserNotConfirmedException::class,
+            'InternalErrorException' => InternalErrorException::class,
+            'EnableSoftwareTokenMFAException' => EnableSoftwareTokenMFAException::class,
+            'NotAuthorizedException' => NotAuthorizedException::class,
+            'SoftwareTokenMFANotFoundException' => SoftwareTokenMFANotFoundException::class,
+            'CodeMismatchException' => CodeMismatchException::class,
+        ]]));
 
         return new VerifySoftwareTokenResponse($response);
     }

--- a/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
+++ b/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
@@ -938,7 +938,6 @@ class CognitoIdentityProviderClient extends AbstractApi
      * @throws UserNotConfirmedException
      * @throws InternalErrorException
      * @throws EnableSoftwareTokenMFAException
-     * @throws NotAuthorizedException
      * @throws SoftwareTokenMFANotFoundException
      * @throws CodeMismatchException
      */
@@ -956,7 +955,6 @@ class CognitoIdentityProviderClient extends AbstractApi
             'UserNotConfirmedException' => UserNotConfirmedException::class,
             'InternalErrorException' => InternalErrorException::class,
             'EnableSoftwareTokenMFAException' => EnableSoftwareTokenMFAException::class,
-            'NotAuthorizedException' => NotAuthorizedException::class,
             'SoftwareTokenMFANotFoundException' => SoftwareTokenMFANotFoundException::class,
             'CodeMismatchException' => CodeMismatchException::class,
         ]]));

--- a/src/Service/CognitoIdentityProvider/src/Exception/AliasExistsException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/AliasExistsException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when a user tries to confirm the account with an email or phone number that has already been
+ * supplied as an alias from a different account. This exception tells user that an account with this email or phone
+ * already exists.
+ */
+final class AliasExistsException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/CodeDeliveryFailureException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/CodeDeliveryFailureException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when a verification code fails to deliver successfully.
+ */
+final class CodeDeliveryFailureException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/CodeMismatchException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/CodeMismatchException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown if the provided code does not match what the server was expecting.
+ */
+final class CodeMismatchException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/ConcurrentModificationException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/ConcurrentModificationException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown if two or more modifications are happening concurrently.
+ */
+final class ConcurrentModificationException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/EnableSoftwareTokenMFAException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/EnableSoftwareTokenMFAException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when there is a code mismatch and the service fails to configure the software token TOTP
+ * multi-factor authentication (MFA).
+ */
+final class EnableSoftwareTokenMFAException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/ExpiredCodeException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/ExpiredCodeException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown if a code has expired.
+ */
+final class ExpiredCodeException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/InternalErrorException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/InternalErrorException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when Amazon Cognito encounters an internal error.
+ */
+final class InternalErrorException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/InvalidEmailRoleAccessPolicyException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/InvalidEmailRoleAccessPolicyException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when Amazon Cognito is not allowed to use your email identity. HTTP status code: 400.
+ */
+final class InvalidEmailRoleAccessPolicyException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/InvalidLambdaResponseException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/InvalidLambdaResponseException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when the Amazon Cognito service encounters an invalid AWS Lambda response.
+ */
+final class InvalidLambdaResponseException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/InvalidParameterException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/InvalidParameterException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when the Amazon Cognito service encounters an invalid parameter.
+ */
+final class InvalidParameterException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/InvalidPasswordException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/InvalidPasswordException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when the Amazon Cognito service encounters an invalid password.
+ */
+final class InvalidPasswordException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/InvalidSmsRoleAccessPolicyException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/InvalidSmsRoleAccessPolicyException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is returned when the role provided for SMS configuration does not have permission to publish using
+ * Amazon SNS.
+ */
+final class InvalidSmsRoleAccessPolicyException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/InvalidSmsRoleTrustRelationshipException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/InvalidSmsRoleTrustRelationshipException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when the trust relationship is invalid for the role provided for SMS configuration. This can
+ * happen if you do not trust **cognito-idp.amazonaws.com** or the external ID provided in the role does not match what
+ * is provided in the SMS configuration for the user pool.
+ */
+final class InvalidSmsRoleTrustRelationshipException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/InvalidUserPoolConfigurationException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/InvalidUserPoolConfigurationException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when the user pool configuration is invalid.
+ */
+final class InvalidUserPoolConfigurationException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/LimitExceededException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/LimitExceededException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when a user exceeds the limit for a requested AWS resource.
+ */
+final class LimitExceededException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/MFAMethodNotFoundException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/MFAMethodNotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when Amazon Cognito cannot find a multi-factor authentication (MFA) method.
+ */
+final class MFAMethodNotFoundException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/NotAuthorizedException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/NotAuthorizedException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when a user is not authorized.
+ */
+final class NotAuthorizedException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/PasswordResetRequiredException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/PasswordResetRequiredException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when a password reset is required.
+ */
+final class PasswordResetRequiredException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/PreconditionNotMetException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/PreconditionNotMetException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when a precondition is not met.
+ */
+final class PreconditionNotMetException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/ResourceNotFoundException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/ResourceNotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when the Amazon Cognito service cannot find the requested resource.
+ */
+final class ResourceNotFoundException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/SoftwareTokenMFANotFoundException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/SoftwareTokenMFANotFoundException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when the software token TOTP multi-factor authentication (MFA) is not enabled for the user
+ * pool.
+ */
+final class SoftwareTokenMFANotFoundException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/TooManyFailedAttemptsException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/TooManyFailedAttemptsException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when the user has made too many failed attempts for a given action (e.g., sign in).
+ */
+final class TooManyFailedAttemptsException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/TooManyRequestsException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/TooManyRequestsException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when the user has made too many requests for a given operation.
+ */
+final class TooManyRequestsException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/UnexpectedLambdaException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/UnexpectedLambdaException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when the Amazon Cognito service encounters an unexpected exception with the AWS Lambda
+ * service.
+ */
+final class UnexpectedLambdaException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/UnsupportedUserStateException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/UnsupportedUserStateException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request failed because the user is in an unsupported state.
+ */
+final class UnsupportedUserStateException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/UserLambdaValidationException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/UserLambdaValidationException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when the Amazon Cognito service encounters a user validation exception with the AWS Lambda
+ * service.
+ */
+final class UserLambdaValidationException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/UserNotConfirmedException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/UserNotConfirmedException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when a user is not confirmed successfully.
+ */
+final class UserNotConfirmedException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/UserNotFoundException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/UserNotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when a user is not found.
+ */
+final class UserNotFoundException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Exception/UsernameExistsException.php
+++ b/src/Service/CognitoIdentityProvider/src/Exception/UsernameExistsException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CognitoIdentityProvider\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * This exception is thrown when Amazon Cognito encounters a user name that already exists in the user pool.
+ */
+final class UsernameExistsException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/CognitoIdentityProvider/src/Result/AdminConfirmSignUpResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/AdminConfirmSignUpResponse.php
@@ -2,7 +2,6 @@
 
 namespace AsyncAws\CognitoIdentityProvider\Result;
 
-use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 
 /**
@@ -10,7 +9,4 @@ use AsyncAws\Core\Result;
  */
 class AdminConfirmSignUpResponse extends Result
 {
-    protected function populateResult(Response $response): void
-    {
-    }
 }

--- a/src/Service/CognitoIdentityProvider/src/Result/AdminSetUserPasswordResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/AdminSetUserPasswordResponse.php
@@ -2,12 +2,8 @@
 
 namespace AsyncAws\CognitoIdentityProvider\Result;
 
-use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 
 class AdminSetUserPasswordResponse extends Result
 {
-    protected function populateResult(Response $response): void
-    {
-    }
 }

--- a/src/Service/CognitoIdentityProvider/src/Result/AdminUpdateUserAttributesResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/AdminUpdateUserAttributesResponse.php
@@ -2,7 +2,6 @@
 
 namespace AsyncAws\CognitoIdentityProvider\Result;
 
-use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 
 /**
@@ -10,7 +9,4 @@ use AsyncAws\Core\Result;
  */
 class AdminUpdateUserAttributesResponse extends Result
 {
-    protected function populateResult(Response $response): void
-    {
-    }
 }

--- a/src/Service/CognitoIdentityProvider/src/Result/ChangePasswordResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/ChangePasswordResponse.php
@@ -2,7 +2,6 @@
 
 namespace AsyncAws\CognitoIdentityProvider\Result;
 
-use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 
 /**
@@ -10,7 +9,4 @@ use AsyncAws\Core\Result;
  */
 class ChangePasswordResponse extends Result
 {
-    protected function populateResult(Response $response): void
-    {
-    }
 }

--- a/src/Service/CognitoIdentityProvider/src/Result/ConfirmForgotPasswordResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/ConfirmForgotPasswordResponse.php
@@ -2,7 +2,6 @@
 
 namespace AsyncAws\CognitoIdentityProvider\Result;
 
-use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 
 /**
@@ -10,7 +9,4 @@ use AsyncAws\Core\Result;
  */
 class ConfirmForgotPasswordResponse extends Result
 {
-    protected function populateResult(Response $response): void
-    {
-    }
 }

--- a/src/Service/CognitoIdentityProvider/src/Result/SetUserMFAPreferenceResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/SetUserMFAPreferenceResponse.php
@@ -2,12 +2,8 @@
 
 namespace AsyncAws\CognitoIdentityProvider\Result;
 
-use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 
 class SetUserMFAPreferenceResponse extends Result
 {
-    protected function populateResult(Response $response): void
-    {
-    }
 }

--- a/src/Service/DynamoDb/CHANGELOG.md
+++ b/src/Service/DynamoDb/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Changed case of object's properties to camelCase.
 - Added documentation in class's headers.
+- Added Business Exceptions.
 
 ## 1.0.1
 

--- a/src/Service/DynamoDb/composer.json
+++ b/src/Service/DynamoDb/composer.json
@@ -14,7 +14,7 @@
         "php": "^7.2.5 || ^8.0",
         "ext-filter": "*",
         "ext-json": "*",
-        "async-aws/core": "^1.2"
+        "async-aws/core": "^1.9"
     },
     "conflict": {
         "symfony/http-client": "<4.4.16,<5.1.7"

--- a/src/Service/DynamoDb/src/DynamoDbClient.php
+++ b/src/Service/DynamoDb/src/DynamoDbClient.php
@@ -13,6 +13,15 @@ use AsyncAws\DynamoDb\Enum\ReturnConsumedCapacity;
 use AsyncAws\DynamoDb\Enum\ReturnItemCollectionMetrics;
 use AsyncAws\DynamoDb\Enum\ReturnValue;
 use AsyncAws\DynamoDb\Enum\Select;
+use AsyncAws\DynamoDb\Exception\ConditionalCheckFailedException;
+use AsyncAws\DynamoDb\Exception\InternalServerErrorException;
+use AsyncAws\DynamoDb\Exception\ItemCollectionSizeLimitExceededException;
+use AsyncAws\DynamoDb\Exception\LimitExceededException;
+use AsyncAws\DynamoDb\Exception\ProvisionedThroughputExceededException;
+use AsyncAws\DynamoDb\Exception\RequestLimitExceededException;
+use AsyncAws\DynamoDb\Exception\ResourceInUseException;
+use AsyncAws\DynamoDb\Exception\ResourceNotFoundException;
+use AsyncAws\DynamoDb\Exception\TransactionConflictException;
 use AsyncAws\DynamoDb\Input\BatchGetItemInput;
 use AsyncAws\DynamoDb\Input\BatchWriteItemInput;
 use AsyncAws\DynamoDb\Input\CreateTableInput;
@@ -74,11 +83,21 @@ class DynamoDbClient extends AbstractApi
      *   ReturnConsumedCapacity?: ReturnConsumedCapacity::*,
      *   @region?: string,
      * }|BatchGetItemInput $input
+     *
+     * @throws ProvisionedThroughputExceededException
+     * @throws ResourceNotFoundException
+     * @throws RequestLimitExceededException
+     * @throws InternalServerErrorException
      */
     public function batchGetItem($input): BatchGetItemOutput
     {
         $input = BatchGetItemInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'BatchGetItem', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'BatchGetItem', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'RequestLimitExceeded' => RequestLimitExceededException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+        ]]));
 
         return new BatchGetItemOutput($response, $this, $input);
     }
@@ -97,11 +116,23 @@ class DynamoDbClient extends AbstractApi
      *   ReturnItemCollectionMetrics?: ReturnItemCollectionMetrics::*,
      *   @region?: string,
      * }|BatchWriteItemInput $input
+     *
+     * @throws ProvisionedThroughputExceededException
+     * @throws ResourceNotFoundException
+     * @throws ItemCollectionSizeLimitExceededException
+     * @throws RequestLimitExceededException
+     * @throws InternalServerErrorException
      */
     public function batchWriteItem($input): BatchWriteItemOutput
     {
         $input = BatchWriteItemInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'BatchWriteItem', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'BatchWriteItem', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'ItemCollectionSizeLimitExceededException' => ItemCollectionSizeLimitExceededException::class,
+            'RequestLimitExceeded' => RequestLimitExceededException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+        ]]));
 
         return new BatchWriteItemOutput($response);
     }
@@ -126,11 +157,19 @@ class DynamoDbClient extends AbstractApi
      *   Tags?: Tag[],
      *   @region?: string,
      * }|CreateTableInput $input
+     *
+     * @throws ResourceInUseException
+     * @throws LimitExceededException
+     * @throws InternalServerErrorException
      */
     public function createTable($input): CreateTableOutput
     {
         $input = CreateTableInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateTable', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateTable', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceInUseException' => ResourceInUseException::class,
+            'LimitExceededException' => LimitExceededException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+        ]]));
 
         return new CreateTableOutput($response);
     }
@@ -155,11 +194,27 @@ class DynamoDbClient extends AbstractApi
      *   ExpressionAttributeValues?: array<string, AttributeValue>,
      *   @region?: string,
      * }|DeleteItemInput $input
+     *
+     * @throws ConditionalCheckFailedException
+     * @throws ProvisionedThroughputExceededException
+     * @throws ResourceNotFoundException
+     * @throws ItemCollectionSizeLimitExceededException
+     * @throws TransactionConflictException
+     * @throws RequestLimitExceededException
+     * @throws InternalServerErrorException
      */
     public function deleteItem($input): DeleteItemOutput
     {
         $input = DeleteItemInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteItem', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteItem', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ConditionalCheckFailedException' => ConditionalCheckFailedException::class,
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'ItemCollectionSizeLimitExceededException' => ItemCollectionSizeLimitExceededException::class,
+            'TransactionConflictException' => TransactionConflictException::class,
+            'RequestLimitExceeded' => RequestLimitExceededException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+        ]]));
 
         return new DeleteItemOutput($response);
     }
@@ -178,11 +233,21 @@ class DynamoDbClient extends AbstractApi
      *   TableName: string,
      *   @region?: string,
      * }|DeleteTableInput $input
+     *
+     * @throws ResourceInUseException
+     * @throws ResourceNotFoundException
+     * @throws LimitExceededException
+     * @throws InternalServerErrorException
      */
     public function deleteTable($input): DeleteTableOutput
     {
         $input = DeleteTableInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteTable', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteTable', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceInUseException' => ResourceInUseException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'LimitExceededException' => LimitExceededException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+        ]]));
 
         return new DeleteTableOutput($response);
     }
@@ -198,11 +263,17 @@ class DynamoDbClient extends AbstractApi
      *   TableName: string,
      *   @region?: string,
      * }|DescribeTableInput $input
+     *
+     * @throws ResourceNotFoundException
+     * @throws InternalServerErrorException
      */
     public function describeTable($input): DescribeTableOutput
     {
         $input = DescribeTableInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DescribeTable', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DescribeTable', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+        ]]));
 
         return new DescribeTableOutput($response);
     }
@@ -224,11 +295,21 @@ class DynamoDbClient extends AbstractApi
      *   ExpressionAttributeNames?: array<string, string>,
      *   @region?: string,
      * }|GetItemInput $input
+     *
+     * @throws ProvisionedThroughputExceededException
+     * @throws ResourceNotFoundException
+     * @throws RequestLimitExceededException
+     * @throws InternalServerErrorException
      */
     public function getItem($input): GetItemOutput
     {
         $input = GetItemInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetItem', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetItem', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'RequestLimitExceeded' => RequestLimitExceededException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+        ]]));
 
         return new GetItemOutput($response);
     }
@@ -245,11 +326,15 @@ class DynamoDbClient extends AbstractApi
      *   Limit?: int,
      *   @region?: string,
      * }|ListTablesInput $input
+     *
+     * @throws InternalServerErrorException
      */
     public function listTables($input = []): ListTablesOutput
     {
         $input = ListTablesInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ListTables', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ListTables', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InternalServerError' => InternalServerErrorException::class,
+        ]]));
 
         return new ListTablesOutput($response, $this, $input);
     }
@@ -277,11 +362,27 @@ class DynamoDbClient extends AbstractApi
      *   ExpressionAttributeValues?: array<string, AttributeValue>,
      *   @region?: string,
      * }|PutItemInput $input
+     *
+     * @throws ConditionalCheckFailedException
+     * @throws ProvisionedThroughputExceededException
+     * @throws ResourceNotFoundException
+     * @throws ItemCollectionSizeLimitExceededException
+     * @throws TransactionConflictException
+     * @throws RequestLimitExceededException
+     * @throws InternalServerErrorException
      */
     public function putItem($input): PutItemOutput
     {
         $input = PutItemInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PutItem', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PutItem', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ConditionalCheckFailedException' => ConditionalCheckFailedException::class,
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'ItemCollectionSizeLimitExceededException' => ItemCollectionSizeLimitExceededException::class,
+            'TransactionConflictException' => TransactionConflictException::class,
+            'RequestLimitExceeded' => RequestLimitExceededException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+        ]]));
 
         return new PutItemOutput($response);
     }
@@ -313,11 +414,21 @@ class DynamoDbClient extends AbstractApi
      *   ExpressionAttributeValues?: array<string, AttributeValue>,
      *   @region?: string,
      * }|QueryInput $input
+     *
+     * @throws ProvisionedThroughputExceededException
+     * @throws ResourceNotFoundException
+     * @throws RequestLimitExceededException
+     * @throws InternalServerErrorException
      */
     public function query($input): QueryOutput
     {
         $input = QueryInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'Query', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'Query', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'RequestLimitExceeded' => RequestLimitExceededException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+        ]]));
 
         return new QueryOutput($response, $this, $input);
     }
@@ -348,18 +459,26 @@ class DynamoDbClient extends AbstractApi
      *   ConsistentRead?: bool,
      *   @region?: string,
      * }|ScanInput $input
+     *
+     * @throws ProvisionedThroughputExceededException
+     * @throws ResourceNotFoundException
+     * @throws RequestLimitExceededException
+     * @throws InternalServerErrorException
      */
     public function scan($input): ScanOutput
     {
         $input = ScanInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'Scan', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'Scan', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'RequestLimitExceeded' => RequestLimitExceededException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+        ]]));
 
         return new ScanOutput($response, $this, $input);
     }
 
     /**
-     * Check status of operation describeTable.
-     *
      * @see describeTable
      *
      * @param array{
@@ -370,14 +489,15 @@ class DynamoDbClient extends AbstractApi
     public function tableExists($input): TableExistsWaiter
     {
         $input = DescribeTableInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DescribeTable', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DescribeTable', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+        ]]));
 
         return new TableExistsWaiter($response, $this, $input);
     }
 
     /**
-     * Check status of operation describeTable.
-     *
      * @see describeTable
      *
      * @param array{
@@ -388,7 +508,10 @@ class DynamoDbClient extends AbstractApi
     public function tableNotExists($input): TableNotExistsWaiter
     {
         $input = DescribeTableInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DescribeTable', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DescribeTable', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+        ]]));
 
         return new TableNotExistsWaiter($response, $this, $input);
     }
@@ -417,11 +540,27 @@ class DynamoDbClient extends AbstractApi
      *   ExpressionAttributeValues?: array<string, AttributeValue>,
      *   @region?: string,
      * }|UpdateItemInput $input
+     *
+     * @throws ConditionalCheckFailedException
+     * @throws ProvisionedThroughputExceededException
+     * @throws ResourceNotFoundException
+     * @throws ItemCollectionSizeLimitExceededException
+     * @throws TransactionConflictException
+     * @throws RequestLimitExceededException
+     * @throws InternalServerErrorException
      */
     public function updateItem($input): UpdateItemOutput
     {
         $input = UpdateItemInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'UpdateItem', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'UpdateItem', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ConditionalCheckFailedException' => ConditionalCheckFailedException::class,
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'ItemCollectionSizeLimitExceededException' => ItemCollectionSizeLimitExceededException::class,
+            'TransactionConflictException' => TransactionConflictException::class,
+            'RequestLimitExceeded' => RequestLimitExceededException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+        ]]));
 
         return new UpdateItemOutput($response);
     }
@@ -444,11 +583,21 @@ class DynamoDbClient extends AbstractApi
      *   ReplicaUpdates?: ReplicationGroupUpdate[],
      *   @region?: string,
      * }|UpdateTableInput $input
+     *
+     * @throws ResourceInUseException
+     * @throws ResourceNotFoundException
+     * @throws LimitExceededException
+     * @throws InternalServerErrorException
      */
     public function updateTable($input): UpdateTableOutput
     {
         $input = UpdateTableInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'UpdateTable', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'UpdateTable', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceInUseException' => ResourceInUseException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'LimitExceededException' => LimitExceededException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+        ]]));
 
         return new UpdateTableOutput($response);
     }
@@ -467,11 +616,21 @@ class DynamoDbClient extends AbstractApi
      *   TimeToLiveSpecification: TimeToLiveSpecification|array,
      *   @region?: string,
      * }|UpdateTimeToLiveInput $input
+     *
+     * @throws ResourceInUseException
+     * @throws ResourceNotFoundException
+     * @throws LimitExceededException
+     * @throws InternalServerErrorException
      */
     public function updateTimeToLive($input): UpdateTimeToLiveOutput
     {
         $input = UpdateTimeToLiveInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'UpdateTimeToLive', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'UpdateTimeToLive', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceInUseException' => ResourceInUseException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'LimitExceededException' => LimitExceededException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+        ]]));
 
         return new UpdateTimeToLiveOutput($response);
     }

--- a/src/Service/DynamoDb/src/Exception/ConditionalCheckFailedException.php
+++ b/src/Service/DynamoDb/src/Exception/ConditionalCheckFailedException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * A condition specified in the operation could not be evaluated.
+ */
+final class ConditionalCheckFailedException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/DynamoDb/src/Exception/InternalServerErrorException.php
+++ b/src/Service/DynamoDb/src/Exception/InternalServerErrorException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * An error occurred on the server side.
+ */
+final class InternalServerErrorException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/DynamoDb/src/Exception/ItemCollectionSizeLimitExceededException.php
+++ b/src/Service/DynamoDb/src/Exception/ItemCollectionSizeLimitExceededException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * An item collection is too large. This exception is only returned for tables that have one or more local secondary
+ * indexes.
+ */
+final class ItemCollectionSizeLimitExceededException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/DynamoDb/src/Exception/LimitExceededException.php
+++ b/src/Service/DynamoDb/src/Exception/LimitExceededException.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * There is no limit to the number of daily on-demand backups that can be taken.
+ * Up to 50 simultaneous table operations are allowed per account. These operations include `CreateTable`,
+ * `UpdateTable`, `DeleteTable`,`UpdateTimeToLive`, `RestoreTableFromBackup`, and `RestoreTableToPointInTime`.
+ * The only exception is when you are creating a table with one or more secondary indexes. You can have up to 25 such
+ * requests running at a time; however, if the table or index specifications are complex, DynamoDB might temporarily
+ * reduce the number of concurrent operations.
+ * There is a soft account quota of 256 tables.
+ */
+final class LimitExceededException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/DynamoDb/src/Exception/ProvisionedThroughputExceededException.php
+++ b/src/Service/DynamoDb/src/Exception/ProvisionedThroughputExceededException.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Your request rate is too high. The AWS SDKs for DynamoDB automatically retry requests that receive this exception.
+ * Your request is eventually successful, unless your retry queue is too large to finish. Reduce the frequency of
+ * requests and use exponential backoff. For more information, go to Error Retries and Exponential Backoff in the
+ * *Amazon DynamoDB Developer Guide*.
+ *
+ * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Programming.Errors.html#Programming.Errors.RetryAndBackoff
+ */
+final class ProvisionedThroughputExceededException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/DynamoDb/src/Exception/RequestLimitExceededException.php
+++ b/src/Service/DynamoDb/src/Exception/RequestLimitExceededException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Throughput exceeds the current throughput quota for your account. Please contact AWS Support at AWS Support to
+ * request a quota increase.
+ *
+ * @see https://aws.amazon.com/support
+ */
+final class RequestLimitExceededException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/DynamoDb/src/Exception/ResourceInUseException.php
+++ b/src/Service/DynamoDb/src/Exception/ResourceInUseException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The operation conflicts with the resource's availability. For example, you attempted to recreate an existing table,
+ * or tried to delete a table currently in the `CREATING` state.
+ */
+final class ResourceInUseException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/DynamoDb/src/Exception/ResourceNotFoundException.php
+++ b/src/Service/DynamoDb/src/Exception/ResourceNotFoundException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The operation tried to access a nonexistent table or index. The resource might not be specified correctly, or its
+ * status might not be `ACTIVE`.
+ */
+final class ResourceNotFoundException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/DynamoDb/src/Exception/TransactionConflictException.php
+++ b/src/Service/DynamoDb/src/Exception/TransactionConflictException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Operation was rejected because there is an ongoing transaction for the item.
+ */
+final class TransactionConflictException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ecr/CHANGELOG.md
+++ b/src/Service/Ecr/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added documentation in class's headers.
+- Added Business Exceptions.
 
 ## 0.1.1
 

--- a/src/Service/Ecr/composer.json
+++ b/src/Service/Ecr/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
-        "async-aws/core": "^1.2"
+        "async-aws/core": "^1.9"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/Ecr/src/EcrClient.php
+++ b/src/Service/Ecr/src/EcrClient.php
@@ -8,6 +8,8 @@ use AsyncAws\Core\AwsError\JsonRpcAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
+use AsyncAws\Ecr\Exception\InvalidParameterException;
+use AsyncAws\Ecr\Exception\ServerException;
 use AsyncAws\Ecr\Input\GetAuthorizationTokenRequest;
 use AsyncAws\Ecr\Result\GetAuthorizationTokenResponse;
 
@@ -25,11 +27,17 @@ class EcrClient extends AbstractApi
      *   registryIds?: string[],
      *   @region?: string,
      * }|GetAuthorizationTokenRequest $input
+     *
+     * @throws ServerException
+     * @throws InvalidParameterException
      */
     public function getAuthorizationToken($input = []): GetAuthorizationTokenResponse
     {
         $input = GetAuthorizationTokenRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetAuthorizationToken', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetAuthorizationToken', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ServerException' => ServerException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+        ]]));
 
         return new GetAuthorizationTokenResponse($response);
     }

--- a/src/Service/Ecr/src/Exception/InvalidParameterException.php
+++ b/src/Service/Ecr/src/Exception/InvalidParameterException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\Ecr\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The specified parameter is invalid. Review the available parameters for the API request.
+ */
+final class InvalidParameterException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ecr/src/Exception/ServerException.php
+++ b/src/Service/Ecr/src/Exception/ServerException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\Ecr\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * These errors are usually caused by a server-side issue.
+ */
+final class ServerException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/EventBridge/CHANGELOG.md
+++ b/src/Service/EventBridge/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Changed case of object's properties to camelCase.
 - Added documentation in class's headers.
+- Added Business Exceptions.
 
 ## 1.0.1
 

--- a/src/Service/EventBridge/composer.json
+++ b/src/Service/EventBridge/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
-        "async-aws/core": "^1.2"
+        "async-aws/core": "^1.9"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/EventBridge/src/EventBridgeClient.php
+++ b/src/Service/EventBridge/src/EventBridgeClient.php
@@ -7,6 +7,7 @@ use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
 use AsyncAws\Core\AwsError\JsonRpcAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
+use AsyncAws\EventBridge\Exception\InternalException;
 use AsyncAws\EventBridge\Input\PutEventsRequest;
 use AsyncAws\EventBridge\Result\PutEventsResponse;
 use AsyncAws\EventBridge\ValueObject\PutEventsRequestEntry;
@@ -23,11 +24,15 @@ class EventBridgeClient extends AbstractApi
      *   Entries: PutEventsRequestEntry[],
      *   @region?: string,
      * }|PutEventsRequest $input
+     *
+     * @throws InternalException
      */
     public function putEvents($input): PutEventsResponse
     {
         $input = PutEventsRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PutEvents', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PutEvents', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InternalException' => InternalException::class,
+        ]]));
 
         return new PutEventsResponse($response);
     }

--- a/src/Service/EventBridge/src/Exception/InternalException.php
+++ b/src/Service/EventBridge/src/Exception/InternalException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\EventBridge\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * This exception occurs due to unexpected causes.
+ */
+final class InternalException extends ClientException
+{
+}

--- a/src/Service/Iam/composer.json
+++ b/src/Service/Iam/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
-        "async-aws/core": "^1.2"
+        "async-aws/core": "^1.9"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/Iam/src/Exception/ConcurrentModificationException.php
+++ b/src/Service/Iam/src/Exception/ConcurrentModificationException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AsyncAws\Iam\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request was rejected because multiple requests to change this object were submitted simultaneously. Wait a few
+ * minutes and submit your request again.
+ */
+final class ConcurrentModificationException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Iam/src/Exception/DeleteConflictException.php
+++ b/src/Service/Iam/src/Exception/DeleteConflictException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AsyncAws\Iam\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request was rejected because it attempted to delete a resource that has attached subordinate entities. The error
+ * message describes these entities.
+ */
+final class DeleteConflictException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Iam/src/Exception/EntityAlreadyExistsException.php
+++ b/src/Service/Iam/src/Exception/EntityAlreadyExistsException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Iam\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request was rejected because it attempted to create a resource that already exists.
+ */
+final class EntityAlreadyExistsException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Iam/src/Exception/EntityTemporarilyUnmodifiableException.php
+++ b/src/Service/Iam/src/Exception/EntityTemporarilyUnmodifiableException.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace AsyncAws\Iam\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request was rejected because it referenced an entity that is temporarily unmodifiable, such as a user name that
+ * was deleted and then recreated. The error indicates that the request is likely to succeed if you try again after
+ * waiting several minutes. The error message describes the entity.
+ */
+final class EntityTemporarilyUnmodifiableException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Iam/src/Exception/InvalidInputException.php
+++ b/src/Service/Iam/src/Exception/InvalidInputException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Iam\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request was rejected because an invalid or out-of-range value was supplied for an input parameter.
+ */
+final class InvalidInputException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Iam/src/Exception/LimitExceededException.php
+++ b/src/Service/Iam/src/Exception/LimitExceededException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AsyncAws\Iam\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request was rejected because it attempted to create resources beyond the current AWS account limitations. The
+ * error message describes the limit exceeded.
+ */
+final class LimitExceededException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Iam/src/Exception/NoSuchEntityException.php
+++ b/src/Service/Iam/src/Exception/NoSuchEntityException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AsyncAws\Iam\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request was rejected because it referenced a resource entity that does not exist. The error message describes the
+ * resource.
+ */
+final class NoSuchEntityException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Iam/src/Exception/ServiceFailureException.php
+++ b/src/Service/Iam/src/Exception/ServiceFailureException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Iam\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request processing has failed because of an unknown error, exception or failure.
+ */
+final class ServiceFailureException extends ServerException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Iam/src/IamClient.php
+++ b/src/Service/Iam/src/IamClient.php
@@ -7,6 +7,14 @@ use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
 use AsyncAws\Core\AwsError\XmlAwsErrorFactory;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
+use AsyncAws\Iam\Exception\ConcurrentModificationException;
+use AsyncAws\Iam\Exception\DeleteConflictException;
+use AsyncAws\Iam\Exception\EntityAlreadyExistsException;
+use AsyncAws\Iam\Exception\EntityTemporarilyUnmodifiableException;
+use AsyncAws\Iam\Exception\InvalidInputException;
+use AsyncAws\Iam\Exception\LimitExceededException;
+use AsyncAws\Iam\Exception\NoSuchEntityException;
+use AsyncAws\Iam\Exception\ServiceFailureException;
 use AsyncAws\Iam\Input\AddUserToGroupRequest;
 use AsyncAws\Iam\Input\CreateAccessKeyRequest;
 use AsyncAws\Iam\Input\CreateUserRequest;
@@ -35,11 +43,19 @@ class IamClient extends AbstractApi
      *   UserName: string,
      *   @region?: string,
      * }|AddUserToGroupRequest $input
+     *
+     * @throws NoSuchEntityException
+     * @throws LimitExceededException
+     * @throws ServiceFailureException
      */
     public function addUserToGroup($input): Result
     {
         $input = AddUserToGroupRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AddUserToGroup', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AddUserToGroup', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'NoSuchEntity' => NoSuchEntityException::class,
+            'LimitExceeded' => LimitExceededException::class,
+            'ServiceFailure' => ServiceFailureException::class,
+        ]]));
 
         return new Result($response);
     }
@@ -55,11 +71,19 @@ class IamClient extends AbstractApi
      *   UserName?: string,
      *   @region?: string,
      * }|CreateAccessKeyRequest $input
+     *
+     * @throws NoSuchEntityException
+     * @throws LimitExceededException
+     * @throws ServiceFailureException
      */
     public function createAccessKey($input = []): CreateAccessKeyResponse
     {
         $input = CreateAccessKeyRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateAccessKey', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateAccessKey', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'NoSuchEntity' => NoSuchEntityException::class,
+            'LimitExceeded' => LimitExceededException::class,
+            'ServiceFailure' => ServiceFailureException::class,
+        ]]));
 
         return new CreateAccessKeyResponse($response);
     }
@@ -77,11 +101,25 @@ class IamClient extends AbstractApi
      *   Tags?: Tag[],
      *   @region?: string,
      * }|CreateUserRequest $input
+     *
+     * @throws LimitExceededException
+     * @throws EntityAlreadyExistsException
+     * @throws NoSuchEntityException
+     * @throws InvalidInputException
+     * @throws ConcurrentModificationException
+     * @throws ServiceFailureException
      */
     public function createUser($input): CreateUserResponse
     {
         $input = CreateUserRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateUser', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateUser', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'LimitExceeded' => LimitExceededException::class,
+            'EntityAlreadyExists' => EntityAlreadyExistsException::class,
+            'NoSuchEntity' => NoSuchEntityException::class,
+            'InvalidInput' => InvalidInputException::class,
+            'ConcurrentModification' => ConcurrentModificationException::class,
+            'ServiceFailure' => ServiceFailureException::class,
+        ]]));
 
         return new CreateUserResponse($response);
     }
@@ -97,11 +135,19 @@ class IamClient extends AbstractApi
      *   AccessKeyId: string,
      *   @region?: string,
      * }|DeleteAccessKeyRequest $input
+     *
+     * @throws NoSuchEntityException
+     * @throws LimitExceededException
+     * @throws ServiceFailureException
      */
     public function deleteAccessKey($input): Result
     {
         $input = DeleteAccessKeyRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteAccessKey', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteAccessKey', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'NoSuchEntity' => NoSuchEntityException::class,
+            'LimitExceeded' => LimitExceededException::class,
+            'ServiceFailure' => ServiceFailureException::class,
+        ]]));
 
         return new Result($response);
     }
@@ -119,11 +165,23 @@ class IamClient extends AbstractApi
      *   UserName: string,
      *   @region?: string,
      * }|DeleteUserRequest $input
+     *
+     * @throws LimitExceededException
+     * @throws NoSuchEntityException
+     * @throws DeleteConflictException
+     * @throws ConcurrentModificationException
+     * @throws ServiceFailureException
      */
     public function deleteUser($input): Result
     {
         $input = DeleteUserRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteUser', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteUser', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'LimitExceeded' => LimitExceededException::class,
+            'NoSuchEntity' => NoSuchEntityException::class,
+            'DeleteConflict' => DeleteConflictException::class,
+            'ConcurrentModification' => ConcurrentModificationException::class,
+            'ServiceFailure' => ServiceFailureException::class,
+        ]]));
 
         return new Result($response);
     }
@@ -138,11 +196,17 @@ class IamClient extends AbstractApi
      *   UserName?: string,
      *   @region?: string,
      * }|GetUserRequest $input
+     *
+     * @throws NoSuchEntityException
+     * @throws ServiceFailureException
      */
     public function getUser($input = []): GetUserResponse
     {
         $input = GetUserRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetUser', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetUser', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'NoSuchEntity' => NoSuchEntityException::class,
+            'ServiceFailure' => ServiceFailureException::class,
+        ]]));
 
         return new GetUserResponse($response);
     }
@@ -160,11 +224,15 @@ class IamClient extends AbstractApi
      *   MaxItems?: int,
      *   @region?: string,
      * }|ListUsersRequest $input
+     *
+     * @throws ServiceFailureException
      */
     public function listUsers($input = []): ListUsersResponse
     {
         $input = ListUsersRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ListUsers', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ListUsers', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ServiceFailure' => ServiceFailureException::class,
+        ]]));
 
         return new ListUsersResponse($response, $this, $input);
     }
@@ -181,11 +249,25 @@ class IamClient extends AbstractApi
      *   NewUserName?: string,
      *   @region?: string,
      * }|UpdateUserRequest $input
+     *
+     * @throws NoSuchEntityException
+     * @throws LimitExceededException
+     * @throws EntityAlreadyExistsException
+     * @throws EntityTemporarilyUnmodifiableException
+     * @throws ConcurrentModificationException
+     * @throws ServiceFailureException
      */
     public function updateUser($input): Result
     {
         $input = UpdateUserRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'UpdateUser', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'UpdateUser', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'NoSuchEntity' => NoSuchEntityException::class,
+            'LimitExceeded' => LimitExceededException::class,
+            'EntityAlreadyExists' => EntityAlreadyExistsException::class,
+            'EntityTemporarilyUnmodifiable' => EntityTemporarilyUnmodifiableException::class,
+            'ConcurrentModification' => ConcurrentModificationException::class,
+            'ServiceFailure' => ServiceFailureException::class,
+        ]]));
 
         return new Result($response);
     }

--- a/src/Service/Lambda/CHANGELOG.md
+++ b/src/Service/Lambda/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Changed case of object's properties to camelCase.
 - Added documentation in class's headers.
+- Added Business Exceptions.
 
 ## 1.2.0
 

--- a/src/Service/Lambda/composer.json
+++ b/src/Service/Lambda/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
-        "async-aws/core": "^1.2"
+        "async-aws/core": "^1.9"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/Lambda/src/Enum/ThrottleReason.php
+++ b/src/Service/Lambda/src/Enum/ThrottleReason.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Lambda\Enum;
+
+final class ThrottleReason
+{
+    public const CALLER_RATE_LIMIT_EXCEEDED = 'CallerRateLimitExceeded';
+    public const CONCURRENT_INVOCATION_LIMIT_EXCEEDED = 'ConcurrentInvocationLimitExceeded';
+    public const FUNCTION_INVOCATION_RATE_LIMIT_EXCEEDED = 'FunctionInvocationRateLimitExceeded';
+    public const RESERVED_FUNCTION_CONCURRENT_INVOCATION_LIMIT_EXCEEDED = 'ReservedFunctionConcurrentInvocationLimitExceeded';
+    public const RESERVED_FUNCTION_INVOCATION_RATE_LIMIT_EXCEEDED = 'ReservedFunctionInvocationRateLimitExceeded';
+
+    public static function exists(string $value): bool
+    {
+        return isset([
+            self::CALLER_RATE_LIMIT_EXCEEDED => true,
+            self::CONCURRENT_INVOCATION_LIMIT_EXCEEDED => true,
+            self::FUNCTION_INVOCATION_RATE_LIMIT_EXCEEDED => true,
+            self::RESERVED_FUNCTION_CONCURRENT_INVOCATION_LIMIT_EXCEEDED => true,
+            self::RESERVED_FUNCTION_INVOCATION_RATE_LIMIT_EXCEEDED => true,
+        ][$value]);
+    }
+}

--- a/src/Service/Lambda/src/Exception/CodeStorageExceededException.php
+++ b/src/Service/Lambda/src/Exception/CodeStorageExceededException.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * You have exceeded your maximum total code size per account. Learn more.
+ *
+ * @see https://docs.aws.amazon.com/lambda/latest/dg/limits.html
+ */
+final class CodeStorageExceededException extends ClientException
+{
+    /**
+     * The exception type.
+     */
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/EC2AccessDeniedException.php
+++ b/src/Service/Lambda/src/Exception/EC2AccessDeniedException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Need additional permissions to configure VPC settings.
+ */
+final class EC2AccessDeniedException extends ServerException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/EC2ThrottledException.php
+++ b/src/Service/Lambda/src/Exception/EC2ThrottledException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * AWS Lambda was throttled by Amazon EC2 during Lambda function initialization using the execution role provided for
+ * the Lambda function.
+ */
+final class EC2ThrottledException extends ServerException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/EC2UnexpectedException.php
+++ b/src/Service/Lambda/src/Exception/EC2UnexpectedException.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * AWS Lambda received an unexpected EC2 client exception while setting up for the Lambda function.
+ */
+final class EC2UnexpectedException extends ServerException
+{
+    private $type;
+
+    private $ec2ErrorCode;
+
+    public function getEc2ErrorCode(): ?string
+    {
+        return $this->ec2ErrorCode;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+        $this->ec2ErrorCode = isset($data['EC2ErrorCode']) ? (string) $data['EC2ErrorCode'] : null;
+    }
+}

--- a/src/Service/Lambda/src/Exception/EFSIOException.php
+++ b/src/Service/Lambda/src/Exception/EFSIOException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * An error occured when reading from or writing to a connected file system.
+ */
+final class EFSIOException extends ClientException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/EFSMountConnectivityException.php
+++ b/src/Service/Lambda/src/Exception/EFSMountConnectivityException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The function couldn't make a network connection to the configured file system.
+ */
+final class EFSMountConnectivityException extends ClientException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/EFSMountFailureException.php
+++ b/src/Service/Lambda/src/Exception/EFSMountFailureException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The function couldn't mount the configured file system due to a permission or configuration issue.
+ */
+final class EFSMountFailureException extends ClientException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/EFSMountTimeoutException.php
+++ b/src/Service/Lambda/src/Exception/EFSMountTimeoutException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The function was able to make a network connection to the configured file system, but the mount operation timed out.
+ */
+final class EFSMountTimeoutException extends ClientException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/ENILimitReachedException.php
+++ b/src/Service/Lambda/src/Exception/ENILimitReachedException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * AWS Lambda was not able to create an elastic network interface in the VPC, specified as part of Lambda function
+ * configuration, because the limit for network interfaces has been reached.
+ */
+final class ENILimitReachedException extends ServerException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/InvalidParameterValueException.php
+++ b/src/Service/Lambda/src/Exception/InvalidParameterValueException.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * One of the parameters in the request is invalid.
+ */
+final class InvalidParameterValueException extends ClientException
+{
+    /**
+     * The exception type.
+     */
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/InvalidRequestContentException.php
+++ b/src/Service/Lambda/src/Exception/InvalidRequestContentException.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request body could not be parsed as JSON.
+ */
+final class InvalidRequestContentException extends ClientException
+{
+    /**
+     * The exception type.
+     */
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/InvalidRuntimeException.php
+++ b/src/Service/Lambda/src/Exception/InvalidRuntimeException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The runtime or runtime version specified is not supported.
+ */
+final class InvalidRuntimeException extends ServerException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/InvalidSecurityGroupIDException.php
+++ b/src/Service/Lambda/src/Exception/InvalidSecurityGroupIDException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The Security Group ID provided in the Lambda function VPC configuration is invalid.
+ */
+final class InvalidSecurityGroupIDException extends ServerException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/InvalidSubnetIDException.php
+++ b/src/Service/Lambda/src/Exception/InvalidSubnetIDException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The Subnet ID provided in the Lambda function VPC configuration is invalid.
+ */
+final class InvalidSubnetIDException extends ServerException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/InvalidZipFileException.php
+++ b/src/Service/Lambda/src/Exception/InvalidZipFileException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * AWS Lambda could not unzip the deployment package.
+ */
+final class InvalidZipFileException extends ServerException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/KMSAccessDeniedException.php
+++ b/src/Service/Lambda/src/Exception/KMSAccessDeniedException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Lambda was unable to decrypt the environment variables because KMS access was denied. Check the Lambda function's KMS
+ * permissions.
+ */
+final class KMSAccessDeniedException extends ServerException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/KMSDisabledException.php
+++ b/src/Service/Lambda/src/Exception/KMSDisabledException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Lambda was unable to decrypt the environment variables because the KMS key used is disabled. Check the Lambda
+ * function's KMS key settings.
+ */
+final class KMSDisabledException extends ServerException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/KMSInvalidStateException.php
+++ b/src/Service/Lambda/src/Exception/KMSInvalidStateException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Lambda was unable to decrypt the environment variables because the KMS key used is in an invalid state for Decrypt.
+ * Check the function's KMS key settings.
+ */
+final class KMSInvalidStateException extends ServerException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/KMSNotFoundException.php
+++ b/src/Service/Lambda/src/Exception/KMSNotFoundException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Lambda was unable to decrypt the environment variables because the KMS key was not found. Check the function's KMS
+ * key settings.
+ */
+final class KMSNotFoundException extends ServerException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/PolicyLengthExceededException.php
+++ b/src/Service/Lambda/src/Exception/PolicyLengthExceededException.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The permissions policy for the resource is too large. Learn more.
+ *
+ * @see https://docs.aws.amazon.com/lambda/latest/dg/limits.html
+ */
+final class PolicyLengthExceededException extends ClientException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/PreconditionFailedException.php
+++ b/src/Service/Lambda/src/Exception/PreconditionFailedException.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The RevisionId provided does not match the latest RevisionId for the Lambda function or alias. Call the `GetFunction`
+ * or the `GetAlias` API to retrieve the latest RevisionId for your resource.
+ */
+final class PreconditionFailedException extends ClientException
+{
+    /**
+     * The exception type.
+     */
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/RequestTooLargeException.php
+++ b/src/Service/Lambda/src/Exception/RequestTooLargeException.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request payload exceeded the `Invoke` request body JSON input limit. For more information, see Limits.
+ *
+ * @see https://docs.aws.amazon.com/lambda/latest/dg/limits.html
+ */
+final class RequestTooLargeException extends ClientException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/ResourceConflictException.php
+++ b/src/Service/Lambda/src/Exception/ResourceConflictException.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The resource already exists, or another operation is in progress.
+ */
+final class ResourceConflictException extends ClientException
+{
+    /**
+     * The exception type.
+     */
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/ResourceNotFoundException.php
+++ b/src/Service/Lambda/src/Exception/ResourceNotFoundException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The resource specified in the request does not exist.
+ */
+final class ResourceNotFoundException extends ClientException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/ResourceNotReadyException.php
+++ b/src/Service/Lambda/src/Exception/ResourceNotReadyException.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The function is inactive and its VPC connection is no longer available. Wait for the VPC connection to reestablish
+ * and try again.
+ */
+final class ResourceNotReadyException extends ServerException
+{
+    /**
+     * The exception type.
+     */
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/ServiceException.php
+++ b/src/Service/Lambda/src/Exception/ServiceException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The AWS Lambda service encountered an internal error.
+ */
+final class ServiceException extends ServerException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/SubnetIPAddressLimitReachedException.php
+++ b/src/Service/Lambda/src/Exception/SubnetIPAddressLimitReachedException.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * AWS Lambda was not able to set up VPC access for the Lambda function because one or more configured subnets has no
+ * available IP addresses.
+ */
+final class SubnetIPAddressLimitReachedException extends ServerException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/Exception/TooManyRequestsException.php
+++ b/src/Service/Lambda/src/Exception/TooManyRequestsException.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use AsyncAws\Lambda\Enum\ThrottleReason;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request throughput limit was exceeded.
+ */
+final class TooManyRequestsException extends ClientException
+{
+    /**
+     * The number of seconds the caller should wait before retrying.
+     */
+    private $retryAfterSeconds;
+
+    private $type;
+
+    private $reason;
+
+    /**
+     * @return ThrottleReason::*|null
+     */
+    public function getReason(): ?string
+    {
+        return $this->reason;
+    }
+
+    public function getRetryAfterSeconds(): ?string
+    {
+        return $this->retryAfterSeconds;
+    }
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $headers = $response->getHeaders();
+
+        $this->retryAfterSeconds = $headers['retry-after'][0] ?? null;
+
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+        $this->reason = isset($data['Reason']) ? (string) $data['Reason'] : null;
+    }
+}

--- a/src/Service/Lambda/src/Exception/UnsupportedMediaTypeException.php
+++ b/src/Service/Lambda/src/Exception/UnsupportedMediaTypeException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AsyncAws\Lambda\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The content type of the `Invoke` request body is not JSON.
+ */
+final class UnsupportedMediaTypeException extends ClientException
+{
+    private $type;
+
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->type = isset($data['Type']) ? (string) $data['Type'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Lambda/src/LambdaClient.php
+++ b/src/Service/Lambda/src/LambdaClient.php
@@ -10,6 +10,35 @@ use AsyncAws\Core\RequestContext;
 use AsyncAws\Lambda\Enum\InvocationType;
 use AsyncAws\Lambda\Enum\LogType;
 use AsyncAws\Lambda\Enum\Runtime;
+use AsyncAws\Lambda\Exception\CodeStorageExceededException;
+use AsyncAws\Lambda\Exception\EC2AccessDeniedException;
+use AsyncAws\Lambda\Exception\EC2ThrottledException;
+use AsyncAws\Lambda\Exception\EC2UnexpectedException;
+use AsyncAws\Lambda\Exception\EFSIOException;
+use AsyncAws\Lambda\Exception\EFSMountConnectivityException;
+use AsyncAws\Lambda\Exception\EFSMountFailureException;
+use AsyncAws\Lambda\Exception\EFSMountTimeoutException;
+use AsyncAws\Lambda\Exception\ENILimitReachedException;
+use AsyncAws\Lambda\Exception\InvalidParameterValueException;
+use AsyncAws\Lambda\Exception\InvalidRequestContentException;
+use AsyncAws\Lambda\Exception\InvalidRuntimeException;
+use AsyncAws\Lambda\Exception\InvalidSecurityGroupIDException;
+use AsyncAws\Lambda\Exception\InvalidSubnetIDException;
+use AsyncAws\Lambda\Exception\InvalidZipFileException;
+use AsyncAws\Lambda\Exception\KMSAccessDeniedException;
+use AsyncAws\Lambda\Exception\KMSDisabledException;
+use AsyncAws\Lambda\Exception\KMSInvalidStateException;
+use AsyncAws\Lambda\Exception\KMSNotFoundException;
+use AsyncAws\Lambda\Exception\PolicyLengthExceededException;
+use AsyncAws\Lambda\Exception\PreconditionFailedException;
+use AsyncAws\Lambda\Exception\RequestTooLargeException;
+use AsyncAws\Lambda\Exception\ResourceConflictException;
+use AsyncAws\Lambda\Exception\ResourceNotFoundException;
+use AsyncAws\Lambda\Exception\ResourceNotReadyException;
+use AsyncAws\Lambda\Exception\ServiceException;
+use AsyncAws\Lambda\Exception\SubnetIPAddressLimitReachedException;
+use AsyncAws\Lambda\Exception\TooManyRequestsException;
+use AsyncAws\Lambda\Exception\UnsupportedMediaTypeException;
 use AsyncAws\Lambda\Input\AddLayerVersionPermissionRequest;
 use AsyncAws\Lambda\Input\InvocationRequest;
 use AsyncAws\Lambda\Input\ListLayerVersionsRequest;
@@ -41,11 +70,27 @@ class LambdaClient extends AbstractApi
      *   RevisionId?: string,
      *   @region?: string,
      * }|AddLayerVersionPermissionRequest $input
+     *
+     * @throws ServiceException
+     * @throws ResourceNotFoundException
+     * @throws ResourceConflictException
+     * @throws TooManyRequestsException
+     * @throws InvalidParameterValueException
+     * @throws PolicyLengthExceededException
+     * @throws PreconditionFailedException
      */
     public function addLayerVersionPermission($input): AddLayerVersionPermissionResponse
     {
         $input = AddLayerVersionPermissionRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AddLayerVersionPermission', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'AddLayerVersionPermission', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ServiceException' => ServiceException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'ResourceConflictException' => ResourceConflictException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'InvalidParameterValueException' => InvalidParameterValueException::class,
+            'PolicyLengthExceededException' => PolicyLengthExceededException::class,
+            'PreconditionFailedException' => PreconditionFailedException::class,
+        ]]));
 
         return new AddLayerVersionPermissionResponse($response);
     }
@@ -66,11 +111,65 @@ class LambdaClient extends AbstractApi
      *   Qualifier?: string,
      *   @region?: string,
      * }|InvocationRequest $input
+     *
+     * @throws ServiceException
+     * @throws ResourceNotFoundException
+     * @throws InvalidRequestContentException
+     * @throws RequestTooLargeException
+     * @throws UnsupportedMediaTypeException
+     * @throws TooManyRequestsException
+     * @throws InvalidParameterValueException
+     * @throws EC2UnexpectedException
+     * @throws SubnetIPAddressLimitReachedException
+     * @throws ENILimitReachedException
+     * @throws EFSMountConnectivityException
+     * @throws EFSMountFailureException
+     * @throws EFSMountTimeoutException
+     * @throws EFSIOException
+     * @throws EC2ThrottledException
+     * @throws EC2AccessDeniedException
+     * @throws InvalidSubnetIDException
+     * @throws InvalidSecurityGroupIDException
+     * @throws InvalidZipFileException
+     * @throws KMSDisabledException
+     * @throws KMSInvalidStateException
+     * @throws KMSAccessDeniedException
+     * @throws KMSNotFoundException
+     * @throws InvalidRuntimeException
+     * @throws ResourceConflictException
+     * @throws ResourceNotReadyException
      */
     public function invoke($input): InvocationResponse
     {
         $input = InvocationRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'Invoke', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'Invoke', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ServiceException' => ServiceException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidRequestContentException' => InvalidRequestContentException::class,
+            'RequestTooLargeException' => RequestTooLargeException::class,
+            'UnsupportedMediaTypeException' => UnsupportedMediaTypeException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'InvalidParameterValueException' => InvalidParameterValueException::class,
+            'EC2UnexpectedException' => EC2UnexpectedException::class,
+            'SubnetIPAddressLimitReachedException' => SubnetIPAddressLimitReachedException::class,
+            'ENILimitReachedException' => ENILimitReachedException::class,
+            'EFSMountConnectivityException' => EFSMountConnectivityException::class,
+            'EFSMountFailureException' => EFSMountFailureException::class,
+            'EFSMountTimeoutException' => EFSMountTimeoutException::class,
+            'EFSIOException' => EFSIOException::class,
+            'EC2ThrottledException' => EC2ThrottledException::class,
+            'EC2AccessDeniedException' => EC2AccessDeniedException::class,
+            'InvalidSubnetIDException' => InvalidSubnetIDException::class,
+            'InvalidSecurityGroupIDException' => InvalidSecurityGroupIDException::class,
+            'InvalidZipFileException' => InvalidZipFileException::class,
+            'KMSDisabledException' => KMSDisabledException::class,
+            'KMSInvalidStateException' => KMSInvalidStateException::class,
+            'KMSAccessDeniedException' => KMSAccessDeniedException::class,
+            'KMSNotFoundException' => KMSNotFoundException::class,
+            'InvalidRuntimeException' => InvalidRuntimeException::class,
+            'ResourceConflictException' => ResourceConflictException::class,
+            'ResourceNotReadyException' => ResourceNotReadyException::class,
+        ]]));
 
         return new InvocationResponse($response);
     }
@@ -91,11 +190,21 @@ class LambdaClient extends AbstractApi
      *   MaxItems?: int,
      *   @region?: string,
      * }|ListLayerVersionsRequest $input
+     *
+     * @throws ServiceException
+     * @throws InvalidParameterValueException
+     * @throws ResourceNotFoundException
+     * @throws TooManyRequestsException
      */
     public function listLayerVersions($input): ListLayerVersionsResponse
     {
         $input = ListLayerVersionsRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ListLayerVersions', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ListLayerVersions', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ServiceException' => ServiceException::class,
+            'InvalidParameterValueException' => InvalidParameterValueException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+        ]]));
 
         return new ListLayerVersionsResponse($response, $this, $input);
     }
@@ -116,11 +225,23 @@ class LambdaClient extends AbstractApi
      *   LicenseInfo?: string,
      *   @region?: string,
      * }|PublishLayerVersionRequest $input
+     *
+     * @throws ServiceException
+     * @throws ResourceNotFoundException
+     * @throws TooManyRequestsException
+     * @throws InvalidParameterValueException
+     * @throws CodeStorageExceededException
      */
     public function publishLayerVersion($input): PublishLayerVersionResponse
     {
         $input = PublishLayerVersionRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PublishLayerVersion', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PublishLayerVersion', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ServiceException' => ServiceException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'InvalidParameterValueException' => InvalidParameterValueException::class,
+            'CodeStorageExceededException' => CodeStorageExceededException::class,
+        ]]));
 
         return new PublishLayerVersionResponse($response);
     }

--- a/src/Service/RdsDataService/CHANGELOG.md
+++ b/src/Service/RdsDataService/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Added documentation in class's headers.
+- Added Business Exceptions.
 
 ## 0.1.1
 

--- a/src/Service/RdsDataService/composer.json
+++ b/src/Service/RdsDataService/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.2.5",
         "ext-json": "*",
-        "async-aws/core": "^1.2"
+        "async-aws/core": "^1.9"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/RdsDataService/src/Exception/BadRequestException.php
+++ b/src/Service/RdsDataService/src/Exception/BadRequestException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\RdsDataService\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * There is an error in the call or in a SQL statement.
+ */
+final class BadRequestException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/RdsDataService/src/Exception/ForbiddenException.php
+++ b/src/Service/RdsDataService/src/Exception/ForbiddenException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\RdsDataService\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * There are insufficient privileges to make the call.
+ */
+final class ForbiddenException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/RdsDataService/src/Exception/InternalServerErrorException.php
+++ b/src/Service/RdsDataService/src/Exception/InternalServerErrorException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\RdsDataService\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+
+/**
+ * An internal error occurred.
+ */
+final class InternalServerErrorException extends ServerException
+{
+}

--- a/src/Service/RdsDataService/src/Exception/NotFoundException.php
+++ b/src/Service/RdsDataService/src/Exception/NotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\RdsDataService\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The `resourceArn`, `secretArn`, or `transactionId` value can't be found.
+ */
+final class NotFoundException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/RdsDataService/src/Exception/ServiceUnavailableErrorException.php
+++ b/src/Service/RdsDataService/src/Exception/ServiceUnavailableErrorException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\RdsDataService\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+
+/**
+ * The service specified by the `resourceArn` parameter is not available.
+ */
+final class ServiceUnavailableErrorException extends ServerException
+{
+}

--- a/src/Service/RdsDataService/src/Exception/StatementTimeoutException.php
+++ b/src/Service/RdsDataService/src/Exception/StatementTimeoutException.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace AsyncAws\RdsDataService\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The execution of the SQL statement timed out.
+ */
+final class StatementTimeoutException extends ClientException
+{
+    /**
+     * The database connection ID that executed the SQL statement.
+     */
+    private $dbConnectionId;
+
+    public function getDbConnectionId(): ?string
+    {
+        return $this->dbConnectionId;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        $this->dbConnectionId = isset($data['dbConnectionId']) ? (string) $data['dbConnectionId'] : null;
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/RdsDataService/src/RdsDataServiceClient.php
+++ b/src/Service/RdsDataService/src/RdsDataServiceClient.php
@@ -7,6 +7,12 @@ use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
 use AsyncAws\Core\AwsError\JsonRestAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
+use AsyncAws\RdsDataService\Exception\BadRequestException;
+use AsyncAws\RdsDataService\Exception\ForbiddenException;
+use AsyncAws\RdsDataService\Exception\InternalServerErrorException;
+use AsyncAws\RdsDataService\Exception\NotFoundException;
+use AsyncAws\RdsDataService\Exception\ServiceUnavailableErrorException;
+use AsyncAws\RdsDataService\Exception\StatementTimeoutException;
 use AsyncAws\RdsDataService\Input\BatchExecuteStatementRequest;
 use AsyncAws\RdsDataService\Input\BeginTransactionRequest;
 use AsyncAws\RdsDataService\Input\CommitTransactionRequest;
@@ -38,11 +44,23 @@ class RdsDataServiceClient extends AbstractApi
      *   transactionId?: string,
      *   @region?: string,
      * }|BatchExecuteStatementRequest $input
+     *
+     * @throws BadRequestException
+     * @throws StatementTimeoutException
+     * @throws InternalServerErrorException
+     * @throws ForbiddenException
+     * @throws ServiceUnavailableErrorException
      */
     public function batchExecuteStatement($input): BatchExecuteStatementResponse
     {
         $input = BatchExecuteStatementRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'BatchExecuteStatement', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'BatchExecuteStatement', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'BadRequestException' => BadRequestException::class,
+            'StatementTimeoutException' => StatementTimeoutException::class,
+            'InternalServerErrorException' => InternalServerErrorException::class,
+            'ForbiddenException' => ForbiddenException::class,
+            'ServiceUnavailableError' => ServiceUnavailableErrorException::class,
+        ]]));
 
         return new BatchExecuteStatementResponse($response);
     }
@@ -60,11 +78,23 @@ class RdsDataServiceClient extends AbstractApi
      *   secretArn: string,
      *   @region?: string,
      * }|BeginTransactionRequest $input
+     *
+     * @throws BadRequestException
+     * @throws StatementTimeoutException
+     * @throws InternalServerErrorException
+     * @throws ForbiddenException
+     * @throws ServiceUnavailableErrorException
      */
     public function beginTransaction($input): BeginTransactionResponse
     {
         $input = BeginTransactionRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'BeginTransaction', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'BeginTransaction', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'BadRequestException' => BadRequestException::class,
+            'StatementTimeoutException' => StatementTimeoutException::class,
+            'InternalServerErrorException' => InternalServerErrorException::class,
+            'ForbiddenException' => ForbiddenException::class,
+            'ServiceUnavailableError' => ServiceUnavailableErrorException::class,
+        ]]));
 
         return new BeginTransactionResponse($response);
     }
@@ -81,11 +111,25 @@ class RdsDataServiceClient extends AbstractApi
      *   transactionId: string,
      *   @region?: string,
      * }|CommitTransactionRequest $input
+     *
+     * @throws BadRequestException
+     * @throws StatementTimeoutException
+     * @throws InternalServerErrorException
+     * @throws ForbiddenException
+     * @throws ServiceUnavailableErrorException
+     * @throws NotFoundException
      */
     public function commitTransaction($input): CommitTransactionResponse
     {
         $input = CommitTransactionRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CommitTransaction', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CommitTransaction', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'BadRequestException' => BadRequestException::class,
+            'StatementTimeoutException' => StatementTimeoutException::class,
+            'InternalServerErrorException' => InternalServerErrorException::class,
+            'ForbiddenException' => ForbiddenException::class,
+            'ServiceUnavailableError' => ServiceUnavailableErrorException::class,
+            'NotFoundException' => NotFoundException::class,
+        ]]));
 
         return new CommitTransactionResponse($response);
     }
@@ -109,11 +153,23 @@ class RdsDataServiceClient extends AbstractApi
      *   transactionId?: string,
      *   @region?: string,
      * }|ExecuteStatementRequest $input
+     *
+     * @throws BadRequestException
+     * @throws StatementTimeoutException
+     * @throws InternalServerErrorException
+     * @throws ForbiddenException
+     * @throws ServiceUnavailableErrorException
      */
     public function executeStatement($input): ExecuteStatementResponse
     {
         $input = ExecuteStatementRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ExecuteStatement', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ExecuteStatement', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'BadRequestException' => BadRequestException::class,
+            'StatementTimeoutException' => StatementTimeoutException::class,
+            'InternalServerErrorException' => InternalServerErrorException::class,
+            'ForbiddenException' => ForbiddenException::class,
+            'ServiceUnavailableError' => ServiceUnavailableErrorException::class,
+        ]]));
 
         return new ExecuteStatementResponse($response);
     }
@@ -130,11 +186,25 @@ class RdsDataServiceClient extends AbstractApi
      *   transactionId: string,
      *   @region?: string,
      * }|RollbackTransactionRequest $input
+     *
+     * @throws BadRequestException
+     * @throws StatementTimeoutException
+     * @throws InternalServerErrorException
+     * @throws ForbiddenException
+     * @throws ServiceUnavailableErrorException
+     * @throws NotFoundException
      */
     public function rollbackTransaction($input): RollbackTransactionResponse
     {
         $input = RollbackTransactionRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'RollbackTransaction', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'RollbackTransaction', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'BadRequestException' => BadRequestException::class,
+            'StatementTimeoutException' => StatementTimeoutException::class,
+            'InternalServerErrorException' => InternalServerErrorException::class,
+            'ForbiddenException' => ForbiddenException::class,
+            'ServiceUnavailableError' => ServiceUnavailableErrorException::class,
+            'NotFoundException' => NotFoundException::class,
+        ]]));
 
         return new RollbackTransactionResponse($response);
     }

--- a/src/Service/Rekognition/CHANGELOG.md
+++ b/src/Service/Rekognition/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Changed case of object's properties to camelCase.
 - Added documentation in class's headers.
+- Added Business Exceptions
 
 ## 0.1.3
 

--- a/src/Service/Rekognition/composer.json
+++ b/src/Service/Rekognition/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
-        "async-aws/core": "^1.2"
+        "async-aws/core": "^1.9"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/Rekognition/src/Exception/AccessDeniedException.php
+++ b/src/Service/Rekognition/src/Exception/AccessDeniedException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Rekognition\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * You are not authorized to perform the action.
+ */
+final class AccessDeniedException extends ClientException
+{
+}

--- a/src/Service/Rekognition/src/Exception/ImageTooLargeException.php
+++ b/src/Service/Rekognition/src/Exception/ImageTooLargeException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace AsyncAws\Rekognition\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The input image size exceeds the allowed limit. For more information, see Limits in Amazon Rekognition in the Amazon
+ * Rekognition Developer Guide.
+ */
+final class ImageTooLargeException extends ClientException
+{
+}

--- a/src/Service/Rekognition/src/Exception/InternalServerErrorException.php
+++ b/src/Service/Rekognition/src/Exception/InternalServerErrorException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Rekognition\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * Amazon Rekognition experienced a service issue. Try your call again.
+ */
+final class InternalServerErrorException extends ClientException
+{
+}

--- a/src/Service/Rekognition/src/Exception/InvalidImageFormatException.php
+++ b/src/Service/Rekognition/src/Exception/InvalidImageFormatException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Rekognition\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The provided image format is not supported.
+ */
+final class InvalidImageFormatException extends ClientException
+{
+}

--- a/src/Service/Rekognition/src/Exception/InvalidPaginationTokenException.php
+++ b/src/Service/Rekognition/src/Exception/InvalidPaginationTokenException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Rekognition\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * Pagination token in the request is not valid.
+ */
+final class InvalidPaginationTokenException extends ClientException
+{
+}

--- a/src/Service/Rekognition/src/Exception/InvalidParameterException.php
+++ b/src/Service/Rekognition/src/Exception/InvalidParameterException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Rekognition\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * Input parameter violated a constraint. Validate your parameter before calling the API operation again.
+ */
+final class InvalidParameterException extends ClientException
+{
+}

--- a/src/Service/Rekognition/src/Exception/InvalidS3ObjectException.php
+++ b/src/Service/Rekognition/src/Exception/InvalidS3ObjectException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Rekognition\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * Amazon Rekognition is unable to access the S3 object specified in the request.
+ */
+final class InvalidS3ObjectException extends ClientException
+{
+}

--- a/src/Service/Rekognition/src/Exception/LimitExceededException.php
+++ b/src/Service/Rekognition/src/Exception/LimitExceededException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace AsyncAws\Rekognition\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * An Amazon Rekognition service limit was exceeded. For example, if you start too many Amazon Rekognition Video jobs
+ * concurrently, calls to start operations (`StartLabelDetection`, for example) will raise a `LimitExceededException`
+ * exception (HTTP status code: 400) until the number of concurrently running jobs is below the Amazon Rekognition
+ * service limit.
+ */
+final class LimitExceededException extends ClientException
+{
+}

--- a/src/Service/Rekognition/src/Exception/ProvisionedThroughputExceededException.php
+++ b/src/Service/Rekognition/src/Exception/ProvisionedThroughputExceededException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace AsyncAws\Rekognition\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The number of requests exceeded your throughput limit. If you want to increase this limit, contact Amazon
+ * Rekognition.
+ */
+final class ProvisionedThroughputExceededException extends ClientException
+{
+}

--- a/src/Service/Rekognition/src/Exception/ResourceAlreadyExistsException.php
+++ b/src/Service/Rekognition/src/Exception/ResourceAlreadyExistsException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Rekognition\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * A collection with the specified ID already exists.
+ */
+final class ResourceAlreadyExistsException extends ClientException
+{
+}

--- a/src/Service/Rekognition/src/Exception/ResourceInUseException.php
+++ b/src/Service/Rekognition/src/Exception/ResourceInUseException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Rekognition\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The specified resource is already being used.
+ */
+final class ResourceInUseException extends ClientException
+{
+}

--- a/src/Service/Rekognition/src/Exception/ResourceNotFoundException.php
+++ b/src/Service/Rekognition/src/Exception/ResourceNotFoundException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Rekognition\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The collection specified in the request cannot be found.
+ */
+final class ResourceNotFoundException extends ClientException
+{
+}

--- a/src/Service/Rekognition/src/Exception/ServiceQuotaExceededException.php
+++ b/src/Service/Rekognition/src/Exception/ServiceQuotaExceededException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace AsyncAws\Rekognition\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The size of the collection exceeds the allowed limit. For more information, see Limits in Amazon Rekognition in the
+ * Amazon Rekognition Developer Guide.
+ */
+final class ServiceQuotaExceededException extends ClientException
+{
+}

--- a/src/Service/Rekognition/src/Exception/ThrottlingException.php
+++ b/src/Service/Rekognition/src/Exception/ThrottlingException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Rekognition\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * Amazon Rekognition is temporarily unable to process the request. Try your call again.
+ */
+final class ThrottlingException extends ClientException
+{
+}

--- a/src/Service/Rekognition/src/RekognitionClient.php
+++ b/src/Service/Rekognition/src/RekognitionClient.php
@@ -9,6 +9,20 @@ use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Rekognition\Enum\Attribute;
 use AsyncAws\Rekognition\Enum\QualityFilter;
+use AsyncAws\Rekognition\Exception\AccessDeniedException;
+use AsyncAws\Rekognition\Exception\ImageTooLargeException;
+use AsyncAws\Rekognition\Exception\InternalServerErrorException;
+use AsyncAws\Rekognition\Exception\InvalidImageFormatException;
+use AsyncAws\Rekognition\Exception\InvalidPaginationTokenException;
+use AsyncAws\Rekognition\Exception\InvalidParameterException;
+use AsyncAws\Rekognition\Exception\InvalidS3ObjectException;
+use AsyncAws\Rekognition\Exception\LimitExceededException;
+use AsyncAws\Rekognition\Exception\ProvisionedThroughputExceededException;
+use AsyncAws\Rekognition\Exception\ResourceAlreadyExistsException;
+use AsyncAws\Rekognition\Exception\ResourceInUseException;
+use AsyncAws\Rekognition\Exception\ResourceNotFoundException;
+use AsyncAws\Rekognition\Exception\ServiceQuotaExceededException;
+use AsyncAws\Rekognition\Exception\ThrottlingException;
 use AsyncAws\Rekognition\Input\CreateCollectionRequest;
 use AsyncAws\Rekognition\Input\CreateProjectRequest;
 use AsyncAws\Rekognition\Input\DeleteCollectionRequest;
@@ -39,11 +53,25 @@ class RekognitionClient extends AbstractApi
      *   CollectionId: string,
      *   @region?: string,
      * }|CreateCollectionRequest $input
+     *
+     * @throws InvalidParameterException
+     * @throws AccessDeniedException
+     * @throws InternalServerErrorException
+     * @throws ThrottlingException
+     * @throws ProvisionedThroughputExceededException
+     * @throws ResourceAlreadyExistsException
      */
     public function createCollection($input): CreateCollectionResponse
     {
         $input = CreateCollectionRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateCollection', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateCollection', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidParameterException' => InvalidParameterException::class,
+            'AccessDeniedException' => AccessDeniedException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+            'ThrottlingException' => ThrottlingException::class,
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+            'ResourceAlreadyExistsException' => ResourceAlreadyExistsException::class,
+        ]]));
 
         return new CreateCollectionResponse($response);
     }
@@ -59,11 +87,27 @@ class RekognitionClient extends AbstractApi
      *   ProjectName: string,
      *   @region?: string,
      * }|CreateProjectRequest $input
+     *
+     * @throws ResourceInUseException
+     * @throws LimitExceededException
+     * @throws InvalidParameterException
+     * @throws AccessDeniedException
+     * @throws InternalServerErrorException
+     * @throws ThrottlingException
+     * @throws ProvisionedThroughputExceededException
      */
     public function createProject($input): CreateProjectResponse
     {
         $input = CreateProjectRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateProject', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateProject', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceInUseException' => ResourceInUseException::class,
+            'LimitExceededException' => LimitExceededException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'AccessDeniedException' => AccessDeniedException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+            'ThrottlingException' => ThrottlingException::class,
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+        ]]));
 
         return new CreateProjectResponse($response);
     }
@@ -79,11 +123,25 @@ class RekognitionClient extends AbstractApi
      *   CollectionId: string,
      *   @region?: string,
      * }|DeleteCollectionRequest $input
+     *
+     * @throws InvalidParameterException
+     * @throws AccessDeniedException
+     * @throws InternalServerErrorException
+     * @throws ThrottlingException
+     * @throws ProvisionedThroughputExceededException
+     * @throws ResourceNotFoundException
      */
     public function deleteCollection($input): DeleteCollectionResponse
     {
         $input = DeleteCollectionRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteCollection', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteCollection', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidParameterException' => InvalidParameterException::class,
+            'AccessDeniedException' => AccessDeniedException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+            'ThrottlingException' => ThrottlingException::class,
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+        ]]));
 
         return new DeleteCollectionResponse($response);
     }
@@ -99,11 +157,27 @@ class RekognitionClient extends AbstractApi
      *   ProjectArn: string,
      *   @region?: string,
      * }|DeleteProjectRequest $input
+     *
+     * @throws ResourceInUseException
+     * @throws ResourceNotFoundException
+     * @throws InvalidParameterException
+     * @throws AccessDeniedException
+     * @throws InternalServerErrorException
+     * @throws ThrottlingException
+     * @throws ProvisionedThroughputExceededException
      */
     public function deleteProject($input): DeleteProjectResponse
     {
         $input = DeleteProjectRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteProject', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteProject', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ResourceInUseException' => ResourceInUseException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'AccessDeniedException' => AccessDeniedException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+            'ThrottlingException' => ThrottlingException::class,
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+        ]]));
 
         return new DeleteProjectResponse($response);
     }
@@ -119,11 +193,29 @@ class RekognitionClient extends AbstractApi
      *   Attributes?: list<Attribute::*>,
      *   @region?: string,
      * }|DetectFacesRequest $input
+     *
+     * @throws InvalidS3ObjectException
+     * @throws InvalidParameterException
+     * @throws ImageTooLargeException
+     * @throws AccessDeniedException
+     * @throws InternalServerErrorException
+     * @throws ThrottlingException
+     * @throws ProvisionedThroughputExceededException
+     * @throws InvalidImageFormatException
      */
     public function detectFaces($input): DetectFacesResponse
     {
         $input = DetectFacesRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DetectFaces', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DetectFaces', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidS3ObjectException' => InvalidS3ObjectException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'ImageTooLargeException' => ImageTooLargeException::class,
+            'AccessDeniedException' => AccessDeniedException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+            'ThrottlingException' => ThrottlingException::class,
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+            'InvalidImageFormatException' => InvalidImageFormatException::class,
+        ]]));
 
         return new DetectFacesResponse($response);
     }
@@ -143,11 +235,33 @@ class RekognitionClient extends AbstractApi
      *   QualityFilter?: QualityFilter::*,
      *   @region?: string,
      * }|IndexFacesRequest $input
+     *
+     * @throws InvalidS3ObjectException
+     * @throws InvalidParameterException
+     * @throws ImageTooLargeException
+     * @throws AccessDeniedException
+     * @throws InternalServerErrorException
+     * @throws ThrottlingException
+     * @throws ProvisionedThroughputExceededException
+     * @throws ResourceNotFoundException
+     * @throws InvalidImageFormatException
+     * @throws ServiceQuotaExceededException
      */
     public function indexFaces($input): IndexFacesResponse
     {
         $input = IndexFacesRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'IndexFaces', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'IndexFaces', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidS3ObjectException' => InvalidS3ObjectException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'ImageTooLargeException' => ImageTooLargeException::class,
+            'AccessDeniedException' => AccessDeniedException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+            'ThrottlingException' => ThrottlingException::class,
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidImageFormatException' => InvalidImageFormatException::class,
+            'ServiceQuotaExceededException' => ServiceQuotaExceededException::class,
+        ]]));
 
         return new IndexFacesResponse($response);
     }
@@ -164,11 +278,27 @@ class RekognitionClient extends AbstractApi
      *   MaxResults?: int,
      *   @region?: string,
      * }|ListCollectionsRequest $input
+     *
+     * @throws InvalidParameterException
+     * @throws AccessDeniedException
+     * @throws InternalServerErrorException
+     * @throws ThrottlingException
+     * @throws ProvisionedThroughputExceededException
+     * @throws InvalidPaginationTokenException
+     * @throws ResourceNotFoundException
      */
     public function listCollections($input = []): ListCollectionsResponse
     {
         $input = ListCollectionsRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ListCollections', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ListCollections', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidParameterException' => InvalidParameterException::class,
+            'AccessDeniedException' => AccessDeniedException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+            'ThrottlingException' => ThrottlingException::class,
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+            'InvalidPaginationTokenException' => InvalidPaginationTokenException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+        ]]));
 
         return new ListCollectionsResponse($response, $this, $input);
     }
@@ -188,11 +318,31 @@ class RekognitionClient extends AbstractApi
      *   QualityFilter?: QualityFilter::*,
      *   @region?: string,
      * }|SearchFacesByImageRequest $input
+     *
+     * @throws InvalidS3ObjectException
+     * @throws InvalidParameterException
+     * @throws ImageTooLargeException
+     * @throws AccessDeniedException
+     * @throws InternalServerErrorException
+     * @throws ThrottlingException
+     * @throws ProvisionedThroughputExceededException
+     * @throws ResourceNotFoundException
+     * @throws InvalidImageFormatException
      */
     public function searchFacesByImage($input): SearchFacesByImageResponse
     {
         $input = SearchFacesByImageRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'SearchFacesByImage', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'SearchFacesByImage', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidS3ObjectException' => InvalidS3ObjectException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'ImageTooLargeException' => ImageTooLargeException::class,
+            'AccessDeniedException' => AccessDeniedException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+            'ThrottlingException' => ThrottlingException::class,
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'InvalidImageFormatException' => InvalidImageFormatException::class,
+        ]]));
 
         return new SearchFacesByImageResponse($response);
     }

--- a/src/Service/S3/CHANGELOG.md
+++ b/src/Service/S3/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Changed case of object's properties to camelCase.
 - Added documentation in class's headers.
+- Added Business Exceptions
 
 ## 1.7.0
 

--- a/src/Service/S3/composer.json
+++ b/src/Service/S3/composer.json
@@ -16,7 +16,7 @@
         "ext-dom": "*",
         "ext-filter": "*",
         "ext-hash": "*",
-        "async-aws/core": "^1.2"
+        "async-aws/core": "^1.9"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/S3/src/Enum/IntelligentTieringAccessTier.php
+++ b/src/Service/S3/src/Enum/IntelligentTieringAccessTier.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace AsyncAws\S3\Enum;
+
+final class IntelligentTieringAccessTier
+{
+    public const ARCHIVE_ACCESS = 'ARCHIVE_ACCESS';
+    public const DEEP_ARCHIVE_ACCESS = 'DEEP_ARCHIVE_ACCESS';
+
+    public static function exists(string $value): bool
+    {
+        return isset([
+            self::ARCHIVE_ACCESS => true,
+            self::DEEP_ARCHIVE_ACCESS => true,
+        ][$value]);
+    }
+}

--- a/src/Service/S3/src/Exception/BucketAlreadyExistsException.php
+++ b/src/Service/S3/src/Exception/BucketAlreadyExistsException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace AsyncAws\S3\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The requested bucket name is not available. The bucket namespace is shared by all users of the system. Select a
+ * different name and try again.
+ */
+final class BucketAlreadyExistsException extends ClientException
+{
+}

--- a/src/Service/S3/src/Exception/BucketAlreadyOwnedByYouException.php
+++ b/src/Service/S3/src/Exception/BucketAlreadyOwnedByYouException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace AsyncAws\S3\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The bucket you tried to create already exists, and you own it. Amazon S3 returns this error in all AWS Regions except
+ * in the North Virginia Region. For legacy compatibility, if you re-create an existing bucket that you already own in
+ * the North Virginia Region, Amazon S3 returns 200 OK and resets the bucket access control lists (ACLs).
+ */
+final class BucketAlreadyOwnedByYouException extends ClientException
+{
+}

--- a/src/Service/S3/src/Exception/InvalidObjectStateException.php
+++ b/src/Service/S3/src/Exception/InvalidObjectStateException.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace AsyncAws\S3\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use AsyncAws\S3\Enum\IntelligentTieringAccessTier;
+use AsyncAws\S3\Enum\StorageClass;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Object is archived and inaccessible until restored.
+ */
+final class InvalidObjectStateException extends ClientException
+{
+    private $storageClass;
+
+    private $accessTier;
+
+    /**
+     * @return IntelligentTieringAccessTier::*|null
+     */
+    public function getAccessTier(): ?string
+    {
+        return $this->accessTier;
+    }
+
+    /**
+     * @return StorageClass::*|null
+     */
+    public function getStorageClass(): ?string
+    {
+        return $this->storageClass;
+    }
+
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        $this->storageClass = ($v = $data->StorageClass) ? (string) $v : null;
+        $this->accessTier = ($v = $data->AccessTier) ? (string) $v : null;
+    }
+}

--- a/src/Service/S3/src/Exception/NoSuchBucketException.php
+++ b/src/Service/S3/src/Exception/NoSuchBucketException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\S3\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The specified bucket does not exist.
+ */
+final class NoSuchBucketException extends ClientException
+{
+}

--- a/src/Service/S3/src/Exception/NoSuchKeyException.php
+++ b/src/Service/S3/src/Exception/NoSuchKeyException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\S3\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The specified key does not exist.
+ */
+final class NoSuchKeyException extends ClientException
+{
+}

--- a/src/Service/S3/src/Exception/NoSuchUploadException.php
+++ b/src/Service/S3/src/Exception/NoSuchUploadException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\S3\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The specified multipart upload does not exist.
+ */
+final class NoSuchUploadException extends ClientException
+{
+}

--- a/src/Service/S3/src/Exception/ObjectNotInActiveTierErrorException.php
+++ b/src/Service/S3/src/Exception/ObjectNotInActiveTierErrorException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\S3\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The source object of the COPY operation is not in the active tier and is only stored in Amazon S3 Glacier.
+ */
+final class ObjectNotInActiveTierErrorException extends ClientException
+{
+}

--- a/src/Service/Ses/CHANGELOG.md
+++ b/src/Service/Ses/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Changed case of object's properties to camelCase.
 - Added documentation in class's headers.
+- Added Business Exceptions
 
 ## 1.3.1
 

--- a/src/Service/Ses/composer.json
+++ b/src/Service/Ses/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
-        "async-aws/core": "^1.0"
+        "async-aws/core": "^1.9"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/Ses/src/Exception/AccountSuspendedException.php
+++ b/src/Service/Ses/src/Exception/AccountSuspendedException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Ses\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The message can't be sent because the account's ability to send email has been permanently restricted.
+ */
+final class AccountSuspendedException extends ClientException
+{
+}

--- a/src/Service/Ses/src/Exception/BadRequestException.php
+++ b/src/Service/Ses/src/Exception/BadRequestException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Ses\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The input you provided is invalid.
+ */
+final class BadRequestException extends ClientException
+{
+}

--- a/src/Service/Ses/src/Exception/LimitExceededException.php
+++ b/src/Service/Ses/src/Exception/LimitExceededException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Ses\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * There are too many instances of the specified resource type.
+ */
+final class LimitExceededException extends ClientException
+{
+}

--- a/src/Service/Ses/src/Exception/MailFromDomainNotVerifiedException.php
+++ b/src/Service/Ses/src/Exception/MailFromDomainNotVerifiedException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Ses\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The message can't be sent because the sending domain isn't verified.
+ */
+final class MailFromDomainNotVerifiedException extends ClientException
+{
+}

--- a/src/Service/Ses/src/Exception/MessageRejectedException.php
+++ b/src/Service/Ses/src/Exception/MessageRejectedException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Ses\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The message can't be sent because it contains invalid content.
+ */
+final class MessageRejectedException extends ClientException
+{
+}

--- a/src/Service/Ses/src/Exception/NotFoundException.php
+++ b/src/Service/Ses/src/Exception/NotFoundException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Ses\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The resource you attempted to access doesn't exist.
+ */
+final class NotFoundException extends ClientException
+{
+}

--- a/src/Service/Ses/src/Exception/SendingPausedException.php
+++ b/src/Service/Ses/src/Exception/SendingPausedException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Ses\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The message can't be sent because the account's ability to send email is currently paused.
+ */
+final class SendingPausedException extends ClientException
+{
+}

--- a/src/Service/Ses/src/Exception/TooManyRequestsException.php
+++ b/src/Service/Ses/src/Exception/TooManyRequestsException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Ses\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * Too many requests have been made to the operation.
+ */
+final class TooManyRequestsException extends ClientException
+{
+}

--- a/src/Service/Ses/src/SesClient.php
+++ b/src/Service/Ses/src/SesClient.php
@@ -7,6 +7,14 @@ use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
 use AsyncAws\Core\AwsError\JsonRestAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
+use AsyncAws\Ses\Exception\AccountSuspendedException;
+use AsyncAws\Ses\Exception\BadRequestException;
+use AsyncAws\Ses\Exception\LimitExceededException;
+use AsyncAws\Ses\Exception\MailFromDomainNotVerifiedException;
+use AsyncAws\Ses\Exception\MessageRejectedException;
+use AsyncAws\Ses\Exception\NotFoundException;
+use AsyncAws\Ses\Exception\SendingPausedException;
+use AsyncAws\Ses\Exception\TooManyRequestsException;
 use AsyncAws\Ses\Input\SendEmailRequest;
 use AsyncAws\Ses\Result\SendEmailResponse;
 use AsyncAws\Ses\ValueObject\Destination;
@@ -35,11 +43,29 @@ class SesClient extends AbstractApi
      *   ListManagementOptions?: ListManagementOptions|array,
      *   @region?: string,
      * }|SendEmailRequest $input
+     *
+     * @throws TooManyRequestsException
+     * @throws LimitExceededException
+     * @throws AccountSuspendedException
+     * @throws SendingPausedException
+     * @throws MessageRejectedException
+     * @throws MailFromDomainNotVerifiedException
+     * @throws NotFoundException
+     * @throws BadRequestException
      */
     public function sendEmail($input): SendEmailResponse
     {
         $input = SendEmailRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'SendEmail', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'SendEmail', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'TooManyRequestsException' => TooManyRequestsException::class,
+            'LimitExceededException' => LimitExceededException::class,
+            'AccountSuspendedException' => AccountSuspendedException::class,
+            'SendingPausedException' => SendingPausedException::class,
+            'MessageRejected' => MessageRejectedException::class,
+            'MailFromDomainNotVerifiedException' => MailFromDomainNotVerifiedException::class,
+            'NotFoundException' => NotFoundException::class,
+            'BadRequestException' => BadRequestException::class,
+        ]]));
 
         return new SendEmailResponse($response);
     }

--- a/src/Service/Sns/CHANGELOG.md
+++ b/src/Service/Sns/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Changed case of object's properties to camelCase.
 - Added documentation in class's headers.
+- Added Business Exceptions
 
 ## 1.1.1
 

--- a/src/Service/Sns/composer.json
+++ b/src/Service/Sns/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-SimpleXML": "*",
-        "async-aws/core": "^1.2"
+        "async-aws/core": "^1.9"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/Sns/src/Exception/AuthorizationErrorException.php
+++ b/src/Service/Sns/src/Exception/AuthorizationErrorException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Indicates that the user has been denied access to the requested resource.
+ */
+final class AuthorizationErrorException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/ConcurrentAccessException.php
+++ b/src/Service/Sns/src/Exception/ConcurrentAccessException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Can't perform multiple operations on a tag simultaneously. Perform the operations sequentially.
+ */
+final class ConcurrentAccessException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/EndpointDisabledException.php
+++ b/src/Service/Sns/src/Exception/EndpointDisabledException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Exception error indicating endpoint disabled.
+ */
+final class EndpointDisabledException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/FilterPolicyLimitExceededException.php
+++ b/src/Service/Sns/src/Exception/FilterPolicyLimitExceededException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Indicates that the number of filter polices in your AWS account exceeds the limit. To add more filter polices, submit
+ * an SNS Limit Increase case in the AWS Support Center.
+ */
+final class FilterPolicyLimitExceededException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/InternalErrorException.php
+++ b/src/Service/Sns/src/Exception/InternalErrorException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ServerException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Indicates an internal service error.
+ */
+final class InternalErrorException extends ServerException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/InvalidParameterException.php
+++ b/src/Service/Sns/src/Exception/InvalidParameterException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Indicates that a request parameter does not comply with the associated constraints.
+ */
+final class InvalidParameterException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/InvalidParameterValueException.php
+++ b/src/Service/Sns/src/Exception/InvalidParameterValueException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Indicates that a request parameter does not comply with the associated constraints.
+ */
+final class InvalidParameterValueException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/InvalidSecurityException.php
+++ b/src/Service/Sns/src/Exception/InvalidSecurityException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The credential signature isn't valid. You must use an HTTPS endpoint and sign your request using Signature Version 4.
+ */
+final class InvalidSecurityException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/KMSAccessDeniedException.php
+++ b/src/Service/Sns/src/Exception/KMSAccessDeniedException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The ciphertext references a key that doesn't exist or that you don't have access to.
+ */
+final class KMSAccessDeniedException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/KMSDisabledException.php
+++ b/src/Service/Sns/src/Exception/KMSDisabledException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request was rejected because the specified customer master key (CMK) isn't enabled.
+ */
+final class KMSDisabledException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/KMSInvalidStateException.php
+++ b/src/Service/Sns/src/Exception/KMSInvalidStateException.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request was rejected because the state of the specified resource isn't valid for this request. For more
+ * information, see How Key State Affects Use of a Customer Master Key in the *AWS Key Management Service Developer
+ * Guide*.
+ *
+ * @see https://docs.aws.amazon.com/kms/latest/developerguide/key-state.html
+ */
+final class KMSInvalidStateException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/KMSNotFoundException.php
+++ b/src/Service/Sns/src/Exception/KMSNotFoundException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request was rejected because the specified entity or resource can't be found.
+ */
+final class KMSNotFoundException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/KMSOptInRequiredException.php
+++ b/src/Service/Sns/src/Exception/KMSOptInRequiredException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The AWS access key ID needs a subscription for the service.
+ */
+final class KMSOptInRequiredException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/KMSThrottlingException.php
+++ b/src/Service/Sns/src/Exception/KMSThrottlingException.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request was denied due to request throttling. For more information about throttling, see Limits in the *AWS Key
+ * Management Service Developer Guide.*.
+ *
+ * @see https://docs.aws.amazon.com/kms/latest/developerguide/limits.html#requests-per-second
+ */
+final class KMSThrottlingException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/NotFoundException.php
+++ b/src/Service/Sns/src/Exception/NotFoundException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Indicates that the requested resource does not exist.
+ */
+final class NotFoundException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/PlatformApplicationDisabledException.php
+++ b/src/Service/Sns/src/Exception/PlatformApplicationDisabledException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Exception error indicating platform application disabled.
+ */
+final class PlatformApplicationDisabledException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/StaleTagException.php
+++ b/src/Service/Sns/src/Exception/StaleTagException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * A tag has been added to a resource with the same ARN as a deleted resource. Wait a short while and then retry the
+ * operation.
+ */
+final class StaleTagException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/SubscriptionLimitExceededException.php
+++ b/src/Service/Sns/src/Exception/SubscriptionLimitExceededException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Indicates that the customer already owns the maximum allowed number of subscriptions.
+ */
+final class SubscriptionLimitExceededException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/TagLimitExceededException.php
+++ b/src/Service/Sns/src/Exception/TagLimitExceededException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Can't add more than 50 tags to a topic.
+ */
+final class TagLimitExceededException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/TagPolicyException.php
+++ b/src/Service/Sns/src/Exception/TagPolicyException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request doesn't comply with the IAM tag policy. Correct your request and then retry it.
+ */
+final class TagPolicyException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/Exception/TopicLimitExceededException.php
+++ b/src/Service/Sns/src/Exception/TopicLimitExceededException.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace AsyncAws\Sns\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Indicates that the customer already owns the maximum allowed number of topics.
+ */
+final class TopicLimitExceededException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent(false));
+        if (0 < $data->Error->count()) {
+            $data = $data->Error;
+        }
+        if (null !== $v = (($v = $data->message) ? (string) $v : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Sns/src/SnsClient.php
+++ b/src/Service/Sns/src/SnsClient.php
@@ -8,6 +8,27 @@ use AsyncAws\Core\AwsError\XmlAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
+use AsyncAws\Sns\Exception\AuthorizationErrorException;
+use AsyncAws\Sns\Exception\ConcurrentAccessException;
+use AsyncAws\Sns\Exception\EndpointDisabledException;
+use AsyncAws\Sns\Exception\FilterPolicyLimitExceededException;
+use AsyncAws\Sns\Exception\InternalErrorException;
+use AsyncAws\Sns\Exception\InvalidParameterException;
+use AsyncAws\Sns\Exception\InvalidParameterValueException;
+use AsyncAws\Sns\Exception\InvalidSecurityException;
+use AsyncAws\Sns\Exception\KMSAccessDeniedException;
+use AsyncAws\Sns\Exception\KMSDisabledException;
+use AsyncAws\Sns\Exception\KMSInvalidStateException;
+use AsyncAws\Sns\Exception\KMSNotFoundException;
+use AsyncAws\Sns\Exception\KMSOptInRequiredException;
+use AsyncAws\Sns\Exception\KMSThrottlingException;
+use AsyncAws\Sns\Exception\NotFoundException;
+use AsyncAws\Sns\Exception\PlatformApplicationDisabledException;
+use AsyncAws\Sns\Exception\StaleTagException;
+use AsyncAws\Sns\Exception\SubscriptionLimitExceededException;
+use AsyncAws\Sns\Exception\TagLimitExceededException;
+use AsyncAws\Sns\Exception\TagPolicyException;
+use AsyncAws\Sns\Exception\TopicLimitExceededException;
 use AsyncAws\Sns\Input\CreatePlatformEndpointInput;
 use AsyncAws\Sns\Input\CreateTopicInput;
 use AsyncAws\Sns\Input\DeleteEndpointInput;
@@ -46,11 +67,21 @@ class SnsClient extends AbstractApi
      *   Attributes?: array<string, string>,
      *   @region?: string,
      * }|CreatePlatformEndpointInput $input
+     *
+     * @throws InvalidParameterException
+     * @throws InternalErrorException
+     * @throws AuthorizationErrorException
+     * @throws NotFoundException
      */
     public function createPlatformEndpoint($input): CreateEndpointResponse
     {
         $input = CreatePlatformEndpointInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreatePlatformEndpoint', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreatePlatformEndpoint', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidParameter' => InvalidParameterException::class,
+            'InternalError' => InternalErrorException::class,
+            'AuthorizationError' => AuthorizationErrorException::class,
+            'NotFound' => NotFoundException::class,
+        ]]));
 
         return new CreateEndpointResponse($response);
     }
@@ -70,11 +101,31 @@ class SnsClient extends AbstractApi
      *   Tags?: Tag[],
      *   @region?: string,
      * }|CreateTopicInput $input
+     *
+     * @throws InvalidParameterException
+     * @throws TopicLimitExceededException
+     * @throws InternalErrorException
+     * @throws AuthorizationErrorException
+     * @throws InvalidSecurityException
+     * @throws TagLimitExceededException
+     * @throws StaleTagException
+     * @throws TagPolicyException
+     * @throws ConcurrentAccessException
      */
     public function createTopic($input): CreateTopicResponse
     {
         $input = CreateTopicInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateTopic', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateTopic', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidParameter' => InvalidParameterException::class,
+            'TopicLimitExceeded' => TopicLimitExceededException::class,
+            'InternalError' => InternalErrorException::class,
+            'AuthorizationError' => AuthorizationErrorException::class,
+            'InvalidSecurity' => InvalidSecurityException::class,
+            'TagLimitExceeded' => TagLimitExceededException::class,
+            'StaleTag' => StaleTagException::class,
+            'TagPolicy' => TagPolicyException::class,
+            'ConcurrentAccess' => ConcurrentAccessException::class,
+        ]]));
 
         return new CreateTopicResponse($response);
     }
@@ -91,11 +142,19 @@ class SnsClient extends AbstractApi
      *   EndpointArn: string,
      *   @region?: string,
      * }|DeleteEndpointInput $input
+     *
+     * @throws InvalidParameterException
+     * @throws InternalErrorException
+     * @throws AuthorizationErrorException
      */
     public function deleteEndpoint($input): Result
     {
         $input = DeleteEndpointInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteEndpoint', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteEndpoint', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidParameter' => InvalidParameterException::class,
+            'InternalError' => InternalErrorException::class,
+            'AuthorizationError' => AuthorizationErrorException::class,
+        ]]));
 
         return new Result($response);
     }
@@ -112,11 +171,27 @@ class SnsClient extends AbstractApi
      *   TopicArn: string,
      *   @region?: string,
      * }|DeleteTopicInput $input
+     *
+     * @throws InvalidParameterException
+     * @throws InternalErrorException
+     * @throws AuthorizationErrorException
+     * @throws NotFoundException
+     * @throws StaleTagException
+     * @throws TagPolicyException
+     * @throws ConcurrentAccessException
      */
     public function deleteTopic($input): Result
     {
         $input = DeleteTopicInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteTopic', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteTopic', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidParameter' => InvalidParameterException::class,
+            'InternalError' => InternalErrorException::class,
+            'AuthorizationError' => AuthorizationErrorException::class,
+            'NotFound' => NotFoundException::class,
+            'StaleTag' => StaleTagException::class,
+            'TagPolicy' => TagPolicyException::class,
+            'ConcurrentAccess' => ConcurrentAccessException::class,
+        ]]));
 
         return new Result($response);
     }
@@ -134,11 +209,21 @@ class SnsClient extends AbstractApi
      *   NextToken?: string,
      *   @region?: string,
      * }|ListSubscriptionsByTopicInput $input
+     *
+     * @throws InvalidParameterException
+     * @throws InternalErrorException
+     * @throws NotFoundException
+     * @throws AuthorizationErrorException
      */
     public function listSubscriptionsByTopic($input): ListSubscriptionsByTopicResponse
     {
         $input = ListSubscriptionsByTopicInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ListSubscriptionsByTopic', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ListSubscriptionsByTopic', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidParameter' => InvalidParameterException::class,
+            'InternalError' => InternalErrorException::class,
+            'NotFound' => NotFoundException::class,
+            'AuthorizationError' => AuthorizationErrorException::class,
+        ]]));
 
         return new ListSubscriptionsByTopicResponse($response, $this, $input);
     }
@@ -162,11 +247,41 @@ class SnsClient extends AbstractApi
      *   MessageGroupId?: string,
      *   @region?: string,
      * }|PublishInput $input
+     *
+     * @throws InvalidParameterException
+     * @throws InvalidParameterValueException
+     * @throws InternalErrorException
+     * @throws NotFoundException
+     * @throws EndpointDisabledException
+     * @throws PlatformApplicationDisabledException
+     * @throws AuthorizationErrorException
+     * @throws KMSDisabledException
+     * @throws KMSInvalidStateException
+     * @throws KMSNotFoundException
+     * @throws KMSOptInRequiredException
+     * @throws KMSThrottlingException
+     * @throws KMSAccessDeniedException
+     * @throws InvalidSecurityException
      */
     public function publish($input): PublishResponse
     {
         $input = PublishInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'Publish', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'Publish', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidParameter' => InvalidParameterException::class,
+            'ParameterValueInvalid' => InvalidParameterValueException::class,
+            'InternalError' => InternalErrorException::class,
+            'NotFound' => NotFoundException::class,
+            'EndpointDisabled' => EndpointDisabledException::class,
+            'PlatformApplicationDisabled' => PlatformApplicationDisabledException::class,
+            'AuthorizationError' => AuthorizationErrorException::class,
+            'KMSDisabled' => KMSDisabledException::class,
+            'KMSInvalidState' => KMSInvalidStateException::class,
+            'KMSNotFound' => KMSNotFoundException::class,
+            'KMSOptInRequired' => KMSOptInRequiredException::class,
+            'KMSThrottling' => KMSThrottlingException::class,
+            'KMSAccessDenied' => KMSAccessDeniedException::class,
+            'InvalidSecurity' => InvalidSecurityException::class,
+        ]]));
 
         return new PublishResponse($response);
     }
@@ -187,11 +302,27 @@ class SnsClient extends AbstractApi
      *   ReturnSubscriptionArn?: bool,
      *   @region?: string,
      * }|SubscribeInput $input
+     *
+     * @throws SubscriptionLimitExceededException
+     * @throws FilterPolicyLimitExceededException
+     * @throws InvalidParameterException
+     * @throws InternalErrorException
+     * @throws NotFoundException
+     * @throws AuthorizationErrorException
+     * @throws InvalidSecurityException
      */
     public function subscribe($input): SubscribeResponse
     {
         $input = SubscribeInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'Subscribe', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'Subscribe', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'SubscriptionLimitExceeded' => SubscriptionLimitExceededException::class,
+            'FilterPolicyLimitExceeded' => FilterPolicyLimitExceededException::class,
+            'InvalidParameter' => InvalidParameterException::class,
+            'InternalError' => InternalErrorException::class,
+            'NotFound' => NotFoundException::class,
+            'AuthorizationError' => AuthorizationErrorException::class,
+            'InvalidSecurity' => InvalidSecurityException::class,
+        ]]));
 
         return new SubscribeResponse($response);
     }
@@ -209,11 +340,23 @@ class SnsClient extends AbstractApi
      *   SubscriptionArn: string,
      *   @region?: string,
      * }|UnsubscribeInput $input
+     *
+     * @throws InvalidParameterException
+     * @throws InternalErrorException
+     * @throws AuthorizationErrorException
+     * @throws NotFoundException
+     * @throws InvalidSecurityException
      */
     public function unsubscribe($input): Result
     {
         $input = UnsubscribeInput::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'Unsubscribe', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'Unsubscribe', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidParameter' => InvalidParameterException::class,
+            'InternalError' => InternalErrorException::class,
+            'AuthorizationError' => AuthorizationErrorException::class,
+            'NotFound' => NotFoundException::class,
+            'InvalidSecurity' => InvalidSecurityException::class,
+        ]]));
 
         return new Result($response);
     }

--- a/src/Service/Sqs/CHANGELOG.md
+++ b/src/Service/Sqs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Changed case of object's properties to camelCase.
 - Added documentation in class's headers.
+- Added Business Exceptions
 
 ## 1.4.0
 

--- a/src/Service/Sqs/composer.json
+++ b/src/Service/Sqs/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-SimpleXML": "*",
-        "async-aws/core": "^1.0"
+        "async-aws/core": "^1.9"
     },
     "extra": {
         "branch-alias": {

--- a/src/Service/Sqs/src/Exception/InvalidAttributeNameException.php
+++ b/src/Service/Sqs/src/Exception/InvalidAttributeNameException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Sqs\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The specified attribute doesn't exist.
+ */
+final class InvalidAttributeNameException extends ClientException
+{
+}

--- a/src/Service/Sqs/src/Exception/InvalidIdFormatException.php
+++ b/src/Service/Sqs/src/Exception/InvalidIdFormatException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Sqs\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The specified receipt handle isn't valid for the current version.
+ */
+final class InvalidIdFormatException extends ClientException
+{
+}

--- a/src/Service/Sqs/src/Exception/InvalidMessageContentsException.php
+++ b/src/Service/Sqs/src/Exception/InvalidMessageContentsException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Sqs\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The message contains characters outside the allowed set.
+ */
+final class InvalidMessageContentsException extends ClientException
+{
+}

--- a/src/Service/Sqs/src/Exception/MessageNotInflightException.php
+++ b/src/Service/Sqs/src/Exception/MessageNotInflightException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Sqs\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The specified message isn't in flight.
+ */
+final class MessageNotInflightException extends ClientException
+{
+}

--- a/src/Service/Sqs/src/Exception/OverLimitException.php
+++ b/src/Service/Sqs/src/Exception/OverLimitException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace AsyncAws\Sqs\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The specified action violates a limit. For example, `ReceiveMessage` returns this error if the maximum number of
+ * inflight messages is reached and `AddPermission` returns this error if the maximum number of permissions for the
+ * queue is reached.
+ */
+final class OverLimitException extends ClientException
+{
+}

--- a/src/Service/Sqs/src/Exception/PurgeQueueInProgressException.php
+++ b/src/Service/Sqs/src/Exception/PurgeQueueInProgressException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace AsyncAws\Sqs\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+final class PurgeQueueInProgressException extends ClientException
+{
+}

--- a/src/Service/Sqs/src/Exception/PurgeQueueInProgressException.php
+++ b/src/Service/Sqs/src/Exception/PurgeQueueInProgressException.php
@@ -4,6 +4,10 @@ namespace AsyncAws\Sqs\Exception;
 
 use AsyncAws\Core\Exception\Http\ClientException;
 
+/**
+ * Indicates that the specified queue previously received a `PurgeQueue` request within the last 60 seconds (the time it
+ * can take to delete the messages in the queue).
+ */
 final class PurgeQueueInProgressException extends ClientException
 {
 }

--- a/src/Service/Sqs/src/Exception/QueueDeletedRecentlyException.php
+++ b/src/Service/Sqs/src/Exception/QueueDeletedRecentlyException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Sqs\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * You must wait 60 seconds after deleting a queue before you can create another queue with the same name.
+ */
+final class QueueDeletedRecentlyException extends ClientException
+{
+}

--- a/src/Service/Sqs/src/Exception/QueueDoesNotExistException.php
+++ b/src/Service/Sqs/src/Exception/QueueDoesNotExistException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace AsyncAws\Sqs\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+final class QueueDoesNotExistException extends ClientException
+{
+}

--- a/src/Service/Sqs/src/Exception/QueueDoesNotExistException.php
+++ b/src/Service/Sqs/src/Exception/QueueDoesNotExistException.php
@@ -4,6 +4,9 @@ namespace AsyncAws\Sqs\Exception;
 
 use AsyncAws\Core\Exception\Http\ClientException;
 
+/**
+ * The specified queue doesn't exist.
+ */
 final class QueueDoesNotExistException extends ClientException
 {
 }

--- a/src/Service/Sqs/src/Exception/QueueNameExistsException.php
+++ b/src/Service/Sqs/src/Exception/QueueNameExistsException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace AsyncAws\Sqs\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * A queue with this name already exists. Amazon SQS returns this error only if the request includes attributes whose
+ * values differ from those of the existing queue.
+ */
+final class QueueNameExistsException extends ClientException
+{
+}

--- a/src/Service/Sqs/src/Exception/ReceiptHandleIsInvalidException.php
+++ b/src/Service/Sqs/src/Exception/ReceiptHandleIsInvalidException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Sqs\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The specified receipt handle isn't valid.
+ */
+final class ReceiptHandleIsInvalidException extends ClientException
+{
+}

--- a/src/Service/Sqs/src/Exception/UnsupportedOperationException.php
+++ b/src/Service/Sqs/src/Exception/UnsupportedOperationException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Sqs\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * Error code 400. Unsupported operation.
+ */
+final class UnsupportedOperationException extends ClientException
+{
+}

--- a/src/Service/Sqs/src/SqsClient.php
+++ b/src/Service/Sqs/src/SqsClient.php
@@ -11,8 +11,17 @@ use AsyncAws\Core\Result;
 use AsyncAws\Sqs\Enum\MessageSystemAttributeName;
 use AsyncAws\Sqs\Enum\MessageSystemAttributeNameForSends;
 use AsyncAws\Sqs\Enum\QueueAttributeName;
+use AsyncAws\Sqs\Exception\InvalidAttributeNameException;
+use AsyncAws\Sqs\Exception\InvalidIdFormatException;
+use AsyncAws\Sqs\Exception\InvalidMessageContentsException;
+use AsyncAws\Sqs\Exception\MessageNotInflightException;
+use AsyncAws\Sqs\Exception\OverLimitException;
 use AsyncAws\Sqs\Exception\PurgeQueueInProgressException;
+use AsyncAws\Sqs\Exception\QueueDeletedRecentlyException;
 use AsyncAws\Sqs\Exception\QueueDoesNotExistException;
+use AsyncAws\Sqs\Exception\QueueNameExistsException;
+use AsyncAws\Sqs\Exception\ReceiptHandleIsInvalidException;
+use AsyncAws\Sqs\Exception\UnsupportedOperationException;
 use AsyncAws\Sqs\Input\ChangeMessageVisibilityRequest;
 use AsyncAws\Sqs\Input\CreateQueueRequest;
 use AsyncAws\Sqs\Input\DeleteMessageRequest;
@@ -50,11 +59,17 @@ class SqsClient extends AbstractApi
      *   VisibilityTimeout: int,
      *   @region?: string,
      * }|ChangeMessageVisibilityRequest $input
+     *
+     * @throws MessageNotInflightException
+     * @throws ReceiptHandleIsInvalidException
      */
     public function changeMessageVisibility($input): Result
     {
         $input = ChangeMessageVisibilityRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ChangeMessageVisibility', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ChangeMessageVisibility', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'AWS.SimpleQueueService.MessageNotInflight' => MessageNotInflightException::class,
+            'ReceiptHandleIsInvalid' => ReceiptHandleIsInvalidException::class,
+        ]]));
 
         return new Result($response);
     }
@@ -71,11 +86,17 @@ class SqsClient extends AbstractApi
      *   tags?: array<string, string>,
      *   @region?: string,
      * }|CreateQueueRequest $input
+     *
+     * @throws QueueDeletedRecentlyException
+     * @throws QueueNameExistsException
      */
     public function createQueue($input): CreateQueueResult
     {
         $input = CreateQueueRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateQueue', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateQueue', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'AWS.SimpleQueueService.QueueDeletedRecently' => QueueDeletedRecentlyException::class,
+            'QueueAlreadyExists' => QueueNameExistsException::class,
+        ]]));
 
         return new CreateQueueResult($response);
     }
@@ -94,11 +115,17 @@ class SqsClient extends AbstractApi
      *   ReceiptHandle: string,
      *   @region?: string,
      * }|DeleteMessageRequest $input
+     *
+     * @throws InvalidIdFormatException
+     * @throws ReceiptHandleIsInvalidException
      */
     public function deleteMessage($input): Result
     {
         $input = DeleteMessageRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteMessage', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteMessage', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidIdFormat' => InvalidIdFormatException::class,
+            'ReceiptHandleIsInvalid' => ReceiptHandleIsInvalidException::class,
+        ]]));
 
         return new Result($response);
     }
@@ -133,11 +160,15 @@ class SqsClient extends AbstractApi
      *   AttributeNames?: list<QueueAttributeName::*>,
      *   @region?: string,
      * }|GetQueueAttributesRequest $input
+     *
+     * @throws InvalidAttributeNameException
      */
     public function getQueueAttributes($input): GetQueueAttributesResult
     {
         $input = GetQueueAttributesRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetQueueAttributes', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetQueueAttributes', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidAttributeName' => InvalidAttributeNameException::class,
+        ]]));
 
         return new GetQueueAttributesResult($response);
     }
@@ -153,11 +184,15 @@ class SqsClient extends AbstractApi
      *   QueueOwnerAWSAccountId?: string,
      *   @region?: string,
      * }|GetQueueUrlRequest $input
+     *
+     * @throws QueueDoesNotExistException
      */
     public function getQueueUrl($input): GetQueueUrlResult
     {
         $input = GetQueueUrlRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetQueueUrl', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetQueueUrl', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'AWS.SimpleQueueService.NonExistentQueue' => QueueDoesNotExistException::class,
+        ]]));
 
         return new GetQueueUrlResult($response);
     }
@@ -211,8 +246,6 @@ class SqsClient extends AbstractApi
     }
 
     /**
-     * Check status of operation getQueueUrl.
-     *
      * @see getQueueUrl
      *
      * @param array{
@@ -224,7 +257,9 @@ class SqsClient extends AbstractApi
     public function queueExists($input): QueueExistsWaiter
     {
         $input = GetQueueUrlRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetQueueUrl', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetQueueUrl', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'AWS.SimpleQueueService.NonExistentQueue' => QueueDoesNotExistException::class,
+        ]]));
 
         return new QueueExistsWaiter($response, $this, $input);
     }
@@ -248,11 +283,15 @@ class SqsClient extends AbstractApi
      *   ReceiveRequestAttemptId?: string,
      *   @region?: string,
      * }|ReceiveMessageRequest $input
+     *
+     * @throws OverLimitException
      */
     public function receiveMessage($input): ReceiveMessageResult
     {
         $input = ReceiveMessageRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ReceiveMessage', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ReceiveMessage', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'OverLimit' => OverLimitException::class,
+        ]]));
 
         return new ReceiveMessageResult($response);
     }
@@ -273,11 +312,17 @@ class SqsClient extends AbstractApi
      *   MessageGroupId?: string,
      *   @region?: string,
      * }|SendMessageRequest $input
+     *
+     * @throws InvalidMessageContentsException
+     * @throws UnsupportedOperationException
      */
     public function sendMessage($input): SendMessageResult
     {
         $input = SendMessageRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'SendMessage', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'SendMessage', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidMessageContents' => InvalidMessageContentsException::class,
+            'AWS.SimpleQueueService.UnsupportedOperation' => UnsupportedOperationException::class,
+        ]]));
 
         return new SendMessageResult($response);
     }

--- a/src/Service/Sqs/src/SqsClient.php
+++ b/src/Service/Sqs/src/SqsClient.php
@@ -11,6 +11,8 @@ use AsyncAws\Core\Result;
 use AsyncAws\Sqs\Enum\MessageSystemAttributeName;
 use AsyncAws\Sqs\Enum\MessageSystemAttributeNameForSends;
 use AsyncAws\Sqs\Enum\QueueAttributeName;
+use AsyncAws\Sqs\Exception\PurgeQueueInProgressException;
+use AsyncAws\Sqs\Exception\QueueDoesNotExistException;
 use AsyncAws\Sqs\Input\ChangeMessageVisibilityRequest;
 use AsyncAws\Sqs\Input\CreateQueueRequest;
 use AsyncAws\Sqs\Input\DeleteMessageRequest;
@@ -193,11 +195,17 @@ class SqsClient extends AbstractApi
      *   QueueUrl: string,
      *   @region?: string,
      * }|PurgeQueueRequest $input
+     *
+     * @throws QueueDoesNotExistException
+     * @throws PurgeQueueInProgressException
      */
     public function purgeQueue($input): Result
     {
         $input = PurgeQueueRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PurgeQueue', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PurgeQueue', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'AWS.SimpleQueueService.NonExistentQueue' => 'AsyncAws\\Sqs\\Exception\\QueueDoesNotExistException',
+            'AWS.SimpleQueueService.PurgeQueueInProgress' => 'AsyncAws\\Sqs\\Exception\\PurgeQueueInProgressException',
+        ]]));
 
         return new Result($response);
     }

--- a/src/Service/Sqs/src/SqsClient.php
+++ b/src/Service/Sqs/src/SqsClient.php
@@ -203,8 +203,8 @@ class SqsClient extends AbstractApi
     {
         $input = PurgeQueueRequest::create($input);
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PurgeQueue', 'region' => $input->getRegion(), 'exceptionMapping' => [
-            'AWS.SimpleQueueService.NonExistentQueue' => 'AsyncAws\\Sqs\\Exception\\QueueDoesNotExistException',
-            'AWS.SimpleQueueService.PurgeQueueInProgress' => 'AsyncAws\\Sqs\\Exception\\PurgeQueueInProgressException',
+            'AWS.SimpleQueueService.NonExistentQueue' => QueueDoesNotExistException::class,
+            'AWS.SimpleQueueService.PurgeQueueInProgress' => PurgeQueueInProgressException::class,
         ]]));
 
         return new Result($response);

--- a/src/Service/Ssm/CHANGELOG.md
+++ b/src/Service/Ssm/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Changed case of object's properties to camelCase.
 - Added documentation in class's headers.
 - AWS enhancement: Added region "us-iso-east-1".
+- Added Business Exceptions
 
 ## 1.1.1
 

--- a/src/Service/Ssm/composer.json
+++ b/src/Service/Ssm/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
-        "async-aws/core": "^1.2"
+        "async-aws/core": "^1.9"
     },
     "conflict": {
         "symfony/http-client": "<4.4.16,<5.1.7"

--- a/src/Service/Ssm/src/Exception/HierarchyLevelLimitExceededException.php
+++ b/src/Service/Ssm/src/Exception/HierarchyLevelLimitExceededException.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * A hierarchy can have a maximum of 15 levels. For more information, see Requirements and constraints for parameter
+ * names in the *AWS Systems Manager User Guide*.
+ *
+ * @see https://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-parameter-name-constraints.html
+ */
+final class HierarchyLevelLimitExceededException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/HierarchyTypeMismatchException.php
+++ b/src/Service/Ssm/src/Exception/HierarchyTypeMismatchException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Parameter Store does not support changing a parameter type in a hierarchy. For example, you can't change a parameter
+ * from a `String` type to a `SecureString` type. You must create a new, unique parameter.
+ */
+final class HierarchyTypeMismatchException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/IncompatiblePolicyException.php
+++ b/src/Service/Ssm/src/Exception/IncompatiblePolicyException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * There is a conflict in the policies specified for this parameter. You can't, for example, specify two Expiration
+ * policies for a parameter. Review your policies, and try again.
+ */
+final class IncompatiblePolicyException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/InternalServerErrorException.php
+++ b/src/Service/Ssm/src/Exception/InternalServerErrorException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * An error occurred on the server side.
+ */
+final class InternalServerErrorException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/InvalidAllowedPatternException.php
+++ b/src/Service/Ssm/src/Exception/InvalidAllowedPatternException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The request does not meet the regular expression requirement.
+ */
+final class InvalidAllowedPatternException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/InvalidFilterKeyException.php
+++ b/src/Service/Ssm/src/Exception/InvalidFilterKeyException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The specified key is not valid.
+ */
+final class InvalidFilterKeyException extends ClientException
+{
+}

--- a/src/Service/Ssm/src/Exception/InvalidFilterOptionException.php
+++ b/src/Service/Ssm/src/Exception/InvalidFilterOptionException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The specified filter option is not valid. Valid options are Equals and BeginsWith. For Path filter, valid options are
+ * Recursive and OneLevel.
+ */
+final class InvalidFilterOptionException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/InvalidFilterValueException.php
+++ b/src/Service/Ssm/src/Exception/InvalidFilterValueException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The filter value is not valid. Verify the value and try again.
+ */
+final class InvalidFilterValueException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/InvalidKeyIdException.php
+++ b/src/Service/Ssm/src/Exception/InvalidKeyIdException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The query key ID is not valid.
+ */
+final class InvalidKeyIdException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/InvalidNextTokenException.php
+++ b/src/Service/Ssm/src/Exception/InvalidNextTokenException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The specified token is not valid.
+ */
+final class InvalidNextTokenException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/InvalidPolicyAttributeException.php
+++ b/src/Service/Ssm/src/Exception/InvalidPolicyAttributeException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * A policy attribute or its value is invalid.
+ */
+final class InvalidPolicyAttributeException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/InvalidPolicyTypeException.php
+++ b/src/Service/Ssm/src/Exception/InvalidPolicyTypeException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The policy type is not supported. Parameter Store supports the following policy types: Expiration,
+ * ExpirationNotification, and NoChangeNotification.
+ */
+final class InvalidPolicyTypeException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/ParameterAlreadyExistsException.php
+++ b/src/Service/Ssm/src/Exception/ParameterAlreadyExistsException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The parameter already exists. You can't create duplicate parameters.
+ */
+final class ParameterAlreadyExistsException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/ParameterLimitExceededException.php
+++ b/src/Service/Ssm/src/Exception/ParameterLimitExceededException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * You have exceeded the number of parameters for this AWS account. Delete one or more parameters and try again.
+ */
+final class ParameterLimitExceededException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/ParameterMaxVersionLimitExceededException.php
+++ b/src/Service/Ssm/src/Exception/ParameterMaxVersionLimitExceededException.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * Parameter Store retains the 100 most recently created versions of a parameter. After this number of versions has been
+ * created, Parameter Store deletes the oldest version when a new one is created. However, if the oldest version has a
+ * *label* attached to it, Parameter Store will not delete the version and instead presents this error message:
+ * `An error occurred (ParameterMaxVersionLimitExceeded) when calling the PutParameter operation: You attempted to
+ * create a new version of *parameter-name* by calling the PutParameter API with the overwrite flag. Version
+ * *version-number*, the oldest version, can't be deleted because it has a label associated with it. Move the label to
+ * another version of the parameter, and try again.`
+ * This safeguard is to prevent parameter versions with mission critical labels assigned to them from being deleted. To
+ * continue creating new parameters, first move the label from the oldest version of the parameter to a newer one for
+ * use in your operations. For information about moving parameter labels, see Move a parameter label (console) or Move a
+ * parameter label (CLI)  in the *AWS Systems Manager User Guide*.
+ *
+ * @see http://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-labels.html#sysman-paramstore-labels-console-move
+ * @see http://docs.aws.amazon.com/systems-manager/latest/userguide/sysman-paramstore-labels.html#sysman-paramstore-labels-cli-move
+ */
+final class ParameterMaxVersionLimitExceededException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/ParameterNotFoundException.php
+++ b/src/Service/Ssm/src/Exception/ParameterNotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The parameter could not be found. Verify the name and try again.
+ */
+final class ParameterNotFoundException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/ParameterPatternMismatchException.php
+++ b/src/Service/Ssm/src/Exception/ParameterPatternMismatchException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The parameter name is not valid.
+ */
+final class ParameterPatternMismatchException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/ParameterVersionNotFoundException.php
+++ b/src/Service/Ssm/src/Exception/ParameterVersionNotFoundException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The specified parameter version was not found. Verify the parameter name and version, and try again.
+ */
+final class ParameterVersionNotFoundException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/PoliciesLimitExceededException.php
+++ b/src/Service/Ssm/src/Exception/PoliciesLimitExceededException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * You specified more than the maximum number of allowed policies for the parameter. The maximum is 10.
+ */
+final class PoliciesLimitExceededException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/TooManyUpdatesException.php
+++ b/src/Service/Ssm/src/Exception/TooManyUpdatesException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * There are concurrent updates for a resource that supports one update at a time.
+ */
+final class TooManyUpdatesException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Exception/UnsupportedParameterTypeException.php
+++ b/src/Service/Ssm/src/Exception/UnsupportedParameterTypeException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\Ssm\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * The parameter type is not supported.
+ */
+final class UnsupportedParameterTypeException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/Ssm/src/Result/DeleteParameterResult.php
+++ b/src/Service/Ssm/src/Result/DeleteParameterResult.php
@@ -2,12 +2,8 @@
 
 namespace AsyncAws\Ssm\Result;
 
-use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
 
 class DeleteParameterResult extends Result
 {
-    protected function populateResult(Response $response): void
-    {
-    }
 }

--- a/src/Service/Ssm/src/SsmClient.php
+++ b/src/Service/Ssm/src/SsmClient.php
@@ -9,6 +9,27 @@ use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Ssm\Enum\ParameterTier;
 use AsyncAws\Ssm\Enum\ParameterType;
+use AsyncAws\Ssm\Exception\HierarchyLevelLimitExceededException;
+use AsyncAws\Ssm\Exception\HierarchyTypeMismatchException;
+use AsyncAws\Ssm\Exception\IncompatiblePolicyException;
+use AsyncAws\Ssm\Exception\InternalServerErrorException;
+use AsyncAws\Ssm\Exception\InvalidAllowedPatternException;
+use AsyncAws\Ssm\Exception\InvalidFilterKeyException;
+use AsyncAws\Ssm\Exception\InvalidFilterOptionException;
+use AsyncAws\Ssm\Exception\InvalidFilterValueException;
+use AsyncAws\Ssm\Exception\InvalidKeyIdException;
+use AsyncAws\Ssm\Exception\InvalidNextTokenException;
+use AsyncAws\Ssm\Exception\InvalidPolicyAttributeException;
+use AsyncAws\Ssm\Exception\InvalidPolicyTypeException;
+use AsyncAws\Ssm\Exception\ParameterAlreadyExistsException;
+use AsyncAws\Ssm\Exception\ParameterLimitExceededException;
+use AsyncAws\Ssm\Exception\ParameterMaxVersionLimitExceededException;
+use AsyncAws\Ssm\Exception\ParameterNotFoundException;
+use AsyncAws\Ssm\Exception\ParameterPatternMismatchException;
+use AsyncAws\Ssm\Exception\ParameterVersionNotFoundException;
+use AsyncAws\Ssm\Exception\PoliciesLimitExceededException;
+use AsyncAws\Ssm\Exception\TooManyUpdatesException;
+use AsyncAws\Ssm\Exception\UnsupportedParameterTypeException;
 use AsyncAws\Ssm\Input\DeleteParameterRequest;
 use AsyncAws\Ssm\Input\GetParameterRequest;
 use AsyncAws\Ssm\Input\GetParametersByPathRequest;
@@ -35,11 +56,17 @@ class SsmClient extends AbstractApi
      *   Name: string,
      *   @region?: string,
      * }|DeleteParameterRequest $input
+     *
+     * @throws InternalServerErrorException
+     * @throws ParameterNotFoundException
      */
     public function deleteParameter($input): DeleteParameterResult
     {
         $input = DeleteParameterRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteParameter', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteParameter', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InternalServerError' => InternalServerErrorException::class,
+            'ParameterNotFound' => ParameterNotFoundException::class,
+        ]]));
 
         return new DeleteParameterResult($response);
     }
@@ -56,11 +83,21 @@ class SsmClient extends AbstractApi
      *   WithDecryption?: bool,
      *   @region?: string,
      * }|GetParameterRequest $input
+     *
+     * @throws InternalServerErrorException
+     * @throws InvalidKeyIdException
+     * @throws ParameterNotFoundException
+     * @throws ParameterVersionNotFoundException
      */
     public function getParameter($input): GetParameterResult
     {
         $input = GetParameterRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetParameter', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetParameter', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InternalServerError' => InternalServerErrorException::class,
+            'InvalidKeyId' => InvalidKeyIdException::class,
+            'ParameterNotFound' => ParameterNotFoundException::class,
+            'ParameterVersionNotFound' => ParameterVersionNotFoundException::class,
+        ]]));
 
         return new GetParameterResult($response);
     }
@@ -76,11 +113,17 @@ class SsmClient extends AbstractApi
      *   WithDecryption?: bool,
      *   @region?: string,
      * }|GetParametersRequest $input
+     *
+     * @throws InvalidKeyIdException
+     * @throws InternalServerErrorException
      */
     public function getParameters($input): GetParametersResult
     {
         $input = GetParametersRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetParameters', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetParameters', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidKeyId' => InvalidKeyIdException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+        ]]));
 
         return new GetParametersResult($response);
     }
@@ -100,11 +143,25 @@ class SsmClient extends AbstractApi
      *   NextToken?: string,
      *   @region?: string,
      * }|GetParametersByPathRequest $input
+     *
+     * @throws InternalServerErrorException
+     * @throws InvalidFilterKeyException
+     * @throws InvalidFilterOptionException
+     * @throws InvalidFilterValueException
+     * @throws InvalidKeyIdException
+     * @throws InvalidNextTokenException
      */
     public function getParametersByPath($input): GetParametersByPathResult
     {
         $input = GetParametersByPathRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetParametersByPath', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetParametersByPath', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InternalServerError' => InternalServerErrorException::class,
+            'InvalidFilterKey' => InvalidFilterKeyException::class,
+            'InvalidFilterOption' => InvalidFilterOptionException::class,
+            'InvalidFilterValue' => InvalidFilterValueException::class,
+            'InvalidKeyId' => InvalidKeyIdException::class,
+            'InvalidNextToken' => InvalidNextTokenException::class,
+        ]]));
 
         return new GetParametersByPathResult($response, $this, $input);
     }
@@ -129,11 +186,43 @@ class SsmClient extends AbstractApi
      *   DataType?: string,
      *   @region?: string,
      * }|PutParameterRequest $input
+     *
+     * @throws InternalServerErrorException
+     * @throws InvalidKeyIdException
+     * @throws ParameterLimitExceededException
+     * @throws TooManyUpdatesException
+     * @throws ParameterAlreadyExistsException
+     * @throws HierarchyLevelLimitExceededException
+     * @throws HierarchyTypeMismatchException
+     * @throws InvalidAllowedPatternException
+     * @throws ParameterMaxVersionLimitExceededException
+     * @throws ParameterPatternMismatchException
+     * @throws UnsupportedParameterTypeException
+     * @throws PoliciesLimitExceededException
+     * @throws InvalidPolicyTypeException
+     * @throws InvalidPolicyAttributeException
+     * @throws IncompatiblePolicyException
      */
     public function putParameter($input): PutParameterResult
     {
         $input = PutParameterRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PutParameter', 'region' => $input->getRegion()]));
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PutParameter', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InternalServerError' => InternalServerErrorException::class,
+            'InvalidKeyId' => InvalidKeyIdException::class,
+            'ParameterLimitExceeded' => ParameterLimitExceededException::class,
+            'TooManyUpdates' => TooManyUpdatesException::class,
+            'ParameterAlreadyExists' => ParameterAlreadyExistsException::class,
+            'HierarchyLevelLimitExceededException' => HierarchyLevelLimitExceededException::class,
+            'HierarchyTypeMismatchException' => HierarchyTypeMismatchException::class,
+            'InvalidAllowedPatternException' => InvalidAllowedPatternException::class,
+            'ParameterMaxVersionLimitExceeded' => ParameterMaxVersionLimitExceededException::class,
+            'ParameterPatternMismatchException' => ParameterPatternMismatchException::class,
+            'UnsupportedParameterType' => UnsupportedParameterTypeException::class,
+            'PoliciesLimitExceededException' => PoliciesLimitExceededException::class,
+            'InvalidPolicyTypeException' => InvalidPolicyTypeException::class,
+            'InvalidPolicyAttributeException' => InvalidPolicyAttributeException::class,
+            'IncompatiblePolicyException' => IncompatiblePolicyException::class,
+        ]]));
 
         return new PutParameterResult($response);
     }


### PR DESCRIPTION
This PR adds generation of Exceptions objects.

I only generate code for 3 methods to see the result. Once PR reviewed, I'll generate everything.

* ResultGenerator and ExceptionGenerator share the same code to populate responses
* I had to `lcfirst` property name to avoid conflict in `Exception::$Message`. This rule applied also for all objects because, the same CodeGenerator is used (cf previous point);
* I added a new key `RequestContext::exceptionMapping`, therefor all clients must bump the version of core to accept this new key. For the future, I wonder if unknown extra key in `RequestContext` shouldn't be silently ignored to ease BC
* Removed final from ClientException and ServerExeptoin
* `@throws` doc bloc is setup on Client's method. Which is technically wrong (because exception is triggered on lazy loading or destruct) but is the best place for this documentation IMHO.

TODO:
* [x] Regenerate ALL classes
* [x] Fix composer version to require latest `async-aws/core` version (required for RequestContext::exceptionMapping)
