### PR TITLE
Regenerate code after nette/php-generator update

### DIFF
--- a/src/Service/CloudFormation/src/Result/DescribeStackEventsOutput.php
+++ b/src/Service/CloudFormation/src/Result/DescribeStackEventsOutput.php
@@ -23,7 +23,7 @@ class DescribeStackEventsOutput extends Result implements \IteratorAggregate
      * If the output exceeds 1 MB in size, a string that identifies the next page of events. If no additional page exists,
      * this value is null.
      */
-    private $NextToken;
+    private $NextToken = null;
 
     /**
      * Iterates over StackEvents.

--- a/src/Service/CloudFormation/src/Result/DescribeStacksOutput.php
+++ b/src/Service/CloudFormation/src/Result/DescribeStacksOutput.php
@@ -30,7 +30,7 @@ class DescribeStacksOutput extends Result implements \IteratorAggregate
      * If the output exceeds 1 MB in size, a string that identifies the next page of stacks. If no additional page exists,
      * this value is null.
      */
-    private $NextToken;
+    private $NextToken = null;
 
     /**
      * Iterates over Stacks.

--- a/src/Service/CloudWatchLogs/src/Result/DescribeLogStreamsResponse.php
+++ b/src/Service/CloudWatchLogs/src/Result/DescribeLogStreamsResponse.php
@@ -19,7 +19,7 @@ class DescribeLogStreamsResponse extends Result implements \IteratorAggregate
      */
     private $logStreams = [];
 
-    private $nextToken;
+    private $nextToken = null;
 
     /**
      * Iterates over logStreams.

--- a/src/Service/CognitoIdentityProvider/src/Result/ListUsersResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/ListUsersResponse.php
@@ -25,7 +25,7 @@ class ListUsersResponse extends Result implements \IteratorAggregate
      * An identifier that was returned from the previous call to this operation, which can be used to return the next set of
      * items in the list.
      */
-    private $PaginationToken;
+    private $PaginationToken = null;
 
     /**
      * Iterates over Users.

--- a/src/Service/DynamoDb/src/Result/ListTablesOutput.php
+++ b/src/Service/DynamoDb/src/Result/ListTablesOutput.php
@@ -23,7 +23,7 @@ class ListTablesOutput extends Result implements \IteratorAggregate
      * The name of the last table in the current page of results. Use this value as the `ExclusiveStartTableName` in a new
      * request to obtain the next page of results, until all the table names are returned.
      */
-    private $LastEvaluatedTableName;
+    private $LastEvaluatedTableName = null;
 
     /**
      * Iterates over TableNames.

--- a/src/Service/DynamoDb/src/Result/QueryOutput.php
+++ b/src/Service/DynamoDb/src/Result/QueryOutput.php
@@ -25,7 +25,7 @@ class QueryOutput extends Result implements \IteratorAggregate
     /**
      * The number of items in the response.
      */
-    private $Count;
+    private $Count = null;
 
     /**
      * The number of items evaluated, before any `QueryFilter` is applied. A high `ScannedCount` value with few, or no,
@@ -34,7 +34,7 @@ class QueryOutput extends Result implements \IteratorAggregate
      *
      * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Count
      */
-    private $ScannedCount;
+    private $ScannedCount = null;
 
     /**
      * The primary key of the item where the operation stopped, inclusive of the previous result set. Use this value to
@@ -50,7 +50,7 @@ class QueryOutput extends Result implements \IteratorAggregate
      *
      * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html
      */
