### PR TITLE
Move logic outside exception

### DIFF
--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <files psalm-version="4.4.1@9fd7a7d885b3a216cff8dec9d8c21a132f275224">
-  <file src="src/Core/src/AwsError/AwsErrorFactory.php">
-    <InvalidArgument occurrences="1"/>
-  </file>
   <file src="src/Core/src/Credentials/PsrCacheProvider.php">
     <InvalidCatch occurrences="1"/>
     <InvalidThrow occurrences="1">

--- a/src/Core/src/AwsError/AwsErrorFactoryFromResponseTrait.php
+++ b/src/Core/src/AwsError/AwsErrorFactoryFromResponseTrait.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace AsyncAws\Core\AwsError;
+
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @internal
+ */
+trait AwsErrorFactoryFromResponseTrait
+{
+    public function createFromResponse(ResponseInterface $response): AwsError
+    {
+        $content = $response->getContent(false);
+        $headers = $response->getHeaders(false);
+
+        return $this->createFromContent($content, $headers);
+    }
+}

--- a/src/Core/src/AwsError/AwsErrorFactoryInterface.php
+++ b/src/Core/src/AwsError/AwsErrorFactoryInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace AsyncAws\Core\AwsError;
+
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * @internal
+ */
+interface AwsErrorFactoryInterface
+{
+    public function createFromResponse(ResponseInterface $response): AwsError;
+
+    public function createFromContent(string $content, array $headers): AwsError;
+}

--- a/src/Core/src/AwsError/ChainAwsErrorFactory.php
+++ b/src/Core/src/AwsError/ChainAwsErrorFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace AsyncAws\Core\AwsError;
+
+use AsyncAws\Core\Exception\UnparsableResponse;
+
+/**
+ * @internal
+ */
+class ChainAwsErrorFactory implements AwsErrorFactoryInterface
+{
+    use AwsErrorFactoryFromResponseTrait;
+
+    private $factories;
+
+    /**
+     * @param AwsErrorFactoryInterface[]|null $factories
+     */
+    public function __construct(array $factories = null)
+    {
+        $this->factories = $factories ?? [
+            new JsonRestAwsErrorFactory(),
+            new JsonRpcAwsErrorFactory(),
+            new XmlAwsErrorFactory(),
+        ];
+    }
+
+    public function createFromContent(string $content, array $headers): AwsError
+    {
+        $e = null;
+        foreach ($this->factories as $factory) {
+            try {
+                return $factory->createFromContent($content, $headers);
+            } catch (UnparsableResponse $e) {
+            }
+        }
+
+        throw new UnparsableResponse('Failed to parse AWS error: ' . $content, 0, $e);
+    }
+}

--- a/src/Core/src/AwsError/JsonRestAwsErrorFactory.php
+++ b/src/Core/src/AwsError/JsonRestAwsErrorFactory.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace AsyncAws\Core\AwsError;
+
+use AsyncAws\Core\Exception\UnexpectedValue;
+use AsyncAws\Core\Exception\UnparsableResponse;
+
+/**
+ * @internal
+ */
+class JsonRestAwsErrorFactory implements AwsErrorFactoryInterface
+{
+    use AwsErrorFactoryFromResponseTrait;
+
+    public function createFromContent(string $content, array $headers): AwsError
+    {
+        try {
+            $body = json_decode($content, true);
+
+            return self::parseJson($body, $headers);
+        } catch (\Throwable $e) {
+            throw new UnparsableResponse('Failed to parse AWS error: ' . $content, 0, $e);
+        }
+    }
+
+    private static function parseJson(array $body, array $headers): AwsError
+    {
+        $code = null;
+        $type = $body['type'] ?? $body['Type'] ?? null;
+        if ($type) {
+            $type = \strtolower($type);
+        }
+        $message = $body['message'] ?? $body['Message'] ?? null;
+        if (isset($headers['x-amzn-errortype'][0])) {
+            $code = explode(':', $headers['x-amzn-errortype'][0], 2)[0];
+        }
+
+        if (null !== $code) {
+            return new AwsError($code, $message, $type, null);
+        }
+
+        throw new UnexpectedValue('JSON does not contains AWS Error');
+    }
+}

