### PR TITLE
Remove cache used in generate command

### DIFF
--- a/src/CodeGenerator/src/Command/GenerateCommand.php
+++ b/src/CodeGenerator/src/Command/GenerateCommand.php
@@ -394,7 +394,6 @@ class GenerateCommand extends Command
                 'path' => [$srcPath, $testPath],
                 'path-mode' => 'override',
                 'using-cache' => false,
-                'cache-file' => $baseDir . '/.php_cs.cache',
                 'diff' => false,
                 'stop-on-violation' => false,
             ],


### PR DESCRIPTION
Cache is disabled (`using-cache=false`) and is useless because the generate command always override the file with non-optimized format...