-    private $ConsumedCapacity;
+    private $ConsumedCapacity = null;
 
     public function getConsumedCapacity(): ?ConsumedCapacity
     {

--- a/src/Service/DynamoDb/src/Result/ScanOutput.php
+++ b/src/Service/DynamoDb/src/Result/ScanOutput.php
@@ -25,7 +25,7 @@ class ScanOutput extends Result implements \IteratorAggregate
     /**
      * The number of items in the response.
      */
-    private $Count;
+    private $Count = null;
 
     /**
      * The number of items evaluated, before any `ScanFilter` is applied. A high `ScannedCount` value with few, or no,
@@ -34,7 +34,7 @@ class ScanOutput extends Result implements \IteratorAggregate
      *
      * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Count
      */
-    private $ScannedCount;
+    private $ScannedCount = null;
 
     /**
      * The primary key of the item where the operation stopped, inclusive of the previous result set. Use this value to
@@ -50,7 +50,7 @@ class ScanOutput extends Result implements \IteratorAggregate
      *
      * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html
      */
-    private $ConsumedCapacity;
+    private $ConsumedCapacity = null;
 
     public function getConsumedCapacity(): ?ConsumedCapacity
     {

--- a/src/Service/Iam/src/Result/ListUsersResponse.php
+++ b/src/Service/Iam/src/Result/ListUsersResponse.php
@@ -27,13 +27,13 @@ class ListUsersResponse extends Result implements \IteratorAggregate
      * fewer than the `MaxItems` number of results even when there are more results available. We recommend that you check
      * `IsTruncated` after every call to ensure that you receive all your results.
      */
-    private $IsTruncated;
+    private $IsTruncated = null;
 
     /**
      * When `IsTruncated` is `true`, this element is present and contains the value to use for the `Marker` parameter in a
      * subsequent pagination request.
      */
-    private $Marker;
+    private $Marker = null;
 
     public function getIsTruncated(): ?bool
     {

--- a/src/Service/Lambda/src/Result/ListLayerVersionsResponse.php
+++ b/src/Service/Lambda/src/Result/ListLayerVersionsResponse.php
@@ -18,7 +18,7 @@ class ListLayerVersionsResponse extends Result implements \IteratorAggregate
     /**
      * A pagination token returned when the response doesn't contain all versions.
      */
-    private $NextMarker;
+    private $NextMarker = null;
 
     /**
      * A list of versions.

--- a/src/Service/Rekognition/src/Result/ListCollectionsResponse.php
+++ b/src/Service/Rekognition/src/Result/ListCollectionsResponse.php
@@ -22,7 +22,7 @@ class ListCollectionsResponse extends Result implements \IteratorAggregate
      * If the result is truncated, the response provides a `NextToken` that you can use in the subsequent request to fetch
      * the next set of collection IDs.
      */
-    private $NextToken;
+    private $NextToken = null;
 
     /**
      * Version numbers of the face detection models associated with the collections in the array `CollectionIds`. For

--- a/src/Service/S3/src/Result/ListMultipartUploadsOutput.php
+++ b/src/Service/S3/src/Result/ListMultipartUploadsOutput.php
@@ -21,53 +21,53 @@ class ListMultipartUploadsOutput extends Result implements \IteratorAggregate
     /**
      * The name of the bucket to which the multipart upload was initiated.
      */
-    private $Bucket;
+    private $Bucket = null;
 
     /**
      * The key at or after which the listing began.
      */
-    private $KeyMarker;
+    private $KeyMarker = null;
 
     /**
      * Upload ID after which listing began.
      */
-    private $UploadIdMarker;
+    private $UploadIdMarker = null;
 
     /**
      * When a list is truncated, this element specifies the value that should be used for the key-marker request parameter
      * in a subsequent request.
      */
-    private $NextKeyMarker;
+    private $NextKeyMarker = null;
 
     /**
      * When a prefix is provided in the request, this field contains the specified prefix. The result contains only keys
      * starting with the specified prefix.
      */
-    private $Prefix;
+    private $Prefix = null;
 
     /**
      * Contains the delimiter you specified in the request. If you don't specify a delimiter in your request, this element
      * is absent from the response.
      */
-    private $Delimiter;
+    private $Delimiter = null;
 
     /**
      * When a list is truncated, this element specifies the value that should be used for the `upload-id-marker` request
      * parameter in a subsequent request.
      */
-    private $NextUploadIdMarker;
+    private $NextUploadIdMarker = null;
 
     /**
      * Maximum number of multipart uploads that could have been included in the response.
      */
-    private $MaxUploads;
+    private $MaxUploads = null;
 
     /**
      * Indicates whether the returned list of multipart uploads is truncated. A value of true indicates that the list was
      * truncated. The list can be truncated if the number of multipart uploads exceeds the limit allowed or specified by max
      * uploads.
      */
-    private $IsTruncated;
+    private $IsTruncated = null;
 
     /**
      * Container for elements related to a particular multipart upload. A response can contain zero or more `Upload`
@@ -84,7 +84,7 @@ class ListMultipartUploadsOutput extends Result implements \IteratorAggregate
     /**
      * Encoding type used by Amazon S3 to encode object keys in the response.
      */
-    private $EncodingType;
+    private $EncodingType = null;
 
     public function getBucket(): ?string
     {

--- a/src/Service/S3/src/Result/ListObjectsV2Output.php
+++ b/src/Service/S3/src/Result/ListObjectsV2Output.php
@@ -21,7 +21,7 @@ class ListObjectsV2Output extends Result implements \IteratorAggregate
      * Set to false if all of the results were returned. Set to true if more keys are available to return. If the number of
      * results exceeds that specified by MaxKeys, all of the results might not be returned.
      */
-    private $IsTruncated;
+    private $IsTruncated = null;
 
     /**
      * Metadata about each object returned.
@@ -31,25 +31,25 @@ class ListObjectsV2Output extends Result implements \IteratorAggregate
     /**
      * The bucket name.
      */
-    private $Name;
+    private $Name = null;
 
     /**
      * Keys that begin with the indicated prefix.
      */
-    private $Prefix;
+    private $Prefix = null;
 
     /**
      * Causes keys that contain the same string between the prefix and the first occurrence of the delimiter to be rolled up
      * into a single result element in the CommonPrefixes collection. These rolled-up keys are not returned elsewhere in the
      * response. Each rolled-up result counts as only one return against the `MaxKeys` value.
      */
-    private $Delimiter;
+    private $Delimiter = null;
 
     /**
      * Sets the maximum number of keys returned in the response. By default the API returns up to 1,000 key names. The
      * response might contain fewer keys but will never contain more.
      */
-    private $MaxKeys;
+    private $MaxKeys = null;
 
     /**
      * All of the keys rolled up into a common prefix count as a single return when calculating the number of returns.
@@ -59,30 +59,30 @@ class ListObjectsV2Output extends Result implements \IteratorAggregate
     /**
      * Encoding type used by Amazon S3 to encode object key names in the XML response.
      */
-    private $EncodingType;
+    private $EncodingType = null;
 
     /**
      * KeyCount is the number of keys returned with this request. KeyCount will always be less than equals to MaxKeys field.
      * Say you ask for 50 keys, your result will include less than equals 50 keys.
      */
-    private $KeyCount;
+    private $KeyCount = null;
 
     /**
      * If ContinuationToken was sent with the request, it is included in the response.
      */
-    private $ContinuationToken;
+    private $ContinuationToken = null;
 
     /**
      * `NextContinuationToken` is sent when `isTruncated` is true, which means there are more keys in the bucket that can be
      * listed. The next list requests to Amazon S3 can be continued with this `NextContinuationToken`.
      * `NextContinuationToken` is obfuscated and is not a real key.
      */
-    private $NextContinuationToken;
+    private $NextContinuationToken = null;
 
     /**
      * If StartAfter was sent with the request, it is included in the response.
      */
-    private $StartAfter;
+    private $StartAfter = null;
 
     /**
      * @param bool $currentPageOnly When true, iterates over items of the current page. Otherwise also fetch items in the next pages.

--- a/src/Service/S3/src/Result/ListPartsOutput.php
+++ b/src/Service/S3/src/Result/ListPartsOutput.php
@@ -26,51 +26,51 @@ class ListPartsOutput extends Result implements \IteratorAggregate
      *
      * @see https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config
      */
-    private $AbortDate;
+    private $AbortDate = null;
 
     /**
      * This header is returned along with the `x-amz-abort-date` header. It identifies applicable lifecycle configuration
      * rule that defines the action to abort incomplete multipart uploads.
      */
-    private $AbortRuleId;
+    private $AbortRuleId = null;
 
     /**
      * The name of the bucket to which the multipart upload was initiated.
      */
-    private $Bucket;
+    private $Bucket = null;
 
     /**
      * Object key for which the multipart upload was initiated.
      */
-    private $Key;
+    private $Key = null;
 
     /**
      * Upload ID identifying the multipart upload whose parts are being listed.
      */
-    private $UploadId;
+    private $UploadId = null;
 
     /**
      * When a list is truncated, this element specifies the last part in the list, as well as the value to use for the
      * part-number-marker request parameter in a subsequent request.
      */
-    private $PartNumberMarker;
+    private $PartNumberMarker = null;
 
     /**
      * When a list is truncated, this element specifies the last part in the list, as well as the value to use for the
      * part-number-marker request parameter in a subsequent request.
      */
-    private $NextPartNumberMarker;
+    private $NextPartNumberMarker = null;
 
     /**
      * Maximum number of parts that were allowed in the response.
      */
-    private $MaxParts;
+    private $MaxParts = null;
 
     /**
      * Indicates whether the returned list of parts is truncated. A true value indicates that the list was truncated. A list
      * can be truncated if the number of parts exceeds the limit returned in the MaxParts element.
      */
-    private $IsTruncated;
+    private $IsTruncated = null;
 
     /**
      * Container for elements related to a particular part. A response can contain zero or more `Part` elements.
@@ -82,20 +82,20 @@ class ListPartsOutput extends Result implements \IteratorAggregate
      * element provides the same information as the `Owner` element. If the initiator is an IAM User, this element provides
      * the user ARN and display name.
      */
-    private $Initiator;
+    private $Initiator = null;
 
     /**
      * Container element that identifies the object owner, after the object is created. If multipart upload is initiated by
      * an IAM user, this element provides the parent account ID and display name.
      */
-    private $Owner;
+    private $Owner = null;
 
     /**
      * Class of storage (STANDARD or REDUCED_REDUNDANCY) used to store the uploaded object.
      */
-    private $StorageClass;
+    private $StorageClass = null;
 
-    private $RequestCharged;
+    private $RequestCharged = null;
 
     public function getAbortDate(): ?\DateTimeImmutable
     {

--- a/src/Service/Sns/src/Result/ListSubscriptionsByTopicResponse.php
+++ b/src/Service/Sns/src/Result/ListSubscriptionsByTopicResponse.php
@@ -23,7 +23,7 @@ class ListSubscriptionsByTopicResponse extends Result implements \IteratorAggreg
      * Token to pass along to the next `ListSubscriptionsByTopic` request. This element is returned if there are more
      * subscriptions to retrieve.
      */
-    private $NextToken;
+    private $NextToken = null;
 
     /**
      * Iterates over Subscriptions.

--- a/src/Service/Sqs/src/Result/ListQueuesResult.php
+++ b/src/Service/Sqs/src/Result/ListQueuesResult.php
@@ -22,7 +22,7 @@ class ListQueuesResult extends Result implements \IteratorAggregate
      * Pagination token to include in the next request. Token value is `null` if there are no additional results to request,
      * or if you did not set `MaxResults` in the request.
      */
-    private $NextToken;
+    private $NextToken = null;
 
     /**
      * Iterates over QueueUrls.

--- a/src/Service/Ssm/src/Result/GetParametersByPathResult.php
+++ b/src/Service/Ssm/src/Result/GetParametersByPathResult.php
@@ -22,7 +22,7 @@ class GetParametersByPathResult extends Result implements \IteratorAggregate
     /**
      * The token for the next set of items to return. Use this token to get the next set of results.
      */
-    private $NextToken;
+    private $NextToken = null;
 
     /**
      * Iterates over Parameters.


### PR DESCRIPTION
Since https://github.com/nette/php-generator/pull/75/files the nullable variables are initialized to `null`.
This PR is similar to the one open by the bot #922 but without CHANGELOG updates