### PR TITLE
Fix usless null initialization

### DIFF
--- a/src/CodeGenerator/src/Generator/PhpGenerator/ClassFactory.php
+++ b/src/CodeGenerator/src/Generator/PhpGenerator/ClassFactory.php
@@ -170,7 +170,9 @@ class ClassFactory
     {
         $defaults = $from->getDeclaringClass()->getDefaultProperties();
         $prop = new Property($from->getName());
-        $prop->setValue($defaults[$prop->getName()] ?? null);
+        if (isset($defaults[$prop->getName()])) {
+            $prop->setValue($defaults[$prop->getName()] ?? null);
+        }
         $prop->setStatic($from->isStatic());
         $prop->setVisibility(
             $from->isPrivate()

--- a/src/Service/CloudFormation/src/Result/DescribeStackEventsOutput.php
+++ b/src/Service/CloudFormation/src/Result/DescribeStackEventsOutput.php
@@ -25,7 +25,7 @@ class DescribeStackEventsOutput extends Result implements \IteratorAggregate
      * If the output exceeds 1 MB in size, a string that identifies the next page of events. If no additional page exists,
      * this value is null.
      */
-    private $NextToken = null;
+    private $NextToken;
 
     /**
      * Iterates over StackEvents.

--- a/src/Service/CloudFormation/src/Result/DescribeStacksOutput.php
+++ b/src/Service/CloudFormation/src/Result/DescribeStacksOutput.php
@@ -32,7 +32,7 @@ class DescribeStacksOutput extends Result implements \IteratorAggregate
      * If the output exceeds 1 MB in size, a string that identifies the next page of stacks. If no additional page exists,
      * this value is null.
      */
-    private $NextToken = null;
+    private $NextToken;
 
     /**
      * Iterates over Stacks.

--- a/src/Service/CloudWatchLogs/src/Result/DescribeLogStreamsResponse.php
+++ b/src/Service/CloudWatchLogs/src/Result/DescribeLogStreamsResponse.php
@@ -19,7 +19,7 @@ class DescribeLogStreamsResponse extends Result implements \IteratorAggregate
      */
     private $logStreams = [];
 
-    private $nextToken = null;
+    private $nextToken;
 
     /**
      * Iterates over logStreams.

--- a/src/Service/CognitoIdentityProvider/src/Result/ListUsersResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/ListUsersResponse.php
@@ -27,7 +27,7 @@ class ListUsersResponse extends Result implements \IteratorAggregate
      * An identifier that was returned from the previous call to this operation, which can be used to return the next set of
      * items in the list.
      */
-    private $PaginationToken = null;
+    private $PaginationToken;
 
     /**
      * Iterates over Users.

--- a/src/Service/DynamoDb/src/Result/ListTablesOutput.php
+++ b/src/Service/DynamoDb/src/Result/ListTablesOutput.php
@@ -25,7 +25,7 @@ class ListTablesOutput extends Result implements \IteratorAggregate
      * The name of the last table in the current page of results. Use this value as the `ExclusiveStartTableName` in a new
      * request to obtain the next page of results, until all the table names are returned.
      */
-    private $LastEvaluatedTableName = null;
+    private $LastEvaluatedTableName;
 
     /**
      * Iterates over TableNames.

--- a/src/Service/DynamoDb/src/Result/QueryOutput.php
+++ b/src/Service/DynamoDb/src/Result/QueryOutput.php
@@ -27,7 +27,7 @@ class QueryOutput extends Result implements \IteratorAggregate
     /**
      * The number of items in the response.
      */
-    private $Count = null;
+    private $Count;
 
     /**
      * The number of items evaluated, before any `QueryFilter` is applied. A high `ScannedCount` value with few, or no,
@@ -36,7 +36,7 @@ class QueryOutput extends Result implements \IteratorAggregate
      *
      * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Count
      */
-    private $ScannedCount = null;
+    private $ScannedCount;
 
     /**
      * The primary key of the item where the operation stopped, inclusive of the previous result set. Use this value to
@@ -52,7 +52,7 @@ class QueryOutput extends Result implements \IteratorAggregate
      *
      * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html
      */
-    private $ConsumedCapacity = null;
+    private $ConsumedCapacity;
 
     public function getConsumedCapacity(): ?ConsumedCapacity
     {

--- a/src/Service/DynamoDb/src/Result/ScanOutput.php
+++ b/src/Service/DynamoDb/src/Result/ScanOutput.php
@@ -27,7 +27,7 @@ class ScanOutput extends Result implements \IteratorAggregate
     /**
      * The number of items in the response.
      */
-    private $Count = null;
+    private $Count;
 
     /**
      * The number of items evaluated, before any `ScanFilter` is applied. A high `ScannedCount` value with few, or no,
@@ -36,7 +36,7 @@ class ScanOutput extends Result implements \IteratorAggregate
      *
      * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/QueryAndScan.html#Count
      */
-    private $ScannedCount = null;
+    private $ScannedCount;
 
     /**
      * The primary key of the item where the operation stopped, inclusive of the previous result set. Use this value to
@@ -52,7 +52,7 @@ class ScanOutput extends Result implements \IteratorAggregate
      *
      * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html
      */
-    private $ConsumedCapacity = null;
+    private $ConsumedCapacity;
 
     public function getConsumedCapacity(): ?ConsumedCapacity
     {

--- a/src/Service/Iam/src/Result/ListUsersResponse.php
+++ b/src/Service/Iam/src/Result/ListUsersResponse.php
@@ -29,13 +29,13 @@ class ListUsersResponse extends Result implements \IteratorAggregate
      * fewer than the `MaxItems` number of results even when there are more results available. We recommend that you check
      * `IsTruncated` after every call to ensure that you receive all your results.
      */
-    private $IsTruncated = null;
+    private $IsTruncated;
 
     /**
      * When `IsTruncated` is `true`, this element is present and contains the value to use for the `Marker` parameter in a
      * subsequent pagination request.
      */
-    private $Marker = null;
+    private $Marker;
 
     public function getIsTruncated(): ?bool
     {

--- a/src/Service/Lambda/src/Result/ListLayerVersionsResponse.php
+++ b/src/Service/Lambda/src/Result/ListLayerVersionsResponse.php
@@ -18,7 +18,7 @@ class ListLayerVersionsResponse extends Result implements \IteratorAggregate
     /**
      * A pagination token returned when the response doesn't contain all versions.
      */
-    private $NextMarker = null;
+    private $NextMarker;
 
     /**
      * A list of versions.

--- a/src/Service/Rekognition/src/Result/ListCollectionsResponse.php
+++ b/src/Service/Rekognition/src/Result/ListCollectionsResponse.php
@@ -22,7 +22,7 @@ class ListCollectionsResponse extends Result implements \IteratorAggregate
      * If the result is truncated, the response provides a `NextToken` that you can use in the subsequent request to fetch
      * the next set of collection IDs.
      */
-    private $NextToken = null;
+    private $NextToken;
 
     /**
      * Version numbers of the face detection models associated with the collections in the array `CollectionIds`. For

--- a/src/Service/S3/src/Result/ListMultipartUploadsOutput.php
+++ b/src/Service/S3/src/Result/ListMultipartUploadsOutput.php
@@ -21,53 +21,53 @@ class ListMultipartUploadsOutput extends Result implements \IteratorAggregate
     /**
      * The name of the bucket to which the multipart upload was initiated.
      */
-    private $Bucket = null;
+    private $Bucket;
 
     /**
      * The key at or after which the listing began.
      */
-    private $KeyMarker = null;
+    private $KeyMarker;
 
     /**
      * Upload ID after which listing began.
      */
-    private $UploadIdMarker = null;
+    private $UploadIdMarker;
 
     /**
      * When a list is truncated, this element specifies the value that should be used for the key-marker request parameter
      * in a subsequent request.
      */
-    private $NextKeyMarker = null;
+    private $NextKeyMarker;
 
     /**
      * When a prefix is provided in the request, this field contains the specified prefix. The result contains only keys
      * starting with the specified prefix.
      */
-    private $Prefix = null;
+    private $Prefix;
 
     /**
      * Contains the delimiter you specified in the request. If you don't specify a delimiter in your request, this element
      * is absent from the response.
      */
-    private $Delimiter = null;
+    private $Delimiter;
 
     /**
      * When a list is truncated, this element specifies the value that should be used for the `upload-id-marker` request
      * parameter in a subsequent request.
      */
-    private $NextUploadIdMarker = null;
+    private $NextUploadIdMarker;
 
     /**
      * Maximum number of multipart uploads that could have been included in the response.
      */
-    private $MaxUploads = null;
+    private $MaxUploads;
 
     /**
      * Indicates whether the returned list of multipart uploads is truncated. A value of true indicates that the list was
      * truncated. The list can be truncated if the number of multipart uploads exceeds the limit allowed or specified by max
      * uploads.
      */
-    private $IsTruncated = null;
+    private $IsTruncated;
 
     /**
      * Container for elements related to a particular multipart upload. A response can contain zero or more `Upload`
@@ -84,7 +84,7 @@ class ListMultipartUploadsOutput extends Result implements \IteratorAggregate
     /**
      * Encoding type used by Amazon S3 to encode object keys in the response.
      */
-    private $EncodingType = null;
+    private $EncodingType;
 
     public function getBucket(): ?string
     {

--- a/src/Service/S3/src/Result/ListObjectsV2Output.php
+++ b/src/Service/S3/src/Result/ListObjectsV2Output.php
@@ -21,7 +21,7 @@ class ListObjectsV2Output extends Result implements \IteratorAggregate
      * Set to false if all of the results were returned. Set to true if more keys are available to return. If the number of
      * results exceeds that specified by MaxKeys, all of the results might not be returned.
      */
-    private $IsTruncated = null;
+    private $IsTruncated;
 
     /**
      * Metadata about each object returned.
@@ -31,25 +31,25 @@ class ListObjectsV2Output extends Result implements \IteratorAggregate
     /**
      * The bucket name.
      */
-    private $Name = null;
+    private $Name;
 
     /**
      * Keys that begin with the indicated prefix.
      */
-    private $Prefix = null;
+    private $Prefix;
 
     /**
      * Causes keys that contain the same string between the prefix and the first occurrence of the delimiter to be rolled up
      * into a single result element in the CommonPrefixes collection. These rolled-up keys are not returned elsewhere in the
      * response. Each rolled-up result counts as only one return against the `MaxKeys` value.
      */
-    private $Delimiter = null;
+    private $Delimiter;
 
     /**
      * Sets the maximum number of keys returned in the response. By default the API returns up to 1,000 key names. The
      * response might contain fewer keys but will never contain more.
      */
-    private $MaxKeys = null;
+    private $MaxKeys;
 
     /**
      * All of the keys rolled up into a common prefix count as a single return when calculating the number of returns.
@@ -59,30 +59,30 @@ class ListObjectsV2Output extends Result implements \IteratorAggregate
     /**
      * Encoding type used by Amazon S3 to encode object key names in the XML response.
      */
-    private $EncodingType = null;
+    private $EncodingType;
 
     /**
      * KeyCount is the number of keys returned with this request. KeyCount will always be less than equals to MaxKeys field.
      * Say you ask for 50 keys, your result will include less than equals 50 keys.
      */
-    private $KeyCount = null;
+    private $KeyCount;
 
     /**
      * If ContinuationToken was sent with the request, it is included in the response.
      */
-    private $ContinuationToken = null;
+    private $ContinuationToken;
 
     /**
      * `NextContinuationToken` is sent when `isTruncated` is true, which means there are more keys in the bucket that can be
      * listed. The next list requests to Amazon S3 can be continued with this `NextContinuationToken`.
      * `NextContinuationToken` is obfuscated and is not a real key.
      */
-    private $NextContinuationToken = null;
+    private $NextContinuationToken;
 
     /**
      * If StartAfter was sent with the request, it is included in the response.
      */
-    private $StartAfter = null;
+    private $StartAfter;
 
     /**
      * @param bool $currentPageOnly When true, iterates over items of the current page. Otherwise also fetch items in the next pages.

--- a/src/Service/S3/src/Result/ListPartsOutput.php
+++ b/src/Service/S3/src/Result/ListPartsOutput.php
@@ -26,51 +26,51 @@ class ListPartsOutput extends Result implements \IteratorAggregate
      *
      * @see https://docs.aws.amazon.com/AmazonS3/latest/dev/mpuoverview.html#mpu-abort-incomplete-mpu-lifecycle-config
      */
-    private $AbortDate = null;
+    private $AbortDate;
 
     /**
      * This header is returned along with the `x-amz-abort-date` header. It identifies applicable lifecycle configuration
      * rule that defines the action to abort incomplete multipart uploads.
      */
-    private $AbortRuleId = null;
+    private $AbortRuleId;
 
     /**
      * The name of the bucket to which the multipart upload was initiated.
      */
-    private $Bucket = null;
+    private $Bucket;
 
     /**
      * Object key for which the multipart upload was initiated.
      */
-    private $Key = null;
+    private $Key;
 
     /**
      * Upload ID identifying the multipart upload whose parts are being listed.
      */
-    private $UploadId = null;
+    private $UploadId;
 
     /**
      * When a list is truncated, this element specifies the last part in the list, as well as the value to use for the
      * part-number-marker request parameter in a subsequent request.
      */
-    private $PartNumberMarker = null;
+    private $PartNumberMarker;
 
     /**
      * When a list is truncated, this element specifies the last part in the list, as well as the value to use for the
      * part-number-marker request parameter in a subsequent request.
      */
-    private $NextPartNumberMarker = null;
+    private $NextPartNumberMarker;
 
     /**
      * Maximum number of parts that were allowed in the response.
      */
-    private $MaxParts = null;
+    private $MaxParts;
 
     /**
      * Indicates whether the returned list of parts is truncated. A true value indicates that the list was truncated. A list
      * can be truncated if the number of parts exceeds the limit returned in the MaxParts element.
      */
-    private $IsTruncated = null;
+    private $IsTruncated;
 
     /**
      * Container for elements related to a particular part. A response can contain zero or more `Part` elements.
@@ -82,20 +82,20 @@ class ListPartsOutput extends Result implements \IteratorAggregate
      * element provides the same information as the `Owner` element. If the initiator is an IAM User, this element provides
      * the user ARN and display name.
      */
-    private $Initiator = null;
+    private $Initiator;
 
     /**
      * Container element that identifies the object owner, after the object is created. If multipart upload is initiated by
      * an IAM user, this element provides the parent account ID and display name.
      */
-    private $Owner = null;
+    private $Owner;
 
     /**
      * Class of storage (STANDARD or REDUCED_REDUNDANCY) used to store the uploaded object.
      */
-    private $StorageClass = null;
+    private $StorageClass;
 
-    private $RequestCharged = null;
+    private $RequestCharged;
 
     public function getAbortDate(): ?\DateTimeImmutable
     {

--- a/src/Service/Sns/src/Result/ListSubscriptionsByTopicResponse.php
+++ b/src/Service/Sns/src/Result/ListSubscriptionsByTopicResponse.php
@@ -25,7 +25,7 @@ class ListSubscriptionsByTopicResponse extends Result implements \IteratorAggreg
      * Token to pass along to the next `ListSubscriptionsByTopic` request. This element is returned if there are more
      * subscriptions to retrieve.
      */
-    private $NextToken = null;
+    private $NextToken;
 
     /**
      * Iterates over Subscriptions.

--- a/src/Service/Sqs/src/Result/ListQueuesResult.php
+++ b/src/Service/Sqs/src/Result/ListQueuesResult.php
@@ -24,7 +24,7 @@ class ListQueuesResult extends Result implements \IteratorAggregate
      * Pagination token to include in the next request. Token value is `null` if there are no additional results to request,
      * or if you did not set `MaxResults` in the request.
      */
-    private $NextToken = null;
+    private $NextToken;
 
     /**
      * Iterates over QueueUrls.

--- a/src/Service/Ssm/src/Result/GetParametersByPathResult.php
+++ b/src/Service/Ssm/src/Result/GetParametersByPathResult.php
@@ -22,7 +22,7 @@ class GetParametersByPathResult extends Result implements \IteratorAggregate
     /**
      * The token for the next set of items to return. Use this token to get the next set of results.
      */
-    private $NextToken = null;
+    private $NextToken;
 
     /**
      * Iterates over Parameters.


### PR DESCRIPTION
Revert #923 (The reason of the change where wrong BTW. The culprit is https://github.com/nette/php-generator/commit/fa9d71a871fc4f0f58286149237d49c49427d675)

When property are not typedhinted, it does not make sens to define a default null value.

Moreover, this change were not consistent: Only files loaded by `ClassFactory::fromExistingClass` (aka Clients and Waiters) where initialized with this value.