--- a/src/Core/src/AwsError/JsonRpcAwsErrorFactory.php
+++ b/src/Core/src/AwsError/JsonRpcAwsErrorFactory.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace AsyncAws\Core\AwsError;
+
+use AsyncAws\Core\Exception\UnexpectedValue;
+use AsyncAws\Core\Exception\UnparsableResponse;
+
+/**
+ * @internal
+ */
+class JsonRpcAwsErrorFactory implements AwsErrorFactoryInterface
+{
+    use AwsErrorFactoryFromResponseTrait;
+
+    public function createFromContent(string $content, array $headers): AwsError
+    {
+        try {
+            $body = json_decode($content, true);
+
+            return self::parseJson($body, $headers);
+        } catch (\Throwable $e) {
+            throw new UnparsableResponse('Failed to parse AWS error: ' . $content, 0, $e);
+        }
+    }
+
+    private static function parseJson(array $body, array $headers): AwsError
+    {
+        $code = null;
+        $message = $body['message'] ?? $body['Message'] ?? null;
+        if (isset($body['__type'])) {
+            $parts = explode('#', $body['__type'], 2);
+            $code = $parts[1] ?? $parts[0];
+        }
+
+        if (null !== $code || null !== $message) {
+            return new AwsError($code, $message, null, null);
+        }
+
+        throw new UnexpectedValue('JSON does not contains AWS Error');
+    }
+}

--- a/src/Core/src/Exception/Http/HttpExceptionTrait.php
+++ b/src/Core/src/Exception/Http/HttpExceptionTrait.php
@@ -3,8 +3,6 @@
 namespace AsyncAws\Core\Exception\Http;
 
 use AsyncAws\Core\AwsError\AwsError;
-use AsyncAws\Core\AwsError\AwsErrorFactory;
-use AsyncAws\Core\Exception\UnparsableResponse;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
 /**
@@ -26,7 +24,7 @@ trait HttpExceptionTrait
      */
     private $awsError;
 
