### PR TITLE
Add integration test via localstack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,12 +10,25 @@ $(SUBCLEAN): %.clean:
 
 
 .PHONY: initialize $(SUBINITIALIZE)
-initialize: $(SUBINITIALIZE)
+initialize: start-docker
+	$(MAKE) $(SUBINITIALIZE)
 $(SUBINITIALIZE): %.initialize:
 	$(MAKE) -C $* initialize
 
-start-docker: initialize
+start-docker: start-docker-s3 start-docker-localstack
+start-docker: start-docker-s3 start-docker-localstack
+start-docker-localstack:
+	docker start async_aws_localstack && exit 0 || \
+	docker pull localstack/localstack && \
+	docker run -d -p 4566:4566 -p 4567:4566 -p 4568:4566 -p 4571:4566 -p 4572:4566 -p 4573:4566 -p 4574:4566 -p 4575:4566 -e SERVICES=sts,cloudformation,logs,events,iam,sns,ssm,dynamodb -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack localstack/localstack && \
+	docker run --rm --link async_aws_localstack:localstack martin/wait -c localstack:4566
+start-docker-s3:
+	docker start async_aws_s3 && exit 0 || \
+	docker pull asyncaws/testing-s3 && \
+	docker run -d -p 4569:4569 -p 4570:4569 --name async_aws_s3 asyncaws/testing-s3
+
 stop-docker: clean
+	docker stop async_aws_localstack || true
 
 test: initialize
 	./vendor/bin/simple-phpunit

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         "ext-hash": "*",
         "ext-json": "*",
         "psr/log": "~1.0",
-        "symfony/http-client": "^4.4 || ^5.0,!=5.2.0",
+        "symfony/http-client": "^4.4.16 || ^5.1.7,!=5.2.0",
         "symfony/http-client-contracts": "^1.0 || ^2.0",
         "symfony/process": "^4.4 || ^5.0",
         "symfony/service-contracts": "^1.0 || ^2.0"

--- a/src/Core/Makefile
+++ b/src/Core/Makefile
@@ -1,0 +1,16 @@
+.EXPORT_ALL_VARIABLES:
+
+initialize: start-docker
+start-docker:
+	docker start async_aws_localstack && exit 0 || \
+	docker start async_aws_localstack-sts && exit 0 || \
+	docker pull localstack/localstack && \
+	docker run -d -p 4566:4566 -e SERVICES=sts -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-sts localstack/localstack && \
+	docker run --rm --link async_aws_localstack-sts:localstack martin/wait -c localstack:4566
+
+test: initialize
+	./vendor/bin/simple-phpunit
+
+clean: stop-docker
+stop-docker:
+	docker stop async_aws_localstack-sts || true

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -18,7 +18,7 @@
         "psr/cache": "^1.0",
         "psr/log": "^1.0",
         "symfony/deprecation-contracts": "^2.1",
-        "symfony/http-client": "^4.4 || ^5.0,!=5.2.0",
+        "symfony/http-client": "^4.4.16 || ^5.1.7,!=5.2.0",
         "symfony/http-client-contracts": "^1.1.8 || ^2.0",
         "symfony/service-contracts": "^1.0 || ^2.0"
     },