-    public function __construct(ResponseInterface $response)
+    public function __construct(ResponseInterface $response, ?AwsError $awsError)
     {
         $this->response = $response;
         /** @var int $code */
@@ -34,14 +32,8 @@ trait HttpExceptionTrait
         /** @var string $url */
         $url = $response->getInfo('url');
 
-        try {
-            $this->awsError = AwsErrorFactory::createFromResponse($response);
-        } catch (UnparsableResponse $e) {
-            // Ignore parsing error
-        }
-
         $message = sprintf('HTTP %d returned for "%s".', $code, $url);
-        if (null !== $this->awsError) {
+        if (null !== $this->awsError = $awsError) {
             $message .= <<<TEXT
 
 

--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace AsyncAws\Core;
 
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\ChainAwsErrorFactory;
 use AsyncAws\Core\Exception\Exception;
 use AsyncAws\Core\Exception\Http\ClientException;
 use AsyncAws\Core\Exception\Http\HttpException;
@@ -13,6 +15,7 @@ use AsyncAws\Core\Exception\Http\ServerException;
 use AsyncAws\Core\Exception\InvalidArgument;
 use AsyncAws\Core\Exception\LogicException;
 use AsyncAws\Core\Exception\RuntimeException;
+use AsyncAws\Core\Exception\UnparsableResponse;
 use AsyncAws\Core\Stream\ResponseBodyResourceStream;
 use AsyncAws\Core\Stream\ResponseBodyStream;
 use AsyncAws\Core\Stream\ResultStream;
@@ -31,6 +34,9 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 class Response
 {
+    /**
+     * @var ResponseInterface
+     */
     private $httpResponse;
 
     private $httpClient;
@@ -39,7 +45,7 @@ class Response
      * A Result can be resolved many times. This variable contains the last resolve result.
      * Null means that the result has never been resolved. Array contains material to create an exception.
      *
-     * @var bool|HttpException|NetworkException|array|null
+     * @var bool|HttpException|NetworkException|callable|null
      */
     private $resolveResult;
 
@@ -68,15 +74,21 @@ class Response
     private $logger;
 
     /**
+     * @var AwsErrorFactoryInterface
+     */
+    private $awsErrorFactory;
+
+    /**
      * @var bool
      */
     private $debug;
 
-    public function __construct(ResponseInterface $response, HttpClientInterface $httpClient, LoggerInterface $logger, bool $debug = false)
+    public function __construct(ResponseInterface $response, HttpClientInterface $httpClient, LoggerInterface $logger, AwsErrorFactoryInterface $awsErrorFactory = null, bool $debug = false)
     {
         $this->httpResponse = $response;
         $this->httpClient = $httpClient;
         $this->logger = $logger;
+        $this->awsErrorFactory = $awsErrorFactory ?? new ChainAwsErrorFactory();
         $this->debug = $debug;
     }
 
@@ -206,7 +218,7 @@ class Response
             } catch (TransportExceptionInterface $e) {
                 // Exception is stored as an array, because storing an instance of \Exception will create a circular
                 // reference and prevent `__destruct` being called.
-                $response->resolveResult = [NetworkException::class, ['Could not contact remote server.', 0, $e]];
+                $response->resolveResult = new NetworkException('Could not contact remote server.', 0, $e);
 
                 if (null !== $index) {
                     unset($indexMap[$hash]);
@@ -339,30 +351,41 @@ class Response
         }
     }
 
+    /**
+     * This method does not instantiate exception, in order to not polute the stackTrace.
+     */
     private function defineResolveStatus(): void
     {
         try {
             $statusCode = $this->httpResponse->getStatusCode();
         } catch (TransportExceptionInterface $e) {
-            $this->resolveResult = [NetworkException::class, ['Could not contact remote server.', 0, $e]];
-
-            return;
-        }
-
-        if (500 <= $statusCode) {
-            $this->resolveResult = [ServerException::class, [$this->httpResponse]];
-
-            return;
-        }
-
-        if (400 <= $statusCode) {
-            $this->resolveResult = [ClientException::class, [$this->httpResponse]];
+            $this->resolveResult = static function () use ($e): NetworkException {
+                return new NetworkException('Could not contact remote server.', 0, $e);
+            };
 
             return;
         }
 
         if (300 <= $statusCode) {
-            $this->resolveResult = [RedirectionException::class, [$this->httpResponse]];
+            $awsErrorFactory = $this->awsErrorFactory;
+            $httpResponse = $this->httpResponse;
+            $this->resolveResult = static function () use ($awsErrorFactory, $httpResponse): HttpException {
+                try {
+                    $awsError = $awsErrorFactory->createFromResponse($httpResponse);
+                } catch (UnparsableResponse $e) {
+                    $awsError = null;
+                }
+                $statusCode = $httpResponse->getStatusCode();
+                if (500 <= $statusCode) {
+                    return new ServerException($httpResponse, $awsError);
+                }
+
+                if (400 <= $statusCode) {
+                    return new ClientException($httpResponse, $awsError);
+                }
+
+                return new RedirectionException($httpResponse, $awsError);
+            };
 
             return;
         }
@@ -376,10 +399,9 @@ class Response
             return $this->resolveResult;
         }
 
-        if (\is_array($this->resolveResult)) {
-            [$class, $args] = $this->resolveResult;
+        if (\is_callable($this->resolveResult)) {
             /** @psalm-suppress PropertyTypeCoercion */
-            $this->resolveResult = new $class(...$args);
+            $this->resolveResult = ($this->resolveResult)();
         }
 
         $code = null;

--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -352,7 +352,13 @@ class Response
     }
 
     /**
-     * This method does not instantiate exception, in order to not polute the stackTrace.
+     * In PHP < 7.4, a reference to the arguments is present in the stackTrace of the exception.
+     * This creates a Circular reference: Response -> resolveResult -> Exception -> stackTrace -> Response.
+     * This mean, that calling `unset($response)` does not call the `__destruct` method and does not throw the
+     * remaining exception present in `resolveResult`. The `__destruct` method will be called once the garbage collector
+     * will detect the loop.
+     * That's why this method does not creates exception here, but creates closure instead that will be resolved right
+     * before throwing the exception.
      */
     private function defineResolveStatus(): void
     {

--- a/src/Core/src/Sts/StsClient.php
+++ b/src/Core/src/Sts/StsClient.php
@@ -3,6 +3,8 @@
 namespace AsyncAws\Core\Sts;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\XmlAwsErrorFactory;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Sts\Input\AssumeRoleRequest;
 use AsyncAws\Core\Sts\Input\AssumeRoleWithWebIdentityRequest;
@@ -92,6 +94,11 @@ class StsClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetCallerIdentity', 'region' => $input->getRegion()]));
 
         return new GetCallerIdentityResponse($response);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new XmlAwsErrorFactory();
     }
 
     protected function getEndpointMetadata(?string $region): array

--- a/src/Core/tests/Unit/AwsError/ChainAwsErrorFactoryTest.php
+++ b/src/Core/tests/Unit/AwsError/ChainAwsErrorFactoryTest.php
@@ -1,0 +1,84 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core\Tests\Unit\AwsError;
+
+use AsyncAws\Core\AwsError\ChainAwsErrorFactory;
+use PHPUnit\Framework\TestCase;
+
+class ChainAwsErrorFactoryTest extends TestCase
+{
+    public function testRestJsonError()
+    {
+        $content = '{"message":"Missing final \'@domain\'"}';
+
+        $factory = new ChainAwsErrorFactory();
+        $awsError = $factory->createFromContent($content, ['x-amzn-errortype' => ['foo']]);
+
+        self::assertEquals('Missing final \'@domain\'', $awsError->getMessage());
+        self::assertEquals('foo', $awsError->getCode());
+    }
+
+    public function testRestXmlError()
+    {
+        $content = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+    <Code>NoSuchKey</Code>
+    <Message>The specified key does not exist.</Message>
+    <Key>travis-ci/8173c58fa3af3cb90ab1/path.txt</Key>
+    <RequestId>E35DA9F89E2F4155</RequestId>
+    <HostId>fQa+jP2WL4wWRe+OFbw9H9HNqoailc7Zv+nRsjEqXjrsOuIy1ubQ1rOXA=</HostId>
+</Error>
+XML;
+
+        $factory = new ChainAwsErrorFactory();
+        $awsError = $factory->createFromContent($content, []);
+
+        self::assertEquals('NoSuchKey', $awsError->getCode());
+        self::assertEquals('The specified key does not exist.', $awsError->getMessage());
+    }
+
+    public function testDynamoDbError()
+    {
+        $content = '{"__type":"com.amazonaws.dynamodb.v20120810#ResourceNotFoundException","message":"Requested resource not found: Table: tablename not found"}';
+
+        $factory = new ChainAwsErrorFactory();
+        $awsError = $factory->createFromContent($content, []);
+
+        self::assertSame('ResourceNotFoundException', $awsError->getCode());
+        self::assertSame('Requested resource not found: Table: tablename not found', $awsError->getMessage());
+    }
+
+    public function testCloudFormationXmlError()
+    {
+        $content = '<ErrorResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+  <Error>
+    <Type>Sender</Type>
+    <Code>ValidationError</Code>
+    <Message>Stack [foo-dev] does not exist</Message>
+  </Error>
+  <RequestId>f1479c09-9fff-498a-89e5-b69d211fa206</RequestId>
+</ErrorResponse>
+';
+
+        $factory = new ChainAwsErrorFactory();
+        $awsError = $factory->createFromContent($content, []);
+
+        self::assertSame('Sender', $awsError->getType());
+        self::assertSame('ValidationError', $awsError->getCode());
+        self::assertSame('Stack [foo-dev] does not exist', $awsError->getMessage());
+    }
+
+    public function testLambdaJsonError()
+    {
+        $content = '{"Type":"User","message":"Invalid Layer name: arn:aws:lambda:eu-central-2:12345:layer:foobar"}';
+
+        $factory = new ChainAwsErrorFactory();
+        $awsError = $factory->createFromContent($content, ['x-amzn-errortype' => ['foo']]);
+
+        self::assertSame('user', $awsError->getType());
+        self::assertSame('Invalid Layer name: arn:aws:lambda:eu-central-2:12345:layer:foobar', $awsError->getMessage());
+    }
+}

--- a/src/Core/tests/Unit/AwsError/JsonRestAwsErrorFactoryTest.php
+++ b/src/Core/tests/Unit/AwsError/JsonRestAwsErrorFactoryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core\Tests\Unit\AwsError;
+
+use AsyncAws\Core\AwsError\JsonRestAwsErrorFactory;
+use PHPUnit\Framework\TestCase;
+
+class JsonRestAwsErrorFactoryTest extends TestCase
+{
+    public function testRestJsonError()
+    {
+        $content = '{"message":"Missing final \'@domain\'"}';
+
+        $factory = new JsonRestAwsErrorFactory();
+        $awsError = $factory->createFromContent($content, ['x-amzn-errortype' => ['foo']]);
+
+        self::assertEquals('Missing final \'@domain\'', $awsError->getMessage());
+        self::assertEquals('foo', $awsError->getCode());
+    }
+
+    public function testLambdaJsonError()
+    {
+        $content = '{"Type":"User","message":"Invalid Layer name: arn:aws:lambda:eu-central-2:12345:layer:foobar"}';
+
+        $factory = new JsonRestAwsErrorFactory();
+        $awsError = $factory->createFromContent($content, ['x-amzn-errortype' => ['foo']]);
+
+        self::assertSame('user', $awsError->getType());
+        self::assertSame('Invalid Layer name: arn:aws:lambda:eu-central-2:12345:layer:foobar', $awsError->getMessage());
+    }
+}

--- a/src/Core/tests/Unit/AwsError/JsonRpcAwsErrorFactoryTest.php
+++ b/src/Core/tests/Unit/AwsError/JsonRpcAwsErrorFactoryTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core\Tests\Unit\AwsError;
+
+use AsyncAws\Core\AwsError\JsonRpcAwsErrorFactory;
+use PHPUnit\Framework\TestCase;
+
+class JsonRpcAwsErrorFactoryTest extends TestCase
+{
+    public function testDynamoDbError()
+    {
+        $content = '{"__type":"com.amazonaws.dynamodb.v20120810#ResourceNotFoundException","message":"Requested resource not found: Table: tablename not found"}';
+
+        $factory = new JsonRpcAwsErrorFactory();
+        $awsError = $factory->createFromContent($content, []);
+
+        self::assertSame('ResourceNotFoundException', $awsError->getCode());
+        self::assertSame('Requested resource not found: Table: tablename not found', $awsError->getMessage());
+    }
+
+    public function testCreateFromContent()
+    {
+        $content = '{"__type":"foo","Message":"capitaliazed message"}';
+
+        $factory = new JsonRpcAwsErrorFactory();
+        $awsError = $factory->createFromContent($content, []);
+
+        self::assertSame('foo', $awsError->getCode());
+        self::assertSame('capitaliazed message', $awsError->getMessage());
+    }
+}

--- a/src/Core/tests/Unit/AwsError/XmlAwsErrorFactoryTest.php
+++ b/src/Core/tests/Unit/AwsError/XmlAwsErrorFactoryTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core\Tests\Unit\AwsError;
+
+use AsyncAws\Core\AwsError\XmlAwsErrorFactory;
+use PHPUnit\Framework\TestCase;
+
+class XmlAwsErrorFactoryTest extends TestCase
+{
+    public function testCreateFromContent()
+    {
+        $content = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<Error>
+    <Code>NoSuchKey</Code>
+    <Message>The specified key does not exist.</Message>
+    <Key>travis-ci/8173c58fa3af3cb90ab1/path.txt</Key>
+    <RequestId>E35DA9F89E2F4155</RequestId>
+    <HostId>fQa+jP2WL4wWRe+OFbw9H9HNqoailc7Zv+nRsjEqXjrsOuIy1ubQ1rOXA=</HostId>
+</Error>
+XML;
+
+        $factory = new XmlAwsErrorFactory();
+        $awsError = $factory->createFromContent($content, []);
+
+        self::assertEquals('NoSuchKey', $awsError->getCode());
+        self::assertEquals('The specified key does not exist.', $awsError->getMessage());
+    }
+
+    public function testCloudFormationXmlError()
+    {
+        $content = '<ErrorResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+  <Error>
+    <Type>Sender</Type>
+    <Code>ValidationError</Code>
+    <Message>Stack [foo-dev] does not exist</Message>
+  </Error>
+  <RequestId>f1479c09-9fff-498a-89e5-b69d211fa206</RequestId>
+</ErrorResponse>
+';
+
+        $factory = new XmlAwsErrorFactory();
+        $awsError = $factory->createFromContent($content, []);
+
+        self::assertSame('Sender', $awsError->getType());
+        self::assertSame('ValidationError', $awsError->getCode());
+        self::assertSame('Stack [foo-dev] does not exist', $awsError->getMessage());
+    }
+}

--- a/src/Core/tests/Unit/Exception/Http/ClientExceptionTest.php
+++ b/src/Core/tests/Unit/Exception/Http/ClientExceptionTest.php
@@ -4,80 +4,25 @@ declare(strict_types=1);
 
 namespace AsyncAws\Core\Tests\Unit\Exception\Http;
 
+use AsyncAws\Core\AwsError\AwsError;
 use AsyncAws\Core\Exception\Http\ClientException;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use PHPUnit\Framework\TestCase;
 
 class ClientExceptionTest extends TestCase
 {
-    public function testRestJsonError()
+    public function testException()
     {
-        $json = '{"message":"Missing final \'@domain\'"}';
-        $response = new SimpleMockedResponse($json, ['content-type' => 'application/json'], 400);
-        $exception = new ClientException($response);
+        $response = new SimpleMockedResponse('content', ['content-type' => 'application/json'], 400);
+        $awsError = new AwsError('code', 'message', 'type', 'detail');
+        $exception = new ClientException($response, $awsError);
 
-        self::assertEquals('Missing final \'@domain\'', $exception->getAwsMessage());
-    }
-
-    public function testRestXmlError()
-    {
-        $xml = <<<XML
-<?xml version="1.0" encoding="UTF-8"?>
-<Error>
-    <Code>NoSuchKey</Code>
-    <Message>The specified key does not exist.</Message>
-    <Key>travis-ci/8173c58fa3af3cb90ab1/path.txt</Key>
-    <RequestId>E35DA9F89E2F4155</RequestId>
-    <HostId>fQa+jP2WL4wWRe+OFbw9H9HNqoailc7Zv+nRsjEqXjrsOuIy1ubQ1rOXA=</HostId>
-</Error>
-XML;
-
-        $response = new SimpleMockedResponse($xml, ['content-type' => 'text/xml'], 400);
-        $exception = new ClientException($response);
-
-        self::assertEquals('NoSuchKey', $exception->getAwsCode());
-        self::assertEquals('The specified key does not exist.', $exception->getAwsMessage());
-    }
-
-    public function testDynamoDbError()
-    {
-        $json = '{"__type":"com.amazonaws.dynamodb.v20120810#ResourceNotFoundException","message":"Requested resource not found: Table: tablename not found"}';
-        $response = new SimpleMockedResponse($json, ['content-type' => 'application/x-amz-json-1.0'], 400);
-        $exception = new ClientException($response);
-
-        self::assertSame(400, $exception->getCode());
-        self::assertSame('ResourceNotFoundException', $exception->getAwsCode());
-        self::assertSame('Requested resource not found: Table: tablename not found', $exception->getAwsMessage());
-    }
-
-    public function testCloudFormationXmlError()
-    {
-        $content = '<ErrorResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
-  <Error>
-    <Type>Sender</Type>
-    <Code>ValidationError</Code>
-    <Message>Stack [foo-dev] does not exist</Message>
-  </Error>
-  <RequestId>f1479c09-9fff-498a-89e5-b69d211fa206</RequestId>
-</ErrorResponse>
-';
-        $response = new SimpleMockedResponse($content, ['content-type' => 'text/xml'], 400);
-        $exception = new ClientException($response);
-
-        self::assertSame(400, $exception->getCode());
-        self::assertSame('Sender', $exception->getAwsType());
-        self::assertSame('ValidationError', $exception->getAwsCode());
-        self::assertSame('Stack [foo-dev] does not exist', $exception->getAwsMessage());
-    }
-
-    public function testLambdaJsonError()
-    {
-        $content = '{"Type":"User","message":"Invalid Layer name: arn:aws:lambda:eu-central-2:12345:layer:foobar"}';
-        $response = new SimpleMockedResponse($content, ['content-type' => 'application/json'], 400);
-        $exception = new ClientException($response);
-
-        self::assertSame(400, $exception->getCode());
-        self::assertSame('User', $exception->getAwsType());
-        self::assertSame('Invalid Layer name: arn:aws:lambda:eu-central-2:12345:layer:foobar', $exception->getAwsMessage());
+        self::assertEquals(400, $exception->getCode());
+        self::assertEquals('message', $exception->getAwsMessage());
+        self::assertEquals('code', $exception->getAwsCode());
+        self::assertEquals('type', $exception->getAwsType());
+        self::assertEquals('detail', $exception->getAwsDetail());
+        self::assertStringContainsString('HTTP 400 returned for "info: url".', $exception->getMessage());
+        self::assertStringContainsString('Message: message', $exception->getMessage());
     }
 }

--- a/src/Core/tests/Unit/Test/ResultMockFactoryTest.php
+++ b/src/Core/tests/Unit/Test/ResultMockFactoryTest.php
@@ -94,7 +94,6 @@ class ResultMockFactoryTest extends TestCase
             $result->resolve();
         } catch (ClientException $e) {
             self::assertSame('ResourceNotFoundException', $e->getAwsCode());
-            self::assertSame('com.amazonaws.dynamodb.v20120810', $e->getAwsType());
 
             return;
         }

--- a/src/Service/CloudFormation/src/CloudFormationClient.php
+++ b/src/Service/CloudFormation/src/CloudFormationClient.php
@@ -8,6 +8,8 @@ use AsyncAws\CloudFormation\Result\DescribeStackEventsOutput;
 use AsyncAws\CloudFormation\Result\DescribeStacksOutput;
 use AsyncAws\CloudFormation\ValueObject\Stack;
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\XmlAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
 
@@ -54,6 +56,11 @@ class CloudFormationClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DescribeStacks', 'region' => $input->getRegion()]));
 
         return new DescribeStacksOutput($response, $this, $input);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new XmlAwsErrorFactory();
     }
 
     protected function getEndpointMetadata(?string $region): array

--- a/src/Service/CloudFront/src/CloudFrontClient.php
+++ b/src/Service/CloudFront/src/CloudFrontClient.php
@@ -6,6 +6,8 @@ use AsyncAws\CloudFront\Input\CreateInvalidationRequest;
 use AsyncAws\CloudFront\Result\CreateInvalidationResult;
 use AsyncAws\CloudFront\ValueObject\InvalidationBatch;
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\XmlAwsErrorFactory;
 use AsyncAws\Core\RequestContext;
 
 class CloudFrontClient extends AbstractApi
@@ -28,6 +30,11 @@ class CloudFrontClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateInvalidation2019_03_26', 'region' => $input->getRegion()]));
 
         return new CreateInvalidationResult($response);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new XmlAwsErrorFactory();
     }
 
     protected function getEndpointMetadata(?string $region): array

--- a/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
+++ b/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
@@ -9,6 +9,8 @@ use AsyncAws\CloudWatchLogs\Result\DescribeLogStreamsResponse;
 use AsyncAws\CloudWatchLogs\Result\PutLogEventsResponse;
 use AsyncAws\CloudWatchLogs\ValueObject\InputLogEvent;
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\JsonRpcAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
 
@@ -59,6 +61,11 @@ class CloudWatchLogsClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PutLogEvents', 'region' => $input->getRegion()]));
 
         return new PutLogEventsResponse($response);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new JsonRpcAwsErrorFactory();
     }
 
     protected function getEndpointMetadata(?string $region): array

--- a/src/Service/CodeDeploy/src/CodeDeployClient.php
+++ b/src/Service/CodeDeploy/src/CodeDeployClient.php
@@ -6,6 +6,8 @@ use AsyncAws\CodeDeploy\Enum\LifecycleEventStatus;
 use AsyncAws\CodeDeploy\Input\PutLifecycleEventHookExecutionStatusInput;
 use AsyncAws\CodeDeploy\Result\PutLifecycleEventHookExecutionStatusOutput;
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\JsonRpcAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
 
@@ -37,6 +39,11 @@ class CodeDeployClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PutLifecycleEventHookExecutionStatus', 'region' => $input->getRegion()]));
 
         return new PutLifecycleEventHookExecutionStatusOutput($response);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new JsonRpcAwsErrorFactory();
     }
 
     protected function getEndpointMetadata(?string $region): array