--- a/src/Core/tests/Unit/Input/AssumeRoleWithWebIdentityRequestTest.php
+++ b/src/Core/tests/Unit/Input/AssumeRoleWithWebIdentityRequestTest.php
@@ -13,7 +13,7 @@ class AssumeRoleWithWebIdentityRequestTest extends TestCase
         $input = new AssumeRoleWithWebIdentityRequest([
             'RoleArn' => 'arn:aws:iam::123456789012:role/FederatedWebIdentityRole',
             'RoleSessionName' => 'app1',
-            'WebIdentityToken' => 'FooBarBz',
+            'WebIdentityToken' => 'FooBarBaz',
             'ProviderId' => 'www.amazon.com',
             'PolicyArns' => [new PolicyDescriptorType([
                 'arn' => 'arn:aws:iam::123456789012:policy/q=webidentitydemopolicy1',
@@ -36,7 +36,7 @@ class AssumeRoleWithWebIdentityRequestTest extends TestCase
             &ProviderId=www.amazon.com
             &RoleSessionName=app1
             &RoleArn=arn%3Aaws%3Aiam%3A%3A123456789012%3Arole%2FFederatedWebIdentityRole
-            &WebIdentityToken=FooBarBz
+            &WebIdentityToken=FooBarBaz
         ';
 
         self::assertRequestEqualsHttpRequest($expected, $input->request());

--- a/src/Integration/Aws/SimpleS3/tests/Unit/SimpleS3ClientTest.php
+++ b/src/Integration/Aws/SimpleS3/tests/Unit/SimpleS3ClientTest.php
@@ -40,14 +40,14 @@ class SimpleS3ClientTest extends TestCase
         $bucket = 'bucket';
         $file = 'robots.txt';
         $callback = function (array $input) use ($bucket, $file, $object) {
-            $this->assertEquals($bucket, $input['Bucket']);
-            $this->assertEquals($file, $input['Key']);
-            $this->assertEquals($object, $input['Body']);
+            self::assertEquals($bucket, $input['Bucket']);
+            self::assertEquals($file, $input['Key']);
+            self::assertEquals($object, $input['Body']);
 
             return true;
         };
 
-        $this->assertSmallFileUpload($callback, $bucket, $file, $object);
+        self::assertSmallFileUpload($callback, $bucket, $file, $object);
     }
 
     public function testUploadSmallFileResource()
@@ -59,14 +59,14 @@ class SimpleS3ClientTest extends TestCase
         // do not rewind
 
         $callback = function (array $input) use ($bucket, $file, $object) {
-            $this->assertEquals($bucket, $input['Bucket']);
-            $this->assertEquals($file, $input['Key']);
-            $this->assertEquals($object, $input['Body']);
+            self::assertEquals($bucket, $input['Bucket']);
+            self::assertEquals($file, $input['Key']);
+            self::assertEquals($object, $input['Body']);
 
             return true;
         };
 
-        $this->assertSmallFileUpload($callback, $bucket, $file, $object);
+        self::assertSmallFileUpload($callback, $bucket, $file, $object);
     }
 
     public function testUploadSmallFileClosure()
@@ -79,17 +79,17 @@ class SimpleS3ClientTest extends TestCase
         \fseek($resource, 0, \SEEK_SET);
 
         $callback = function (array $input) use ($bucket, $file, $contents) {
-            $this->assertEquals($bucket, $input['Bucket']);
-            $this->assertEquals($file, $input['Key']);
-            $this->assertIsResource($input['Body']);
+            self::assertEquals($bucket, $input['Bucket']);
+            self::assertEquals($file, $input['Key']);
+            self::assertIsResource($input['Body']);
 
             \fseek($input['Body'], 0, \SEEK_SET);
-            $this->assertEquals($contents, stream_get_contents($input['Body']));
+            self::assertEquals($contents, stream_get_contents($input['Body']));
 
             return true;
         };
 
-        $this->assertSmallFileUpload($callback, $bucket, $file, static function (int $length) use ($resource): string {
+        self::assertSmallFileUpload($callback, $bucket, $file, static function (int $length) use ($resource): string {
             return fread($resource, $length);
         });
     }
@@ -105,15 +105,15 @@ class SimpleS3ClientTest extends TestCase
         $file = 'robots.txt';
 
         $callback = function (array $input) use ($bucket, $file, $contents) {
-            $this->assertEquals($bucket, $input['Bucket']);
-            $this->assertEquals($file, $input['Key']);
+            self::assertEquals($bucket, $input['Bucket']);
+            self::assertEquals($file, $input['Key']);
             \fseek($input['Body'], 0, \SEEK_SET);
-            $this->assertEquals(implode('', $contents), stream_get_contents($input['Body']));
+            self::assertEquals(implode('', $contents), stream_get_contents($input['Body']));
 
             return true;
         };
 
-        $this->assertSmallFileUpload($callback, $bucket, $file, (static function () use ($contents): iterable {
+        self::assertSmallFileUpload($callback, $bucket, $file, (static function () use ($contents): iterable {
             foreach ($contents as $data) {
                 yield $data;
             }

--- a/src/Integration/Flysystem/S3/Makefile
+++ b/src/Integration/Flysystem/S3/Makefile
@@ -2,12 +2,14 @@
 
 initialize: start-docker
 start-docker:
-	docker pull asyncaws/testing-s3
-	docker start async_aws_flysystem_s3 || docker run -d -p 4570:4569 --name async_aws_flysystem_s3 asyncaws/testing-s3
+	docker start async_aws_s3 && exit 0 || \
+	docker start async_aws_s3-fly && exit 0 || \
+	docker pull asyncaws/testing-s3 && \
+	docker run -d -p 4569:4569 --name async_aws_s3-fly asyncaws/testing-s3
 
 test: initialize
 	./vendor/bin/simple-phpunit
 
 clean: stop-docker
 stop-docker:
-	docker stop async_aws_flysystem_s3 || true
+	docker stop async_aws_s3-fly || true

--- a/src/Integration/Laravel/Queue/tests/Unit/AsyncAwsSqsQueueTest.php
+++ b/src/Integration/Laravel/Queue/tests/Unit/AsyncAwsSqsQueueTest.php
@@ -79,9 +79,9 @@ class AsyncAwsSqsQueueTest extends TestCase
 
                 // verify that body is serialized.
                 $body = json_decode($input['MessageBody'], true);
-                $this->assertArrayHasKey('displayName', $body);
-                $this->assertArrayHasKey('job', $body);
-                $this->assertArrayHasKey('data', $body);
+                self::assertArrayHasKey('displayName', $body);
+                self::assertArrayHasKey('job', $body);
+                self::assertArrayHasKey('data', $body);
 
                 if (CreateUser::class !== $body['displayName']) {
                     return false;

--- a/src/Integration/Symfony/Bundle/tests/Functional/BundleInitializationTest.php
+++ b/src/Integration/Symfony/Bundle/tests/Functional/BundleInitializationTest.php
@@ -31,22 +31,22 @@ class BundleInitializationTest extends BaseBundleTestCase
         $kernel->addConfigFile(__DIR__ . '/Resources/config/default.yaml');
         $this->bootKernel();
 
-        $this->assertServiceExists('async_aws.client.s3', S3Client::class);
-        $this->assertServiceExists('async_aws.client.sqs', SqsClient::class);
-        $this->assertServiceExists('async_aws.client.ses', SesClient::class);
-        $this->assertServiceExists('async_aws.client.foobar', SqsClient::class);
-        $this->assertServiceExists('async_aws.client.secret', SsmClient::class);
+        self::assertServiceExists('async_aws.client.s3', S3Client::class);
+        self::assertServiceExists('async_aws.client.sqs', SqsClient::class);
+        self::assertServiceExists('async_aws.client.ses', SesClient::class);
+        self::assertServiceExists('async_aws.client.foobar', SqsClient::class);
+        self::assertServiceExists('async_aws.client.secret', SsmClient::class);
 
         // Test autowired clients
-        $this->assertServiceExists(S3Client::class, S3Client::class);
-        $this->assertServiceExists(SqsClient::class, SqsClient::class);
-        $this->assertServiceExists(SesClient::class, SesClient::class);
+        self::assertServiceExists(S3Client::class, S3Client::class);
+        self::assertServiceExists(SqsClient::class, SqsClient::class);
+        self::assertServiceExists(SesClient::class, SesClient::class);
 
         // Test autowire by name
-        $this->assertServiceExists(SqsClient::class . ' $foobar', SqsClient::class);
+        self::assertServiceExists(SqsClient::class . ' $foobar', SqsClient::class);
 
         // Test secret
-        $this->assertServiceExists(SsmVault::class, SsmVault::class);
+        self::assertServiceExists(SsmVault::class, SsmVault::class);
 
         $container = $this->getContainer();
         self::assertFalse($container->has(SqsClient::class . ' $notFound'));
@@ -59,14 +59,14 @@ class BundleInitializationTest extends BaseBundleTestCase
         $kernel->addConfigFile(__DIR__ . '/Resources/config/empty.yaml');
         $this->bootKernel();
 
-        $this->assertServiceExists('async_aws.client.s3', S3Client::class);
-        $this->assertServiceExists('async_aws.client.sqs', SqsClient::class);
-        $this->assertServiceExists('async_aws.client.ses', SesClient::class);
+        self::assertServiceExists('async_aws.client.s3', S3Client::class);
+        self::assertServiceExists('async_aws.client.sqs', SqsClient::class);
+        self::assertServiceExists('async_aws.client.ses', SesClient::class);
 
         // Test autowired clients
-        $this->assertServiceExists(S3Client::class, S3Client::class);
-        $this->assertServiceExists(SqsClient::class, SqsClient::class);
-        $this->assertServiceExists(SesClient::class, SesClient::class);
+        self::assertServiceExists(S3Client::class, S3Client::class);
+        self::assertServiceExists(SqsClient::class, SqsClient::class);
+        self::assertServiceExists(SesClient::class, SesClient::class);
     }
 
     public function testNotRegisterServices()

--- a/src/Integration/Symfony/Bundle/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/src/Integration/Symfony/Bundle/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -14,14 +14,14 @@ class ConfigurationTest extends TestCase
 
     public function testNoConfigIsValid(): void
     {
-        $this->assertConfigurationIsValid([
+        self::assertConfigurationIsValid([
             [], // no values at all
         ]);
     }
 
     public function testDefaultValues(): void
     {
-        $this->assertProcessedConfigurationEquals([
+        self::assertProcessedConfigurationEquals([
             [],
         ], [
             'register_service' => true,
@@ -45,7 +45,7 @@ class ConfigurationTest extends TestCase
 
     public function testServiceWithAwsName(): void
     {
-        $this->assertProcessedConfigurationEquals([
+        self::assertProcessedConfigurationEquals([
             ['clients' => [
                 'sqs' => ['config' => ['foo' => 'bar']],
             ]],
@@ -62,7 +62,7 @@ class ConfigurationTest extends TestCase
 
     public function testServiceWithCustomName(): void
     {
-        $this->assertProcessedConfigurationEquals([
+        self::assertProcessedConfigurationEquals([
             ['clients' => [
                 'foobar' => [
                     'type' => 'sqs',
@@ -81,7 +81,7 @@ class ConfigurationTest extends TestCase
 
     public function testServiceWithCustomNameWithoutType(): void
     {
-        $this->assertConfigurationIsInvalid([
+        self::assertConfigurationIsInvalid([
             ['clients' => [
                 'foobar' => [
                 ],
@@ -91,7 +91,7 @@ class ConfigurationTest extends TestCase
 
     public function testServiceWithCustomNameWithWrongType(): void
     {
-        $this->assertConfigurationIsInvalid([
+        self::assertConfigurationIsInvalid([
             ['clients' => [
                 'foobar' => [
                     'type' => 'blabla',
@@ -102,7 +102,7 @@ class ConfigurationTest extends TestCase
 
     public function testServiceWithAwsNameWithWrongType(): void
     {
-        $this->assertConfigurationIsInvalid([
+        self::assertConfigurationIsInvalid([
             ['clients' => [
                 'sqs' => [
                     'type' => 's3',

--- a/src/Service/CloudFormation/Makefile
+++ b/src/Service/CloudFormation/Makefile
@@ -2,11 +2,15 @@
 
 initialize: start-docker
 start-docker:
-	echo "Noop"
+	docker start async_aws_localstack && exit 0 || \
+	docker start async_aws_localstack-cloudformation && exit 0 || \
+	docker pull localstack/localstack && \
+	docker run -d -p 4567:4566 -e SERVICES=cloudformation -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-cloudformation localstack/localstack && \
+	docker run --rm --link async_aws_localstack-cloudformation:localstack martin/wait -c localstack:4566
 
 test: initialize
 	./vendor/bin/simple-phpunit
 
 clean: stop-docker
 stop-docker:
-	echo "Noop"
+	docker stop async_aws_localstack-cloudformation || true

--- a/src/Service/CloudFormation/tests/Integration/CloudFormationClientTest.php
+++ b/src/Service/CloudFormation/tests/Integration/CloudFormationClientTest.php
@@ -5,7 +5,8 @@ namespace AsyncAws\CloudFormation\Tests\Integration;
 use AsyncAws\CloudFormation\CloudFormationClient;
 use AsyncAws\CloudFormation\Input\DescribeStackEventsInput;
 use AsyncAws\CloudFormation\Input\DescribeStacksInput;
-use AsyncAws\Core\Credentials\NullProvider;
+use AsyncAws\Core\Credentials\Credentials;
+use AsyncAws\Core\Exception\Http\ClientException;
 use PHPUnit\Framework\TestCase;
 
 class CloudFormationClientTest extends TestCase
@@ -15,15 +16,12 @@ class CloudFormationClientTest extends TestCase
         $client = $this->getClient();
 
         $input = new DescribeStackEventsInput([
-            'StackName' => 'change me',
-            'NextToken' => 'change me',
+            'StackName' => 'demo',
         ]);
         $result = $client->DescribeStackEvents($input);
 
-        $result->resolve();
-
-        // self::assertTODO(expected, $result->getStackEvents());
-        self::assertStringContainsString('change it', $result->getNextToken());
+        self::assertCount(0, $result->getStackEvents());
+        self::assertNull($result->getNextToken());
     }
 
     public function testDescribeStacks(): void
@@ -31,23 +29,20 @@ class CloudFormationClientTest extends TestCase
         $client = $this->getClient();
 
         $input = new DescribeStacksInput([
-            'StackName' => 'change me',
-            'NextToken' => 'change me',
+            'StackName' => 'demo',
         ]);
         $result = $client->DescribeStacks($input);
 
-        $result->resolve();
+        self::expectException(ClientException::class);
+        self::expectExceptionMessageMatches('/Stack with id demo does not exist/');
 
-        // self::assertTODO(expected, $result->getStacks());
-        self::assertStringContainsString('change it', $result->getNextToken());
+        $result->resolve();
     }
 
     private function getClient(): CloudFormationClient
     {
-        self::markTestSkipped('No Docker image for CloudFormation');
-
         return new CloudFormationClient([
-            'endpoint' => 'http://localhost',
-        ], new NullProvider());
+            'endpoint' => 'http://localhost:4567',
+        ], new Credentials('aws_id', 'aws_secret'));
     }
 }

--- a/src/Service/CloudFront/tests/Integration/CloudFrontClientTest.php
+++ b/src/Service/CloudFront/tests/Integration/CloudFrontClientTest.php
@@ -35,7 +35,7 @@ class CloudFrontClientTest extends TestCase
 
     private function getClient(): CloudFrontClient
     {
-        self::markTestSkipped('Not implemented');
+        self::markTestSkipped('There is no docker image available for CloudFront.');
 
         return new CloudFrontClient([
             'endpoint' => 'http://localhost',

--- a/src/Service/CloudWatchLogs/Makefile
+++ b/src/Service/CloudWatchLogs/Makefile
@@ -2,11 +2,15 @@
 
 initialize: start-docker
 start-docker:
-	echo "Noop"
+	docker start async_aws_localstack && exit 0 || \
+	docker start async_aws_localstack-logs && exit 0 || \
+	docker pull localstack/localstack && \
+	docker run -d -p 4568:4566 -e SERVICES=logs -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-logs localstack/localstack && \
+	docker run --rm --link async_aws_localstack-logs:localstack martin/wait -c localstack:4566
 
 test: initialize
 	./vendor/bin/simple-phpunit
 
 clean: stop-docker
 stop-docker:
-	echo "Noop"
+	docker stop async_aws_localstack-logs || true

--- a/src/Service/CloudWatchLogs/tests/Integration/CloudWatchLogsClientTest.php
+++ b/src/Service/CloudWatchLogs/tests/Integration/CloudWatchLogsClientTest.php
@@ -3,10 +3,12 @@
 namespace AsyncAws\CloudWatchLogs\Tests\Integration;
 
 use AsyncAws\CloudWatchLogs\CloudWatchLogsClient;
+use AsyncAws\CloudWatchLogs\Enum\OrderBy;
 use AsyncAws\CloudWatchLogs\Input\DescribeLogStreamsRequest;
 use AsyncAws\CloudWatchLogs\Input\PutLogEventsRequest;
 use AsyncAws\CloudWatchLogs\ValueObject\InputLogEvent;
-use AsyncAws\Core\Credentials\NullProvider;
+use AsyncAws\Core\Credentials\Credentials;
+use AsyncAws\Core\Exception\Http\ClientException;
 use AsyncAws\Core\Test\TestCase;
 
 class CloudWatchLogsClientTest extends TestCase
@@ -16,18 +18,17 @@ class CloudWatchLogsClientTest extends TestCase
         $client = $this->getClient();
 
         $input = new DescribeLogStreamsRequest([
-            'logGroupName' => 'change me',
-            'logStreamNamePrefix' => 'change me',
-            'orderBy' => 'change me',
+            'logGroupName' => 'app-logs',
+            'orderBy' => OrderBy::LAST_EVENT_TIME,
             'descending' => false,
-            'nextToken' => 'change me',
-            'limit' => 1337,
+            'limit' => 10,
         ]);
         $result = $client->DescribeLogStreams($input);
 
-        $result->resolve();
+        self::expectException(ClientException::class);
+        self::expectExceptionMessageMatches('/The specified log group does not exist/');
 
-        self::assertSame('changeIt', $result->getnextToken());
+        $result->resolve();
     }
 
     public function testPutLogEvents(): void
@@ -35,27 +36,25 @@ class CloudWatchLogsClientTest extends TestCase
         $client = $this->getClient();
 
         $input = new PutLogEventsRequest([
-            'logGroupName' => 'change me',
-            'logStreamName' => 'change me',
+            'logGroupName' => 'app-logs',
+            'logStreamName' => 'front-stream',
             'logEvents' => [new InputLogEvent([
-                'timestamp' => 1337,
-                'message' => 'change me',
+                'timestamp' => time(),
+                'message' => 'something goes wrong',
             ])],
-            'sequenceToken' => 'change me',
         ]);
         $result = $client->PutLogEvents($input);
 
-        $result->resolve();
+        self::expectException(ClientException::class);
+        self::expectExceptionMessageMatches('/The specified log group does not exist/');
 
-        self::assertSame('changeIt', $result->getnextSequenceToken());
+        $result->resolve();
     }
 
     private function getClient(): CloudWatchLogsClient
     {
-        self::markTestSkipped('There is no docker image available for CloudWatchLogs.');
-
         return new CloudWatchLogsClient([
-            'endpoint' => 'http://localhost',
-        ], new NullProvider());
+            'endpoint' => 'http://localhost:4568',
+        ], new Credentials('aws_id', 'aws_secret'));
     }
 }

--- a/src/Service/CodeDeploy/tests/Integration/CodeDeployClientTest.php
+++ b/src/Service/CodeDeploy/tests/Integration/CodeDeployClientTest.php
@@ -27,7 +27,7 @@ class CodeDeployClientTest extends TestCase
 
     private function getClient(): CodeDeployClient
     {
-        self::markTestSkipped('There is not docker image available for CodeDeploy.');
+        self::markTestSkipped('There is no docker image available for CodeDeploy.');
 
         return new CodeDeployClient([
             'endpoint' => 'http://localhost',

--- a/src/Service/CognitoIdentityProvider/tests/Integration/CognitoIdentityProviderClientTest.php
+++ b/src/Service/CognitoIdentityProvider/tests/Integration/CognitoIdentityProviderClientTest.php
@@ -393,7 +393,7 @@ class CognitoIdentityProviderClientTest extends TestCase
 
     private function getClient(): CognitoIdentityProviderClient
     {
-        self::markTestSkipped('No Docker image for Cognito Identity Provider');
+        self::markTestSkipped('There is no docker image available for CognitoIdentityProvider.');
 
         return new CognitoIdentityProviderClient([
             'endpoint' => 'http://localhost',

--- a/src/Service/DynamoDb/Makefile
+++ b/src/Service/DynamoDb/Makefile
@@ -2,12 +2,15 @@
 
 initialize: start-docker
 start-docker:
-	docker pull amazon/dynamodb-local
-	docker start async_aws_dynamodb || docker run -d -p 8000:8000 --name async_aws_dynamodb amazon/dynamodb-local
+	docker start async_aws_localstack && exit 0 || \
+	docker start async_aws_localstack-dynamodb && exit 0 || \
+	docker pull localstack/localstack && \
+	docker run -d -p 4575:4566 -e SERVICES=dynamodb -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-dynamodb localstack/localstack && \
+	docker run --rm --link async_aws_localstack-dynamodb:localstack martin/wait -c localstack:4566
 
 test: initialize
 	./vendor/bin/simple-phpunit
 
 clean: stop-docker
 stop-docker:
-	docker stop async_aws_dynamodb || true
+	docker stop async_aws_localstack-dynamodb || true

--- a/src/Service/DynamoDb/composer.json
+++ b/src/Service/DynamoDb/composer.json
@@ -16,6 +16,9 @@
         "ext-json": "*",
         "async-aws/core": "^1.2"
     },
+    "conflict": {
+        "symfony/http-client": "<4.4.16,<5.1.7"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.1-dev"

--- a/src/Service/Ecr/tests/Integration/EcrClientTest.php
+++ b/src/Service/Ecr/tests/Integration/EcrClientTest.php
@@ -25,7 +25,7 @@ class EcrClientTest extends TestCase
 
     private function getClient(): EcrClient
     {
-        self::markTestSkipped('No docker image found..');
+        self::markTestSkipped('There is no docker image available for Ecr.');
 
         return new EcrClient([
             'endpoint' => 'http://localhost',

--- a/src/Service/EventBridge/Makefile
+++ b/src/Service/EventBridge/Makefile
@@ -2,11 +2,15 @@
 
 initialize: start-docker
 start-docker:
-	echo "Noop"
+	docker start async_aws_localstack && exit 0 || \
+	docker start async_aws_localstack-events && exit 0 || \
+	docker pull localstack/localstack && \
+	docker run -d -p 4571:4566 -e SERVICES=events -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-events localstack/localstack && \
+	docker run --rm --link async_aws_localstack-events:localstack martin/wait -c localstack:4566
 
 test: initialize
 	./vendor/bin/simple-phpunit
 
 clean: stop-docker
 stop-docker:
-	echo "Noop"
+	docker stop async_aws_localstack-events || true

--- a/src/Service/EventBridge/tests/Integration/EventBridgeClientTest.php
+++ b/src/Service/EventBridge/tests/Integration/EventBridgeClientTest.php
@@ -2,7 +2,7 @@
 
 namespace AsyncAws\EventBridge\Tests\Integration;
 
-use AsyncAws\Core\Credentials\NullProvider;
+use AsyncAws\Core\Credentials\Credentials;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\EventBridge\EventBridgeClient;
 use AsyncAws\EventBridge\Input\PutEventsRequest;
@@ -17,27 +17,24 @@ class EventBridgeClientTest extends TestCase
         $input = new PutEventsRequest([
             'Entries' => [new PutEventsRequestEntry([
                 'Time' => new \DateTimeImmutable(),
-                'Source' => 'change me',
-                'Resources' => ['change me'],
-                'DetailType' => 'change me',
-                'Detail' => 'change me',
-                'EventBusName' => 'change me',
+                'Source' => 'com.mycompany.myapp',
+                'Detail' => '{"key1": "value1","key2": "value2"}',
+                'Resources' => [
+                    'resource1',
+                    'resource2',
+                ],
+                'DetailType' => 'myDetailType',
             ])],
         ]);
         $result = $client->PutEvents($input);
 
-        $result->resolve();
-
-        self::assertSame(1337, $result->getFailedEntryCount());
-        // self::assertTODO(expected, $result->getEntries());
+        self::assertCount(1, $result->getEntries());
     }
 
     private function getClient(): EventBridgeClient
     {
-        self::markTestSkipped('No docker image found..');
-
         return new EventBridgeClient([
-            'endpoint' => 'http://localhost',
-        ], new NullProvider());
+            'endpoint' => 'http://localhost:4571',
+        ], new Credentials('aws_id', 'aws_secret'));
     }
 }

--- a/src/Service/Iam/Makefile
+++ b/src/Service/Iam/Makefile
@@ -2,11 +2,15 @@
 
 initialize: start-docker
 start-docker:
-	echo "Noop"
+	docker start async_aws_localstack && exit 0 || \
+	docker start async_aws_localstack-iam && exit 0 || \
+	docker pull localstack/localstack && \
+	docker run -d -p 4572:4566 -e SERVICES=iam -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-iam localstack/localstack && \
+	docker run --rm --link async_aws_localstack-iam:localstack martin/wait -c localstack:4566
 
 test: initialize
 	./vendor/bin/simple-phpunit
 
 clean: stop-docker
 stop-docker:
-	echo "Noop"
+	docker stop async_aws_localstack-iam || true

--- a/src/Service/Lambda/Makefile
+++ b/src/Service/Lambda/Makefile
@@ -4,8 +4,9 @@ ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
 initialize: start-docker
 start-docker:
-	docker pull lambci/lambda
-	docker start async_aws_lambda || docker run -d -p 9001:9001 -e DOCKER_LAMBDA_STAY_OPEN=1 -v "$(ROOT_DIR)/tests/fixtures/lambda":/var/task:ro,delegated --name async_aws_lambda lambci/lambda:nodejs12.x index.handler
+	docker start async_aws_lambda && exit 0 || \
+	docker pull lambci/lambda && \
+	docker run -d -p 9001:9001 -e DOCKER_LAMBDA_STAY_OPEN=1 -v "$(ROOT_DIR)/tests/fixtures/lambda":/var/task:ro,delegated --name async_aws_lambda lambci/lambda:nodejs12.x index.handler
 
 test: initialize
 	./vendor/bin/simple-phpunit

--- a/src/Service/RdsDataService/tests/Integration/RdsDataServiceClientTest.php
+++ b/src/Service/RdsDataService/tests/Integration/RdsDataServiceClientTest.php
@@ -122,7 +122,7 @@ class RdsDataServiceClientTest extends TestCase
 
     private function getClient(): RdsDataServiceClient
     {
-        self::markTestSkipped('Not implemented');
+        self::markTestSkipped('There is no docker image available for RdsDataService.');
 
         return new RdsDataServiceClient([
             'endpoint' => 'http://localhost',

--- a/src/Service/S3/Makefile
+++ b/src/Service/S3/Makefile
@@ -2,12 +2,14 @@
 
 initialize: start-docker
 start-docker:
-	docker pull asyncaws/testing-s3
-	docker start async_aws_s3 || docker run -d -p 4569:4569 --name async_aws_s3 asyncaws/testing-s3
+	docker start async_aws_s3 && exit 0 || \
+	docker start async_aws_s3-client && exit 0 || \
+	docker pull asyncaws/testing-s3 && \
+	docker run -d -p 4569:4569 --name async_aws_s3-client asyncaws/testing-s3
 
 test: initialize
 	./vendor/bin/simple-phpunit
 
 clean: stop-docker
 stop-docker:
-	docker stop async_aws_s3 || true
+	docker stop async_aws_s3-client || true

--- a/src/Service/S3/tests/Unit/S3ClientTest.php
+++ b/src/Service/S3/tests/Unit/S3ClientTest.php
@@ -151,8 +151,8 @@ class S3ClientTest extends TestCase
     public function testCustomEndpoint()
     {
         $callback = function ($method, $url, $options) {
-            $this->assertEquals('PUT', $method);
-            $this->assertEquals('https://fra1.digitaloceanspaces.com/my_bucket/image/cat.jpg', $url);
+            self::assertEquals('PUT', $method);
+            self::assertEquals('https://fra1.digitaloceanspaces.com/my_bucket/image/cat.jpg', $url);
 
             return new SimpleMockedResponse();
         };

--- a/src/Service/Ses/tests/Integration/SesClientTest.php
+++ b/src/Service/Ses/tests/Integration/SesClientTest.php
@@ -3,16 +3,16 @@
 namespace AsyncAws\Ses\Tests\Integration;
 
 use AsyncAws\Core\Credentials\NullProvider;
-use AsyncAws\Ses\Input\Body;
-use AsyncAws\Ses\Input\Content;
-use AsyncAws\Ses\Input\Destination;
-use AsyncAws\Ses\Input\EmailContent;
-use AsyncAws\Ses\Input\Message;
-use AsyncAws\Ses\Input\MessageTag;
-use AsyncAws\Ses\Input\RawMessage;
 use AsyncAws\Ses\Input\SendEmailRequest;
-use AsyncAws\Ses\Input\Template;
 use AsyncAws\Ses\SesClient;
+use AsyncAws\Ses\ValueObject\Body;
+use AsyncAws\Ses\ValueObject\Content;
+use AsyncAws\Ses\ValueObject\Destination;
+use AsyncAws\Ses\ValueObject\EmailContent;
+use AsyncAws\Ses\ValueObject\Message;
+use AsyncAws\Ses\ValueObject\MessageTag;
+use AsyncAws\Ses\ValueObject\RawMessage;
+use AsyncAws\Ses\ValueObject\Template;
 use PHPUnit\Framework\TestCase;
 
 class SesClientTest extends TestCase

--- a/src/Service/Ses/tests/Unit/SesClientTest.php
+++ b/src/Service/Ses/tests/Unit/SesClientTest.php
@@ -70,15 +70,15 @@ class SesClientTest extends TestCase
     public function testSendMessage()
     {
         $httpClient = new MockHttpClient(function (string $method, string $url, array $options): ResponseInterface {
-            $this->assertSame('POST', $method);
-            $this->assertStringStartsWith('https://email.eu-west-1.amazonaws.com:8984/', $url);
+            self::assertSame('POST', $method);
+            self::assertStringStartsWith('https://email.eu-west-1.amazonaws.com:8984/', $url);
 
             $content = json_decode(StreamFactory::create($options['body'])->stringify(), true);
 
-            $this->assertSame('Hello!', $content['Content']['Simple']['Subject']['Data']);
-            $this->assertSame('tobias.nyholm@gmail.com', $content['Destination']['ToAddresses'][0]);
-            $this->assertSame('foo@test.se', $content['FromEmailAddress']);
-            $this->assertSame('Hello There!', $content['Content']['Simple']['Body']['Text']['Data']);
+            self::assertSame('Hello!', $content['Content']['Simple']['Subject']['Data']);
+            self::assertSame('tobias.nyholm@gmail.com', $content['Destination']['ToAddresses'][0]);
+            self::assertSame('foo@test.se', $content['FromEmailAddress']);
+            self::assertSame('Hello There!', $content['Content']['Simple']['Body']['Text']['Data']);
 
             $json = '{"MessageId":"foobar"}';
 

--- a/src/Service/Sns/Makefile
+++ b/src/Service/Sns/Makefile
@@ -2,11 +2,15 @@
 
 initialize: start-docker
 start-docker:
-	echo "Noop"
+	docker start async_aws_localstack && exit 0 || \
+	docker start async_aws_localstack-sns && exit 0 || \
+	docker pull localstack/localstack && \
+	docker run -d -p 4573:4566 -e SERVICES=sns -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-sns localstack/localstack && \
+	docker run --rm --link async_aws_localstack-sns:localstack martin/wait -c localstack:4566
 
 test: initialize
 	./vendor/bin/simple-phpunit
 
 clean: stop-docker
 stop-docker:
-	echo "Noop"
+	docker stop async_aws_localstack-sns || true

--- a/src/Service/Sns/tests/Integration/SnsClientTest.php
+++ b/src/Service/Sns/tests/Integration/SnsClientTest.php
@@ -2,14 +2,14 @@
 
 namespace AsyncAws\Sns\Tests\Integration;
 
-use AsyncAws\Core\Credentials\NullProvider;
+use AsyncAws\Core\Credentials\Credentials;
+use AsyncAws\Core\Exception\Http\ClientException;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\Sns\Input\CreatePlatformEndpointInput;
 use AsyncAws\Sns\Input\CreateTopicInput;
 use AsyncAws\Sns\Input\DeleteEndpointInput;
 use AsyncAws\Sns\Input\DeleteTopicInput;
 use AsyncAws\Sns\Input\ListSubscriptionsByTopicInput;
-use AsyncAws\Sns\Input\MessageAttributeValue;
 use AsyncAws\Sns\Input\PublishInput;
 use AsyncAws\Sns\Input\SubscribeInput;
 use AsyncAws\Sns\Input\UnsubscribeInput;
@@ -18,8 +18,30 @@ use AsyncAws\Sns\ValueObject\Tag;
 
 class SnsClientTest extends TestCase
 {
+    private $topicArn = null;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->topicArn = $this->getClient()->createTopic(['Name' => 'async-aws'])->getTopicArn();
+    }
+
+    public function tearDown(): void
+    {
+        parent::tearDown();
+
+        try {
+            $this->getClient()->deleteTopic(['TopicArn' => $this->topicArn]);
+        } catch (ClientException $e) {
+            if (404 !== $e->getCode()) {
+                throw $e;
+            }
+        }
+    }
+
     public function testCreatePlatformEndpoint(): void
     {
+        self::markTestIncomplete('Needs to create a platform in order to create an endpoint');
         $client = $this->getClient();
 
         $input = new CreatePlatformEndpointInput([
@@ -40,22 +62,21 @@ class SnsClientTest extends TestCase
         $client = $this->getClient();
 
         $input = new CreateTopicInput([
-            'Name' => 'change me',
-            'Attributes' => ['change me' => 'change me'],
+            'Name' => 'my-topic',
+            'Attributes' => ['attribute1' => 'value 1'],
             'Tags' => [new Tag([
-                'Key' => 'change me',
-                'Value' => 'change me',
+                'Key' => 'group',
+                'Value' => 'demo',
             ])],
         ]);
         $result = $client->CreateTopic($input);
 
-        $result->resolve();
-
-        self::assertSame('changeIt', $result->getTopicArn());
+        self::assertSame('arn:aws:sns:us-east-1:000000000000:my-topic', $result->getTopicArn());
     }
 
     public function testDeleteEndpoint(): void
     {
+        self::markTestIncomplete('Needs to create an endpoint in order to delete it');
         $client = $this->getClient();
 
         $input = new DeleteEndpointInput([
@@ -71,10 +92,11 @@ class SnsClientTest extends TestCase
         $client = $this->getClient();
 
         $input = new DeleteTopicInput([
-            'TopicArn' => 'change me',
+            'TopicArn' => $this->topicArn,
         ]);
         $result = $client->DeleteTopic($input);
 
+        self::expectNotToPerformAssertions();
         $result->resolve();
     }
 
@@ -82,16 +104,21 @@ class SnsClientTest extends TestCase
     {
         $client = $this->getClient();
 
+        $client->Subscribe([
+            'TopicArn' => $this->topicArn,
+            'Protocol' => 'http',
+            'Endpoint' => 'http://async-aws.com',
+            'ReturnSubscriptionArn' => true,
+        ]);
+
         $input = new ListSubscriptionsByTopicInput([
-            'TopicArn' => 'change me',
-            'NextToken' => 'change me',
+            'TopicArn' => $this->topicArn,
         ]);
         $result = $client->ListSubscriptionsByTopic($input);
 
-        $result->resolve();
-
-        // self::assertTODO(expected, $result->getSubscriptions());
-        self::assertSame('changeIt', $result->getNextToken());
+        self::assertCount(1, $result->getSubscriptions());
+        $subscription = \iterator_to_array($result->getSubscriptions())[0];
+        self::assertSame('http://async-aws.com', $subscription->getEndpoint());
     }
 
     public function testPublish(): void
@@ -99,23 +126,13 @@ class SnsClientTest extends TestCase
         $client = $this->getClient();
 
         $input = new PublishInput([
-            'TopicArn' => 'change me',
-            'TargetArn' => 'change me',
-            'PhoneNumber' => 'change me',
-            'Message' => 'change me',
-            'Subject' => 'change me',
-            'MessageStructure' => 'change me',
-            'MessageAttributes' => ['change me' => new MessageAttributeValue([
-                'DataType' => 'change me',
-                'StringValue' => 'change me',
-                'BinaryValue' => 'change me',
-            ])],
+            'TopicArn' => $this->topicArn,
+            'Message' => 'Hello world',
+            'Subject' => 'Read this',
         ]);
         $result = $client->Publish($input);
 
-        $result->resolve();
-
-        self::assertStringContainsString('change it', $result->getMessageId());
+        self::assertNotEmpty($result->getMessageId());
     }
 
     public function testSubscribe(): void
@@ -123,37 +140,45 @@ class SnsClientTest extends TestCase
         $client = $this->getClient();
 
         $input = new SubscribeInput([
-            'TopicArn' => 'change me',
-            'Protocol' => 'change me',
-            'Endpoint' => 'change me',
-            'Attributes' => ['change me' => 'change me'],
-            'ReturnSubscriptionArn' => false,
+            'TopicArn' => $this->topicArn,
+            'Protocol' => 'http',
+            'Endpoint' => 'http://async-aws.com',
+            'ReturnSubscriptionArn' => true,
         ]);
         $result = $client->Subscribe($input);
 
-        $result->resolve();
+        self::assertStringContainsString('arn:aws:sns:us-east-1:000000000000:async-aws:', $result->getSubscriptionArn());
 
-        self::assertSame('changeIt', $result->getSubscriptionArn());
+        self::assertCount(1, $client->listSubscriptionsByTopic(['TopicArn' => $this->topicArn]));
     }
 
     public function testUnsubscribe(): void
     {
         $client = $this->getClient();
 
+        $result = $client->Subscribe([
+            'TopicArn' => $this->topicArn,
+            'Protocol' => 'http',
+            'Endpoint' => 'http://async-aws.com',
+            'ReturnSubscriptionArn' => true,
+        ]);
+
+        $result->resolve();
+        self::assertCount(1, $client->listSubscriptionsByTopic(['TopicArn' => $this->topicArn]));
+
         $input = new UnsubscribeInput([
-            'SubscriptionArn' => 'change me',
+            'SubscriptionArn' => $result->getSubscriptionArn(),
         ]);
         $result = $client->Unsubscribe($input);
 
         $result->resolve();
+        self::assertCount(0, $client->listSubscriptionsByTopic(['TopicArn' => $this->topicArn]));
     }
 
     private function getClient(): SnsClient
     {
-        self::markTestSkipped('No Docker image for SNS');
-
         return new SnsClient([
-            'endpoint' => 'http://localhost',
-        ], new NullProvider());
+            'endpoint' => 'http://localhost:4573',
+        ], new Credentials('aws_id', 'aws_secret'));
     }
 }

--- a/src/Service/Sqs/Makefile
+++ b/src/Service/Sqs/Makefile
@@ -2,8 +2,9 @@
 
 initialize: start-docker
 start-docker:
-	docker pull asyncaws/testing-sqs
-	docker start async_aws_sqs || docker run -d -p 9494:9494 --name async_aws_sqs asyncaws/testing-sqs
+	docker start async_aws_sqs && exit 0 || \
+	docker pull asyncaws/testing-sqs && \
+	docker run -d -p 9494:9494 --name async_aws_sqs asyncaws/testing-sqs
 
 test: initialize
 	./vendor/bin/simple-phpunit

--- a/src/Service/Ssm/Makefile
+++ b/src/Service/Ssm/Makefile
@@ -2,11 +2,15 @@
 
 initialize: start-docker
 start-docker:
-	echo "Noop"
+	docker start async_aws_localstack && exit 0 || \
+	docker start async_aws_localstack-ssm && exit 0 || \
+	docker pull localstack/localstack && \
+	docker run -d -p 4574:4566 -e SERVICES=ssm -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-ssm localstack/localstack && \
+	docker run --rm --link async_aws_localstack-ssm:localstack martin/wait -c localstack:4566
 
 test: initialize
 	./vendor/bin/simple-phpunit
 
 clean: stop-docker
 stop-docker:
-	echo "Noop"
+	docker stop async_aws_localstack-ssm || true

--- a/src/Service/Ssm/composer.json
+++ b/src/Service/Ssm/composer.json
@@ -15,6 +15,9 @@
         "ext-json": "*",
         "async-aws/core": "^1.2"
     },
+    "conflict": {
+        "symfony/http-client": "<4.4.16,<5.1.7"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "1.2-dev"


### PR DESCRIPTION
This adds localstack and enable integration tests for:
* sts
* cloudformation
* cloudwatch logs
* events bridge
* iam
* sns
* ssm

When possible, I migrate existing services to localstack:
* dynamodb 

Other services can't be migrated because use a specific set of feature that are not provided by localstack
* s3
* sqs
* lambda