--- a/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
+++ b/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
@@ -48,6 +48,8 @@ use AsyncAws\CognitoIdentityProvider\ValueObject\SMSMfaSettingsType;
 use AsyncAws\CognitoIdentityProvider\ValueObject\SoftwareTokenMfaSettingsType;
 use AsyncAws\CognitoIdentityProvider\ValueObject\UserContextDataType;
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\JsonRpcAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
@@ -481,6 +483,11 @@ class CognitoIdentityProviderClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'VerifySoftwareToken', 'region' => $input->getRegion()]));
 
         return new VerifySoftwareTokenResponse($response);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new JsonRpcAwsErrorFactory();
     }
 
     protected function getEndpointMetadata(?string $region): array

--- a/src/Service/DynamoDb/src/DynamoDbClient.php
+++ b/src/Service/DynamoDb/src/DynamoDbClient.php
@@ -3,6 +3,8 @@
 namespace AsyncAws\DynamoDb;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\JsonRpcAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\DynamoDb\Enum\BillingMode;
@@ -472,6 +474,11 @@ class DynamoDbClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'UpdateTimeToLive', 'region' => $input->getRegion()]));
 
         return new UpdateTimeToLiveOutput($response);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new JsonRpcAwsErrorFactory();
     }
 
     protected function getEndpointMetadata(?string $region): array

--- a/src/Service/Ecr/src/EcrClient.php
+++ b/src/Service/Ecr/src/EcrClient.php
@@ -3,6 +3,8 @@
 namespace AsyncAws\Ecr;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\JsonRpcAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\Exception\UnsupportedRegion;
 use AsyncAws\Core\RequestContext;
@@ -30,6 +32,11 @@ class EcrClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetAuthorizationToken', 'region' => $input->getRegion()]));
 
         return new GetAuthorizationTokenResponse($response);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new JsonRpcAwsErrorFactory();
     }
 
     protected function getEndpointMetadata(?string $region): array

--- a/src/Service/EventBridge/src/EventBridgeClient.php
+++ b/src/Service/EventBridge/src/EventBridgeClient.php
@@ -3,6 +3,8 @@
 namespace AsyncAws\EventBridge;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\JsonRpcAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\EventBridge\Input\PutEventsRequest;
@@ -28,6 +30,11 @@ class EventBridgeClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PutEvents', 'region' => $input->getRegion()]));
 
         return new PutEventsResponse($response);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new JsonRpcAwsErrorFactory();
     }
 
     protected function getEndpointMetadata(?string $region): array

--- a/src/Service/Iam/src/IamClient.php
+++ b/src/Service/Iam/src/IamClient.php
@@ -3,6 +3,8 @@
 namespace AsyncAws\Iam;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\XmlAwsErrorFactory;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
 use AsyncAws\Iam\Input\AddUserToGroupRequest;
@@ -186,6 +188,11 @@ class IamClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'UpdateUser', 'region' => $input->getRegion()]));
 
         return new Result($response);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new XmlAwsErrorFactory();
     }
 
     protected function getEndpointMetadata(?string $region): array

--- a/src/Service/Lambda/src/LambdaClient.php
+++ b/src/Service/Lambda/src/LambdaClient.php
@@ -3,6 +3,8 @@
 namespace AsyncAws\Lambda;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\JsonRestAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Lambda\Enum\InvocationType;
@@ -121,6 +123,11 @@ class LambdaClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PublishLayerVersion', 'region' => $input->getRegion()]));
 
         return new PublishLayerVersionResponse($response);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new JsonRestAwsErrorFactory();
     }
 
     protected function getEndpointMetadata(?string $region): array

--- a/src/Service/RdsDataService/src/RdsDataServiceClient.php
+++ b/src/Service/RdsDataService/src/RdsDataServiceClient.php
@@ -3,6 +3,8 @@
 namespace AsyncAws\RdsDataService;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\JsonRestAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\RdsDataService\Input\BatchExecuteStatementRequest;
@@ -135,6 +137,11 @@ class RdsDataServiceClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'RollbackTransaction', 'region' => $input->getRegion()]));
 
         return new RollbackTransactionResponse($response);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new JsonRestAwsErrorFactory();
     }
 
     protected function getEndpointMetadata(?string $region): array

--- a/src/Service/Rekognition/src/RekognitionClient.php
+++ b/src/Service/Rekognition/src/RekognitionClient.php
@@ -3,6 +3,8 @@
 namespace AsyncAws\Rekognition;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\JsonRpcAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Rekognition\Enum\Attribute;
@@ -193,6 +195,11 @@ class RekognitionClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'SearchFacesByImage', 'region' => $input->getRegion()]));
 
         return new SearchFacesByImageResponse($response);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new JsonRpcAwsErrorFactory();
     }
 
     protected function getEndpointMetadata(?string $region): array

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -3,6 +3,8 @@
 namespace AsyncAws\S3;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\XmlAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
@@ -763,6 +765,11 @@ class S3Client extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'UploadPart', 'region' => $input->getRegion()]));
 
         return new UploadPartOutput($response);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new XmlAwsErrorFactory();
     }
 
     protected function getEndpoint(string $uri, array $query, ?string $region): string

--- a/src/Service/Ses/src/SesClient.php
+++ b/src/Service/Ses/src/SesClient.php
@@ -3,6 +3,8 @@
 namespace AsyncAws\Ses;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\JsonRestAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Ses\Input\SendEmailRequest;
@@ -40,6 +42,11 @@ class SesClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'SendEmail', 'region' => $input->getRegion()]));
 
         return new SendEmailResponse($response);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new JsonRestAwsErrorFactory();
     }
 
     protected function getEndpointMetadata(?string $region): array

--- a/src/Service/Sns/src/SnsClient.php
+++ b/src/Service/Sns/src/SnsClient.php
@@ -3,6 +3,8 @@
 namespace AsyncAws\Sns;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\XmlAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
@@ -214,6 +216,11 @@ class SnsClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'Unsubscribe', 'region' => $input->getRegion()]));
 
         return new Result($response);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new XmlAwsErrorFactory();
     }
 
     protected function getEndpointMetadata(?string $region): array

--- a/src/Service/Sqs/src/SqsClient.php
+++ b/src/Service/Sqs/src/SqsClient.php
@@ -3,6 +3,8 @@
 namespace AsyncAws\Sqs;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\XmlAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Result;
@@ -270,6 +272,11 @@ class SqsClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'SendMessage', 'region' => $input->getRegion()]));
 
         return new SendMessageResult($response);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new XmlAwsErrorFactory();
     }
 
     protected function getEndpointMetadata(?string $region): array

--- a/src/Service/Ssm/src/SsmClient.php
+++ b/src/Service/Ssm/src/SsmClient.php
@@ -3,6 +3,8 @@
 namespace AsyncAws\Ssm;
 
 use AsyncAws\Core\AbstractApi;
+use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
+use AsyncAws\Core\AwsError\JsonRpcAwsErrorFactory;
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Ssm\Enum\ParameterTier;
@@ -134,6 +136,11 @@ class SsmClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PutParameter', 'region' => $input->getRegion()]));
 
         return new PutParameterResult($response);
+    }
+
+    protected function getAwsErrorFactory(): AwsErrorFactoryInterface
+    {
+        return new JsonRpcAwsErrorFactory();
     }
 
     protected function getEndpointMetadata(?string $region): array


### PR DESCRIPTION
This fixes several design issues:
- Remove logic from Exception's constructor
- Replace static calls to AwsErrorFactory by dependency injection
- Use specialized parser (Xml, JsonRpc, Rest, ...) instead of blindly try json_decode, and presume it's XML

This factory could be reused in #921 

All classes, but RetryStrategy are internal and changing the signature should be BC compatible.