### PR TITLE
[S3] Add methods to handle bucket cors

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -202,6 +202,7 @@
                 "CreateBucket",
                 "CreateMultipartUpload",
                 "DeleteBucket",
+                "DeleteBucketCors",
                 "DeleteObject",
                 "DeleteObjects",
                 "GetObject",

--- a/manifest.json
+++ b/manifest.json
@@ -212,6 +212,7 @@
                 "ListParts",
                 "ObjectExists",
                 "ObjectNotExists",
+                "PutBucketCors",
                 "PutBucketNotificationConfiguration",
                 "PutObject",
                 "PutObjectAcl",

--- a/manifest.json
+++ b/manifest.json
@@ -205,6 +205,7 @@
                 "DeleteBucketCors",
                 "DeleteObject",
                 "DeleteObjects",
+                "GetBucketCors",
                 "GetObject",
                 "GetObjectAcl",
                 "HeadObject",

--- a/src/CodeGenerator/src/Generator/GeneratorHelper.php
+++ b/src/CodeGenerator/src/Generator/GeneratorHelper.php
@@ -24,6 +24,7 @@ class GeneratorHelper
         // Ordered by search length to avoid collision and wrong substitution
         static $replacements = [
             'BOOL' => 'Bool',
+            'CORS' => 'Cors',
             'ETag' => 'Etag',
             'NULL' => 'Null',
             'AWS' => 'Aws',

--- a/src/Service/S3/src/Input/DeleteBucketCorsRequest.php
+++ b/src/Service/S3/src/Input/DeleteBucketCorsRequest.php
@@ -16,7 +16,7 @@ final class DeleteBucketCorsRequest extends Input
      *
      * @var string|null
      */
-    private $Bucket;
+    private $bucket;
 
     /**
      * The account id of the expected bucket owner. If the bucket is owned by a different account, the request will fail
@@ -24,7 +24,7 @@ final class DeleteBucketCorsRequest extends Input
      *
      * @var string|null
      */
-    private $ExpectedBucketOwner;
+    private $expectedBucketOwner;
 
     /**
      * @param array{
@@ -35,8 +35,8 @@ final class DeleteBucketCorsRequest extends Input
      */
     public function __construct(array $input = [])
     {
-        $this->Bucket = $input['Bucket'] ?? null;
-        $this->ExpectedBucketOwner = $input['ExpectedBucketOwner'] ?? null;
+        $this->bucket = $input['Bucket'] ?? null;
+        $this->expectedBucketOwner = $input['ExpectedBucketOwner'] ?? null;
         parent::__construct($input);
     }
 
@@ -47,12 +47,12 @@ final class DeleteBucketCorsRequest extends Input
 
     public function getBucket(): ?string
     {
-        return $this->Bucket;
+        return $this->bucket;
     }
 
     public function getExpectedBucketOwner(): ?string
     {
-        return $this->ExpectedBucketOwner;
+        return $this->expectedBucketOwner;
     }
 
     /**
@@ -62,8 +62,8 @@ final class DeleteBucketCorsRequest extends Input
     {
         // Prepare headers
         $headers = ['content-type' => 'application/xml'];
-        if (null !== $this->ExpectedBucketOwner) {
-            $headers['x-amz-expected-bucket-owner'] = $this->ExpectedBucketOwner;
+        if (null !== $this->expectedBucketOwner) {
+            $headers['x-amz-expected-bucket-owner'] = $this->expectedBucketOwner;
         }
 
         // Prepare query
@@ -71,7 +71,7 @@ final class DeleteBucketCorsRequest extends Input
 
         // Prepare URI
         $uri = [];
-        if (null === $v = $this->Bucket) {
+        if (null === $v = $this->bucket) {
             throw new InvalidArgument(sprintf('Missing parameter "Bucket" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Bucket'] = $v;
@@ -86,14 +86,14 @@ final class DeleteBucketCorsRequest extends Input
 
     public function setBucket(?string $value): self
     {
-        $this->Bucket = $value;
+        $this->bucket = $value;
 
         return $this;
     }
 
     public function setExpectedBucketOwner(?string $value): self
     {
-        $this->ExpectedBucketOwner = $value;
+        $this->expectedBucketOwner = $value;
 
         return $this;
     }

--- a/src/Service/S3/src/Input/DeleteBucketCorsRequest.php
+++ b/src/Service/S3/src/Input/DeleteBucketCorsRequest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace AsyncAws\S3\Input;
+
+use AsyncAws\Core\Exception\InvalidArgument;
+use AsyncAws\Core\Input;
+use AsyncAws\Core\Request;
+use AsyncAws\Core\Stream\StreamFactory;
+
+final class DeleteBucketCorsRequest extends Input
+{
+    /**
+     * Specifies the bucket whose `cors` configuration is being deleted.
+     *
+     * @required
+     *
+     * @var string|null
+     */
+    private $Bucket;
+
+    /**
+     * The account id of the expected bucket owner. If the bucket is owned by a different account, the request will fail
+     * with an HTTP `403 (Access Denied)` error.
+     *
+     * @var string|null
+     */
+    private $ExpectedBucketOwner;
+
+    /**
+     * @param array{
+     *   Bucket?: string,
+     *   ExpectedBucketOwner?: string,
+     *   @region?: string,
+     * } $input
+     */
+    public function __construct(array $input = [])
+    {
+        $this->Bucket = $input['Bucket'] ?? null;
+        $this->ExpectedBucketOwner = $input['ExpectedBucketOwner'] ?? null;
+        parent::__construct($input);
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getBucket(): ?string
+    {
+        return $this->Bucket;
+    }
+
+    public function getExpectedBucketOwner(): ?string
+    {
+        return $this->ExpectedBucketOwner;
+    }
+
+    /**
+     * @internal
+     */
+    public function request(): Request
+    {
+        // Prepare headers
+        $headers = ['content-type' => 'application/xml'];
+        if (null !== $this->ExpectedBucketOwner) {
+            $headers['x-amz-expected-bucket-owner'] = $this->ExpectedBucketOwner;
+        }
+
+        // Prepare query
+        $query = [];
+
+        // Prepare URI
+        $uri = [];
+        if (null === $v = $this->Bucket) {
+            throw new InvalidArgument(sprintf('Missing parameter "Bucket" for "%s". The value cannot be null.', __CLASS__));
+        }
+        $uri['Bucket'] = $v;
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '?cors';
+
+        // Prepare Body
+        $body = '';
+
+        // Return the Request
+        return new Request('DELETE', $uriString, $query, $headers, StreamFactory::create($body));
+    }
+
+    public function setBucket(?string $value): self
+    {
+        $this->Bucket = $value;
+
+        return $this;
+    }
+
+    public function setExpectedBucketOwner(?string $value): self
+    {
+        $this->ExpectedBucketOwner = $value;
+
+        return $this;
+    }
+}

--- a/src/Service/S3/src/Input/GetBucketCorsRequest.php
+++ b/src/Service/S3/src/Input/GetBucketCorsRequest.php
@@ -16,7 +16,7 @@ final class GetBucketCorsRequest extends Input
      *
      * @var string|null
      */
-    private $Bucket;
+    private $bucket;
 
     /**
      * The account id of the expected bucket owner. If the bucket is owned by a different account, the request will fail
@@ -24,7 +24,7 @@ final class GetBucketCorsRequest extends Input
      *
      * @var string|null
      */
-    private $ExpectedBucketOwner;
+    private $expectedBucketOwner;
 
     /**
      * @param array{
@@ -35,8 +35,8 @@ final class GetBucketCorsRequest extends Input
      */
     public function __construct(array $input = [])
     {
-        $this->Bucket = $input['Bucket'] ?? null;
-        $this->ExpectedBucketOwner = $input['ExpectedBucketOwner'] ?? null;
+        $this->bucket = $input['Bucket'] ?? null;
+        $this->expectedBucketOwner = $input['ExpectedBucketOwner'] ?? null;
         parent::__construct($input);
     }
 
@@ -47,12 +47,12 @@ final class GetBucketCorsRequest extends Input
 
     public function getBucket(): ?string
     {
-        return $this->Bucket;
+        return $this->bucket;
     }
 
     public function getExpectedBucketOwner(): ?string
     {
-        return $this->ExpectedBucketOwner;
+        return $this->expectedBucketOwner;
     }
 
     /**
@@ -62,8 +62,8 @@ final class GetBucketCorsRequest extends Input
     {
         // Prepare headers
         $headers = ['content-type' => 'application/xml'];
-        if (null !== $this->ExpectedBucketOwner) {
-            $headers['x-amz-expected-bucket-owner'] = $this->ExpectedBucketOwner;
+        if (null !== $this->expectedBucketOwner) {
+            $headers['x-amz-expected-bucket-owner'] = $this->expectedBucketOwner;
         }
 
         // Prepare query
@@ -71,7 +71,7 @@ final class GetBucketCorsRequest extends Input
 
         // Prepare URI
         $uri = [];
-        if (null === $v = $this->Bucket) {
+        if (null === $v = $this->bucket) {
             throw new InvalidArgument(sprintf('Missing parameter "Bucket" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Bucket'] = $v;
@@ -86,14 +86,14 @@ final class GetBucketCorsRequest extends Input
 
     public function setBucket(?string $value): self
     {
-        $this->Bucket = $value;
+        $this->bucket = $value;
 
         return $this;
     }
 
     public function setExpectedBucketOwner(?string $value): self
     {
-        $this->ExpectedBucketOwner = $value;
+        $this->expectedBucketOwner = $value;
 
         return $this;
     }

--- a/src/Service/S3/src/Input/GetBucketCorsRequest.php
+++ b/src/Service/S3/src/Input/GetBucketCorsRequest.php
@@ -1,0 +1,100 @@
+<?php
+
+namespace AsyncAws\S3\Input;
+
+use AsyncAws\Core\Exception\InvalidArgument;
+use AsyncAws\Core\Input;
+use AsyncAws\Core\Request;
+use AsyncAws\Core\Stream\StreamFactory;
+
+final class GetBucketCorsRequest extends Input
+{
+    /**
+     * The bucket name for which to get the cors configuration.
+     *
+     * @required
+     *
+     * @var string|null
+     */
+    private $Bucket;
+
+    /**
+     * The account id of the expected bucket owner. If the bucket is owned by a different account, the request will fail
+     * with an HTTP `403 (Access Denied)` error.
+     *
+     * @var string|null
+     */
+    private $ExpectedBucketOwner;
+
+    /**
+     * @param array{
+     *   Bucket?: string,
+     *   ExpectedBucketOwner?: string,
+     *   @region?: string,
+     * } $input
+     */
+    public function __construct(array $input = [])
+    {
+        $this->Bucket = $input['Bucket'] ?? null;
+        $this->ExpectedBucketOwner = $input['ExpectedBucketOwner'] ?? null;
+        parent::__construct($input);
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getBucket(): ?string
+    {
+        return $this->Bucket;
+    }
+
+    public function getExpectedBucketOwner(): ?string
+    {
+        return $this->ExpectedBucketOwner;
+    }
+
+    /**
+     * @internal
+     */
+    public function request(): Request
+    {
+        // Prepare headers
+        $headers = ['content-type' => 'application/xml'];
+        if (null !== $this->ExpectedBucketOwner) {
+            $headers['x-amz-expected-bucket-owner'] = $this->ExpectedBucketOwner;
+        }
+
+        // Prepare query
+        $query = [];
+
+        // Prepare URI
+        $uri = [];
+        if (null === $v = $this->Bucket) {
+            throw new InvalidArgument(sprintf('Missing parameter "Bucket" for "%s". The value cannot be null.', __CLASS__));
+        }
+        $uri['Bucket'] = $v;
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '?cors';
+
+        // Prepare Body
+        $body = '';
+
+        // Return the Request
+        return new Request('GET', $uriString, $query, $headers, StreamFactory::create($body));
+    }
+
+    public function setBucket(?string $value): self
+    {
+        $this->Bucket = $value;
+
+        return $this;
+    }
+
+    public function setExpectedBucketOwner(?string $value): self
+    {
+        $this->ExpectedBucketOwner = $value;
+
+        return $this;
+    }
+}

--- a/src/Service/S3/src/Input/PutBucketCorsRequest.php
+++ b/src/Service/S3/src/Input/PutBucketCorsRequest.php
@@ -1,0 +1,168 @@
+<?php
+
+namespace AsyncAws\S3\Input;
+
+use AsyncAws\Core\Exception\InvalidArgument;
+use AsyncAws\Core\Input;
+use AsyncAws\Core\Request;
+use AsyncAws\Core\Stream\StreamFactory;
+use AsyncAws\S3\ValueObject\CORSConfiguration;
+
+final class PutBucketCorsRequest extends Input
+{
+    /**
+     * Specifies the bucket impacted by the `cors`configuration.
+     *
+     * @required
+     *
+     * @var string|null
+     */
+    private $Bucket;
+
+    /**
+     * Describes the cross-origin access configuration for objects in an Amazon S3 bucket. For more information, see
+     * Enabling Cross-Origin Resource Sharing in the *Amazon Simple Storage Service Developer Guide*.
+     *
+     * @see https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html
+     * @required
+     *
+     * @var CORSConfiguration|null
+     */
+    private $CORSConfiguration;
+
+    /**
+     * The base64-encoded 128-bit MD5 digest of the data. This header must be used as a message integrity check to verify
+     * that the request body was not corrupted in transit. For more information, go to RFC 1864.
+     *
+     * @see http://www.ietf.org/rfc/rfc1864.txt
+     *
+     * @var string|null
+     */
+    private $ContentMD5;
+
+    /**
+     * The account id of the expected bucket owner. If the bucket is owned by a different account, the request will fail
+     * with an HTTP `403 (Access Denied)` error.
+     *
+     * @var string|null
+     */
+    private $ExpectedBucketOwner;
+
+    /**
+     * @param array{
+     *   Bucket?: string,
+     *   CORSConfiguration?: CORSConfiguration|array,
+     *   ContentMD5?: string,
+     *   ExpectedBucketOwner?: string,
+     *   @region?: string,
+     * } $input
+     */
+    public function __construct(array $input = [])
+    {
+        $this->Bucket = $input['Bucket'] ?? null;
+        $this->CORSConfiguration = isset($input['CORSConfiguration']) ? CORSConfiguration::create($input['CORSConfiguration']) : null;
+        $this->ContentMD5 = $input['ContentMD5'] ?? null;
+        $this->ExpectedBucketOwner = $input['ExpectedBucketOwner'] ?? null;
+        parent::__construct($input);
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getBucket(): ?string
+    {
+        return $this->Bucket;
+    }
+
+    public function getCORSConfiguration(): ?CORSConfiguration
+    {
+        return $this->CORSConfiguration;
+    }
+
+    public function getContentMD5(): ?string
+    {
+        return $this->ContentMD5;
+    }
+
+    public function getExpectedBucketOwner(): ?string
+    {
+        return $this->ExpectedBucketOwner;
+    }
+
+    /**
+     * @internal
+     */
+    public function request(): Request
+    {
+        // Prepare headers
+        $headers = ['content-type' => 'application/xml'];
+        if (null !== $this->ContentMD5) {
+            $headers['Content-MD5'] = $this->ContentMD5;
+        }
+        if (null !== $this->ExpectedBucketOwner) {
+            $headers['x-amz-expected-bucket-owner'] = $this->ExpectedBucketOwner;
+        }
+
+        // Prepare query
+        $query = [];
+
+        // Prepare URI
+        $uri = [];
+        if (null === $v = $this->Bucket) {
+            throw new InvalidArgument(sprintf('Missing parameter "Bucket" for "%s". The value cannot be null.', __CLASS__));
+        }
+        $uri['Bucket'] = $v;
+        $uriString = '/' . rawurlencode($uri['Bucket']) . '?cors';
+
+        // Prepare Body
+
+        $document = new \DOMDocument('1.0', 'UTF-8');
+        $document->formatOutput = false;
+        $this->requestBody($document, $document);
+        $body = $document->hasChildNodes() ? $document->saveXML() : '';
+
+        // Return the Request
+        return new Request('PUT', $uriString, $query, $headers, StreamFactory::create($body));
+    }
+
+    public function setBucket(?string $value): self
+    {
+        $this->Bucket = $value;
+
+        return $this;
+    }
+
+    public function setCORSConfiguration(?CORSConfiguration $value): self
+    {
+        $this->CORSConfiguration = $value;
+
+        return $this;
+    }
+
+    public function setContentMD5(?string $value): self
+    {
+        $this->ContentMD5 = $value;
+
+        return $this;
+    }
+
+    public function setExpectedBucketOwner(?string $value): self
+    {
+        $this->ExpectedBucketOwner = $value;
+
+        return $this;
+    }
+
+    private function requestBody(\DomNode $node, \DomDocument $document): void
+    {
+        if (null === $v = $this->CORSConfiguration) {
+            throw new InvalidArgument(sprintf('Missing parameter "CORSConfiguration" for "%s". The value cannot be null.', __CLASS__));
+        }
+
+        $node->appendChild($child = $document->createElement('CORSConfiguration'));
+        $child->setAttribute('xmlns', 'http://s3.amazonaws.com/doc/2006-03-01/');
+        $v->requestBody($child, $document);
+    }
+}

--- a/src/Service/S3/src/Input/PutBucketCorsRequest.php
+++ b/src/Service/S3/src/Input/PutBucketCorsRequest.php
@@ -17,7 +17,7 @@ final class PutBucketCorsRequest extends Input
      *
      * @var string|null
      */
-    private $Bucket;
+    private $bucket;
 
     /**
      * Describes the cross-origin access configuration for objects in an Amazon S3 bucket. For more information, see
@@ -28,7 +28,7 @@ final class PutBucketCorsRequest extends Input
      *
      * @var CORSConfiguration|null
      */
-    private $CORSConfiguration;
+    private $corsConfiguration;
 
     /**
      * The base64-encoded 128-bit MD5 digest of the data. This header must be used as a message integrity check to verify
@@ -38,7 +38,7 @@ final class PutBucketCorsRequest extends Input
      *
      * @var string|null
      */
-    private $ContentMD5;
+    private $contentMd5;
 
     /**
      * The account id of the expected bucket owner. If the bucket is owned by a different account, the request will fail
@@ -46,7 +46,7 @@ final class PutBucketCorsRequest extends Input
      *
      * @var string|null
      */
-    private $ExpectedBucketOwner;
+    private $expectedBucketOwner;
 
     /**
      * @param array{
@@ -59,10 +59,10 @@ final class PutBucketCorsRequest extends Input
      */
     public function __construct(array $input = [])
     {
-        $this->Bucket = $input['Bucket'] ?? null;
-        $this->CORSConfiguration = isset($input['CORSConfiguration']) ? CORSConfiguration::create($input['CORSConfiguration']) : null;
-        $this->ContentMD5 = $input['ContentMD5'] ?? null;
-        $this->ExpectedBucketOwner = $input['ExpectedBucketOwner'] ?? null;
+        $this->bucket = $input['Bucket'] ?? null;
+        $this->corsConfiguration = isset($input['CORSConfiguration']) ? CORSConfiguration::create($input['CORSConfiguration']) : null;
+        $this->contentMd5 = $input['ContentMD5'] ?? null;
+        $this->expectedBucketOwner = $input['ExpectedBucketOwner'] ?? null;
         parent::__construct($input);
     }
 
@@ -73,22 +73,22 @@ final class PutBucketCorsRequest extends Input
 
     public function getBucket(): ?string
     {
-        return $this->Bucket;
+        return $this->bucket;
     }
 
-    public function getCORSConfiguration(): ?CORSConfiguration
+    public function getContentMd5(): ?string
     {
-        return $this->CORSConfiguration;
+        return $this->contentMd5;
     }
 
-    public function getContentMD5(): ?string
+    public function getCorsConfiguration(): ?CORSConfiguration
     {
-        return $this->ContentMD5;
+        return $this->corsConfiguration;
     }
 
     public function getExpectedBucketOwner(): ?string
     {
-        return $this->ExpectedBucketOwner;
+        return $this->expectedBucketOwner;
     }
 
     /**
@@ -98,11 +98,11 @@ final class PutBucketCorsRequest extends Input
     {
         // Prepare headers
         $headers = ['content-type' => 'application/xml'];
-        if (null !== $this->ContentMD5) {
-            $headers['Content-MD5'] = $this->ContentMD5;
+        if (null !== $this->contentMd5) {
+            $headers['Content-MD5'] = $this->contentMd5;
         }
-        if (null !== $this->ExpectedBucketOwner) {
-            $headers['x-amz-expected-bucket-owner'] = $this->ExpectedBucketOwner;
+        if (null !== $this->expectedBucketOwner) {
+            $headers['x-amz-expected-bucket-owner'] = $this->expectedBucketOwner;
         }
 
         // Prepare query
@@ -110,7 +110,7 @@ final class PutBucketCorsRequest extends Input
 
         // Prepare URI
         $uri = [];
-        if (null === $v = $this->Bucket) {
+        if (null === $v = $this->bucket) {
             throw new InvalidArgument(sprintf('Missing parameter "Bucket" for "%s". The value cannot be null.', __CLASS__));
         }
         $uri['Bucket'] = $v;
@@ -129,35 +129,35 @@ final class PutBucketCorsRequest extends Input
 
     public function setBucket(?string $value): self
     {
-        $this->Bucket = $value;
+        $this->bucket = $value;
 
         return $this;
     }
 
-    public function setCORSConfiguration(?CORSConfiguration $value): self
+    public function setContentMd5(?string $value): self
     {
-        $this->CORSConfiguration = $value;
+        $this->contentMd5 = $value;
 
         return $this;
     }
 
-    public function setContentMD5(?string $value): self
+    public function setCorsConfiguration(?CORSConfiguration $value): self
     {
-        $this->ContentMD5 = $value;
+        $this->corsConfiguration = $value;
 
         return $this;
     }
 
     public function setExpectedBucketOwner(?string $value): self
     {
-        $this->ExpectedBucketOwner = $value;
+        $this->expectedBucketOwner = $value;
 
         return $this;
     }
 
     private function requestBody(\DomNode $node, \DomDocument $document): void
     {
-        if (null === $v = $this->CORSConfiguration) {
+        if (null === $v = $this->corsConfiguration) {
             throw new InvalidArgument(sprintf('Missing parameter "CORSConfiguration" for "%s". The value cannot be null.', __CLASS__));
         }
 

--- a/src/Service/S3/src/Result/GetBucketCorsOutput.php
+++ b/src/Service/S3/src/Result/GetBucketCorsOutput.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace AsyncAws\S3\Result;
+
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Result;
+use AsyncAws\S3\ValueObject\CORSRule;
+
+class GetBucketCorsOutput extends Result
+{
+    /**
+     * A set of origins and methods (cross-origin access that you want to allow). You can add up to 100 rules to the
+     * configuration.
+     */
+    private $CORSRules = [];
+
+    /**
+     * @return CORSRule[]
+     */
+    public function getCORSRules(): array
+    {
+        $this->initialize();
+
+        return $this->CORSRules;
+    }
+
+    protected function populateResult(Response $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent());
+        $this->CORSRules = !$data->CORSRule ? [] : $this->populateResultCORSRules($data->CORSRule);
+    }
+
+    /**
+     * @return string[]
+     */
+    private function populateResultAllowedHeaders(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml as $item) {
+            $a = ($v = $item) ? (string) $v : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function populateResultAllowedMethods(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml as $item) {
+            $a = ($v = $item) ? (string) $v : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function populateResultAllowedOrigins(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml as $item) {
+            $a = ($v = $item) ? (string) $v : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return CORSRule[]
+     */
+    private function populateResultCORSRules(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml as $item) {
+            $items[] = new CORSRule([
+                'AllowedHeaders' => !$item->AllowedHeader ? [] : $this->populateResultAllowedHeaders($item->AllowedHeader),
+                'AllowedMethods' => $this->populateResultAllowedMethods($item->AllowedMethod),
+                'AllowedOrigins' => $this->populateResultAllowedOrigins($item->AllowedOrigin),
+                'ExposeHeaders' => !$item->ExposeHeader ? [] : $this->populateResultExposeHeaders($item->ExposeHeader),
+                'MaxAgeSeconds' => ($v = $item->MaxAgeSeconds) ? (int) (string) $v : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function populateResultExposeHeaders(\SimpleXMLElement $xml): array
+    {
+        $items = [];
+        foreach ($xml as $item) {
+            $a = ($v = $item) ? (string) $v : null;
+            if (null !== $a) {
+                $items[] = $a;
+            }
+        }
+
+        return $items;
+    }
+}

--- a/src/Service/S3/src/Result/GetBucketCorsOutput.php
+++ b/src/Service/S3/src/Result/GetBucketCorsOutput.php
@@ -12,22 +12,22 @@ class GetBucketCorsOutput extends Result
      * A set of origins and methods (cross-origin access that you want to allow). You can add up to 100 rules to the
      * configuration.
      */
-    private $CORSRules = [];
+    private $corsRules = [];
 
     /**
      * @return CORSRule[]
      */
-    public function getCORSRules(): array
+    public function getCorsRules(): array
     {
         $this->initialize();
 
-        return $this->CORSRules;
+        return $this->corsRules;
     }
 
     protected function populateResult(Response $response): void
     {
         $data = new \SimpleXMLElement($response->getContent());
-        $this->CORSRules = !$data->CORSRule ? [] : $this->populateResultCORSRules($data->CORSRule);
+        $this->corsRules = !$data->CORSRule ? [] : $this->populateResultCORSRules($data->CORSRule);
     }
 
     /**

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -33,6 +33,7 @@ use AsyncAws\S3\Input\HeadObjectRequest;
 use AsyncAws\S3\Input\ListMultipartUploadsRequest;
 use AsyncAws\S3\Input\ListObjectsV2Request;
 use AsyncAws\S3\Input\ListPartsRequest;
+use AsyncAws\S3\Input\PutBucketCorsRequest;
 use AsyncAws\S3\Input\PutBucketNotificationConfigurationRequest;
 use AsyncAws\S3\Input\PutObjectAclRequest;
 use AsyncAws\S3\Input\PutObjectRequest;
@@ -60,6 +61,7 @@ use AsyncAws\S3\Result\UploadPartOutput;
 use AsyncAws\S3\Signer\SignerV4ForS3;
 use AsyncAws\S3\ValueObject\AccessControlPolicy;
 use AsyncAws\S3\ValueObject\CompletedMultipartUpload;
+use AsyncAws\S3\ValueObject\CORSConfiguration;
 use AsyncAws\S3\ValueObject\CreateBucketConfiguration;
 use AsyncAws\S3\ValueObject\Delete;
 use AsyncAws\S3\ValueObject\MultipartUpload;
@@ -625,6 +627,29 @@ class S3Client extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'HeadObject', 'region' => $input->getRegion()]));
 
         return new ObjectNotExistsWaiter($response, $this, $input);
+    }
+
+    /**
+     * Sets the `cors` configuration for your bucket. If the configuration exists, Amazon S3 replaces it.
+     *
+     * @see http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTBucketPUTcors.html
+     * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_PutBucketCors.html
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-s3-2006-03-01.html#putbucketcors
+     *
+     * @param array{
+     *   Bucket: string,
+     *   CORSConfiguration: CORSConfiguration|array,
+     *   ContentMD5?: string,
+     *   ExpectedBucketOwner?: string,
+     *   @region?: string,
+     * }|PutBucketCorsRequest $input
+     */
+    public function putBucketCors($input): Result
+    {
+        $input = PutBucketCorsRequest::create($input);
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PutBucketCors', 'region' => $input->getRegion()]));
+
+        return new Result($response);
     }
 
     /**

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -27,6 +27,7 @@ use AsyncAws\S3\Input\DeleteBucketCorsRequest;
 use AsyncAws\S3\Input\DeleteBucketRequest;
 use AsyncAws\S3\Input\DeleteObjectRequest;
 use AsyncAws\S3\Input\DeleteObjectsRequest;
+use AsyncAws\S3\Input\GetBucketCorsRequest;
 use AsyncAws\S3\Input\GetObjectAclRequest;
 use AsyncAws\S3\Input\GetObjectRequest;
 use AsyncAws\S3\Input\HeadBucketRequest;
@@ -48,6 +49,7 @@ use AsyncAws\S3\Result\CreateBucketOutput;
 use AsyncAws\S3\Result\CreateMultipartUploadOutput;
 use AsyncAws\S3\Result\DeleteObjectOutput;
 use AsyncAws\S3\Result\DeleteObjectsOutput;
+use AsyncAws\S3\Result\GetBucketCorsOutput;
 use AsyncAws\S3\Result\GetObjectAclOutput;
 use AsyncAws\S3\Result\GetObjectOutput;
 use AsyncAws\S3\Result\HeadObjectOutput;
@@ -397,6 +399,27 @@ class S3Client extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteObjects', 'region' => $input->getRegion()]));
 
         return new DeleteObjectsOutput($response);
+    }
+
+    /**
+     * Returns the cors configuration information set for the bucket.
+     *
+     * @see http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTBucketGETcors.html
+     * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketCors.html
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-s3-2006-03-01.html#getbucketcors
+     *
+     * @param array{
+     *   Bucket: string,
+     *   ExpectedBucketOwner?: string,
+     *   @region?: string,
+     * }|GetBucketCorsRequest $input
+     */
+    public function getBucketCors($input): GetBucketCorsOutput
+    {
+        $input = GetBucketCorsRequest::create($input);
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetBucketCors', 'region' => $input->getRegion()]));
+
+        return new GetBucketCorsOutput($response);
     }
 
     /**

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -23,6 +23,7 @@ use AsyncAws\S3\Input\CompleteMultipartUploadRequest;
 use AsyncAws\S3\Input\CopyObjectRequest;
 use AsyncAws\S3\Input\CreateBucketRequest;
 use AsyncAws\S3\Input\CreateMultipartUploadRequest;
+use AsyncAws\S3\Input\DeleteBucketCorsRequest;
 use AsyncAws\S3\Input\DeleteBucketRequest;
 use AsyncAws\S3\Input\DeleteObjectRequest;
 use AsyncAws\S3\Input\DeleteObjectsRequest;
@@ -319,6 +320,27 @@ class S3Client extends AbstractApi
     {
         $input = DeleteBucketRequest::create($input);
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteBucket', 'region' => $input->getRegion()]));
+
+        return new Result($response);
+    }
+
+    /**
+     * Deletes the `cors` configuration information set for the bucket.
+     *
+     * @see http://docs.amazonwebservices.com/AmazonS3/latest/API/RESTBucketDELETEcors.html
+     * @see https://docs.aws.amazon.com/AmazonS3/latest/API/API_DeleteBucketCors.html
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-s3-2006-03-01.html#deletebucketcors
+     *
+     * @param array{
+     *   Bucket: string,
+     *   ExpectedBucketOwner?: string,
+     *   @region?: string,
+     * }|DeleteBucketCorsRequest $input
+     */
+    public function deleteBucketCors($input): Result
+    {
+        $input = DeleteBucketCorsRequest::create($input);
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DeleteBucketCors', 'region' => $input->getRegion()]));
 
         return new Result($response);
     }

--- a/src/Service/S3/src/ValueObject/CORSConfiguration.php
+++ b/src/Service/S3/src/ValueObject/CORSConfiguration.php
@@ -16,7 +16,7 @@ final class CORSConfiguration
      * A set of origins and methods (cross-origin access that you want to allow). You can add up to 100 rules to the
      * configuration.
      */
-    private $CORSRules;
+    private $corsRules;
 
     /**
      * @param array{
@@ -25,7 +25,7 @@ final class CORSConfiguration
      */
     public function __construct(array $input)
     {
-        $this->CORSRules = isset($input['CORSRules']) ? array_map([CORSRule::class, 'create'], $input['CORSRules']) : null;
+        $this->corsRules = isset($input['CORSRules']) ? array_map([CORSRule::class, 'create'], $input['CORSRules']) : null;
     }
 
     public static function create($input): self
@@ -36,9 +36,9 @@ final class CORSConfiguration
     /**
      * @return CORSRule[]
      */
-    public function getCORSRules(): array
+    public function getCorsRules(): array
     {
-        return $this->CORSRules ?? [];
+        return $this->corsRules ?? [];
     }
 
     /**
@@ -46,7 +46,7 @@ final class CORSConfiguration
      */
     public function requestBody(\DomElement $node, \DomDocument $document): void
     {
-        if (null === $v = $this->CORSRules) {
+        if (null === $v = $this->corsRules) {
             throw new InvalidArgument(sprintf('Missing parameter "CORSRules" for "%s". The value cannot be null.', __CLASS__));
         }
         foreach ($v as $item) {

--- a/src/Service/S3/src/ValueObject/CORSConfiguration.php
+++ b/src/Service/S3/src/ValueObject/CORSConfiguration.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace AsyncAws\S3\ValueObject;
+
+use AsyncAws\Core\Exception\InvalidArgument;
+
+/**
+ * Describes the cross-origin access configuration for objects in an Amazon S3 bucket. For more information, see
+ * Enabling Cross-Origin Resource Sharing in the *Amazon Simple Storage Service Developer Guide*.
+ *
+ * @see https://docs.aws.amazon.com/AmazonS3/latest/dev/cors.html
+ */
+final class CORSConfiguration
+{
+    /**
+     * A set of origins and methods (cross-origin access that you want to allow). You can add up to 100 rules to the
+     * configuration.
+     */
+    private $CORSRules;
+
+    /**
+     * @param array{
+     *   CORSRules: CORSRule[],
+     * } $input
+     */
+    public function __construct(array $input)
+    {
+        $this->CORSRules = isset($input['CORSRules']) ? array_map([CORSRule::class, 'create'], $input['CORSRules']) : null;
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    /**
+     * @return CORSRule[]
+     */
+    public function getCORSRules(): array
+    {
+        return $this->CORSRules ?? [];
+    }
+
+    /**
+     * @internal
+     */
+    public function requestBody(\DomElement $node, \DomDocument $document): void
+    {
+        if (null === $v = $this->CORSRules) {
+            throw new InvalidArgument(sprintf('Missing parameter "CORSRules" for "%s". The value cannot be null.', __CLASS__));
+        }
+        foreach ($v as $item) {
+            $node->appendChild($child = $document->createElement('CORSRule'));
+
+            $item->requestBody($child, $document);
+        }
+    }
+}

--- a/src/Service/S3/src/ValueObject/CORSRule.php
+++ b/src/Service/S3/src/ValueObject/CORSRule.php
@@ -14,28 +14,28 @@ final class CORSRule
      * OPTIONS request. In response to any preflight OPTIONS request, Amazon S3 returns any requested headers that are
      * allowed.
      */
-    private $AllowedHeaders;
+    private $allowedHeaders;
 
     /**
      * An HTTP method that you allow the origin to execute. Valid values are `GET`, `PUT`, `HEAD`, `POST`, and `DELETE`.
      */
-    private $AllowedMethods;
+    private $allowedMethods;
 
     /**
      * One or more origins you want customers to be able to access the bucket from.
      */
-    private $AllowedOrigins;
+    private $allowedOrigins;
 
     /**
      * One or more headers in the response that you want customers to be able to access from their applications (for
      * example, from a JavaScript `XMLHttpRequest` object).
      */
-    private $ExposeHeaders;
+    private $exposeHeaders;
 
     /**
      * The time in seconds that your browser is to cache the preflight response for the specified resource.
      */
-    private $MaxAgeSeconds;
+    private $maxAgeSeconds;
 
     /**
      * @param array{
@@ -48,11 +48,11 @@ final class CORSRule
      */
     public function __construct(array $input)
     {
-        $this->AllowedHeaders = $input['AllowedHeaders'] ?? null;
-        $this->AllowedMethods = $input['AllowedMethods'] ?? null;
-        $this->AllowedOrigins = $input['AllowedOrigins'] ?? null;
-        $this->ExposeHeaders = $input['ExposeHeaders'] ?? null;
-        $this->MaxAgeSeconds = $input['MaxAgeSeconds'] ?? null;
+        $this->allowedHeaders = $input['AllowedHeaders'] ?? null;
+        $this->allowedMethods = $input['AllowedMethods'] ?? null;
+        $this->allowedOrigins = $input['AllowedOrigins'] ?? null;
+        $this->exposeHeaders = $input['ExposeHeaders'] ?? null;
+        $this->maxAgeSeconds = $input['MaxAgeSeconds'] ?? null;
     }
 
     public static function create($input): self
@@ -65,7 +65,7 @@ final class CORSRule
      */
     public function getAllowedHeaders(): array
     {
-        return $this->AllowedHeaders ?? [];
+        return $this->allowedHeaders ?? [];
     }
 
     /**
@@ -73,7 +73,7 @@ final class CORSRule
      */
     public function getAllowedMethods(): array
     {
-        return $this->AllowedMethods ?? [];
+        return $this->allowedMethods ?? [];
     }
 
     /**
@@ -81,7 +81,7 @@ final class CORSRule
      */
     public function getAllowedOrigins(): array
     {
-        return $this->AllowedOrigins ?? [];
+        return $this->allowedOrigins ?? [];
     }
 
     /**
@@ -89,12 +89,12 @@ final class CORSRule
      */
     public function getExposeHeaders(): array
     {
-        return $this->ExposeHeaders ?? [];
+        return $this->exposeHeaders ?? [];
     }
 
     public function getMaxAgeSeconds(): ?int
     {
-        return $this->MaxAgeSeconds;
+        return $this->maxAgeSeconds;
     }
 
     /**
@@ -102,31 +102,31 @@ final class CORSRule
      */
     public function requestBody(\DomElement $node, \DomDocument $document): void
     {
-        if (null !== $v = $this->AllowedHeaders) {
+        if (null !== $v = $this->allowedHeaders) {
             foreach ($v as $item) {
                 $node->appendChild($document->createElement('AllowedHeader', $item));
             }
         }
-        if (null === $v = $this->AllowedMethods) {
+        if (null === $v = $this->allowedMethods) {
             throw new InvalidArgument(sprintf('Missing parameter "AllowedMethods" for "%s". The value cannot be null.', __CLASS__));
         }
         foreach ($v as $item) {
             $node->appendChild($document->createElement('AllowedMethod', $item));
         }
 
-        if (null === $v = $this->AllowedOrigins) {
+        if (null === $v = $this->allowedOrigins) {
             throw new InvalidArgument(sprintf('Missing parameter "AllowedOrigins" for "%s". The value cannot be null.', __CLASS__));
         }
         foreach ($v as $item) {
             $node->appendChild($document->createElement('AllowedOrigin', $item));
         }
 
-        if (null !== $v = $this->ExposeHeaders) {
+        if (null !== $v = $this->exposeHeaders) {
             foreach ($v as $item) {
                 $node->appendChild($document->createElement('ExposeHeader', $item));
             }
         }
-        if (null !== $v = $this->MaxAgeSeconds) {
+        if (null !== $v = $this->maxAgeSeconds) {
             $node->appendChild($document->createElement('MaxAgeSeconds', $v));
         }
     }

--- a/src/Service/S3/src/ValueObject/CORSRule.php
+++ b/src/Service/S3/src/ValueObject/CORSRule.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace AsyncAws\S3\ValueObject;
+
+use AsyncAws\Core\Exception\InvalidArgument;
+
+/**
+ * Specifies a cross-origin access rule for an Amazon S3 bucket.
+ */
+final class CORSRule
+{
+    /**
+     * Headers that are specified in the `Access-Control-Request-Headers` header. These headers are allowed in a preflight
+     * OPTIONS request. In response to any preflight OPTIONS request, Amazon S3 returns any requested headers that are
+     * allowed.
+     */
+    private $AllowedHeaders;
+
+    /**
+     * An HTTP method that you allow the origin to execute. Valid values are `GET`, `PUT`, `HEAD`, `POST`, and `DELETE`.
+     */
+    private $AllowedMethods;
+
+    /**
+     * One or more origins you want customers to be able to access the bucket from.
+     */
+    private $AllowedOrigins;
+
+    /**
+     * One or more headers in the response that you want customers to be able to access from their applications (for
+     * example, from a JavaScript `XMLHttpRequest` object).
+     */
+    private $ExposeHeaders;
+
+    /**
+     * The time in seconds that your browser is to cache the preflight response for the specified resource.
+     */
+    private $MaxAgeSeconds;
+
+    /**
+     * @param array{
+     *   AllowedHeaders?: null|string[],
+     *   AllowedMethods: string[],
+     *   AllowedOrigins: string[],
+     *   ExposeHeaders?: null|string[],
+     *   MaxAgeSeconds?: null|int,
+     * } $input
+     */
+    public function __construct(array $input)
+    {
+        $this->AllowedHeaders = $input['AllowedHeaders'] ?? null;
+        $this->AllowedMethods = $input['AllowedMethods'] ?? null;
+        $this->AllowedOrigins = $input['AllowedOrigins'] ?? null;
+        $this->ExposeHeaders = $input['ExposeHeaders'] ?? null;
+        $this->MaxAgeSeconds = $input['MaxAgeSeconds'] ?? null;
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAllowedHeaders(): array
+    {
+        return $this->AllowedHeaders ?? [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAllowedMethods(): array
+    {
+        return $this->AllowedMethods ?? [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAllowedOrigins(): array
+    {
+        return $this->AllowedOrigins ?? [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExposeHeaders(): array
+    {
+        return $this->ExposeHeaders ?? [];
+    }
+
+    public function getMaxAgeSeconds(): ?int
+    {
+        return $this->MaxAgeSeconds;
+    }
+
+    /**
+     * @internal
+     */
+    public function requestBody(\DomElement $node, \DomDocument $document): void
+    {
+        if (null !== $v = $this->AllowedHeaders) {
+            foreach ($v as $item) {
+                $node->appendChild($document->createElement('AllowedHeader', $item));
+            }
+        }
+        if (null === $v = $this->AllowedMethods) {
+            throw new InvalidArgument(sprintf('Missing parameter "AllowedMethods" for "%s". The value cannot be null.', __CLASS__));
+        }
+        foreach ($v as $item) {
+            $node->appendChild($document->createElement('AllowedMethod', $item));
+        }
+
+        if (null === $v = $this->AllowedOrigins) {
+            throw new InvalidArgument(sprintf('Missing parameter "AllowedOrigins" for "%s". The value cannot be null.', __CLASS__));
+        }
+        foreach ($v as $item) {
+            $node->appendChild($document->createElement('AllowedOrigin', $item));
+        }
+
+        if (null !== $v = $this->ExposeHeaders) {
+            foreach ($v as $item) {
+                $node->appendChild($document->createElement('ExposeHeader', $item));
+            }
+        }
+        if (null !== $v = $this->MaxAgeSeconds) {
+            $node->appendChild($document->createElement('MaxAgeSeconds', $v));
+        }
+    }
+}

--- a/src/Service/S3/tests/Integration/S3ClientTest.php
+++ b/src/Service/S3/tests/Integration/S3ClientTest.php
@@ -23,6 +23,7 @@ use AsyncAws\S3\Input\HeadObjectRequest;
 use AsyncAws\S3\Input\ListMultipartUploadsRequest;
 use AsyncAws\S3\Input\ListObjectsV2Request;
 use AsyncAws\S3\Input\ListPartsRequest;
+use AsyncAws\S3\Input\PutBucketCorsRequest;
 use AsyncAws\S3\Input\PutBucketNotificationConfigurationRequest;
 use AsyncAws\S3\Input\PutObjectAclRequest;
 use AsyncAws\S3\Input\PutObjectRequest;
@@ -34,6 +35,8 @@ use AsyncAws\S3\ValueObject\AwsObject;
 use AsyncAws\S3\ValueObject\CommonPrefix;
 use AsyncAws\S3\ValueObject\CompletedMultipartUpload;
 use AsyncAws\S3\ValueObject\CompletedPart;
+use AsyncAws\S3\ValueObject\CORSConfiguration;
+use AsyncAws\S3\ValueObject\CORSRule;
 use AsyncAws\S3\ValueObject\FilterRule;
 use AsyncAws\S3\ValueObject\Grant;
 use AsyncAws\S3\ValueObject\Grantee;
@@ -557,6 +560,32 @@ class S3ClientTest extends TestCase
         // self::assertTODO(expected, $result->getOwner());
         self::assertSame('changeIt', $result->getStorageClass());
         self::assertSame('changeIt', $result->getRequestCharged());
+    }
+
+    public function testPutBucketCors(): void
+    {
+        $client = $this->getClient();
+
+        $input = new PutBucketCorsRequest([
+            'Bucket' => 'bucket-name',
+            'CORSConfiguration' => new CORSConfiguration([
+                'CORSRules' => [new CORSRule([
+                    'AllowedHeaders' => ['*'],
+                    'AllowedMethods' => ['GET', 'PUT'],
+                    'AllowedOrigins' => ['test.example.com'],
+                    'ExposeHeaders' => [],
+                    'MaxAgeSeconds' => 1337,
+                ])],
+            ]),
+            'ContentMD5' => 'change me',
+            'ExpectedBucketOwner' => 'change me',
+        ]);
+        $result = $client->PutBucketCors($input);
+
+        self::assertTrue($result->resolve());
+
+        $info = $result->info();
+        self::assertEquals(200, $info['status']);
     }
 
     public function testPutBucketNotificationConfiguration(): void

--- a/src/Service/S3/tests/Integration/S3ClientTest.php
+++ b/src/Service/S3/tests/Integration/S3ClientTest.php
@@ -17,6 +17,7 @@ use AsyncAws\S3\Input\CreateMultipartUploadRequest;
 use AsyncAws\S3\Input\DeleteBucketCorsRequest;
 use AsyncAws\S3\Input\DeleteBucketRequest;
 use AsyncAws\S3\Input\DeleteObjectRequest;
+use AsyncAws\S3\Input\GetBucketCorsRequest;
 use AsyncAws\S3\Input\GetObjectAclRequest;
 use AsyncAws\S3\Input\GetObjectRequest;
 use AsyncAws\S3\Input\HeadBucketRequest;
@@ -301,6 +302,22 @@ class S3ClientTest extends TestCase
         $result->resolve();
         $info = $result->info();
         self::assertEquals(204, $info['status']);
+    }
+
+    public function testGetBucketCors(): void
+    {
+        self::markTestSkipped('The S3 Docker image does not implement GetBucketCors.');
+        $client = $this->getClient();
+        $bucket = 'foo';
+
+        $input = new GetBucketCorsRequest([
+            'Bucket' => $bucket,
+        ]);
+        $result = $client->GetBucketCors($input);
+
+        $result->resolve();
+
+        // self::assertTODO(expected, $result->getCORSRules());
     }
 
     public function testGetFileNotExist()

--- a/src/Service/S3/tests/Integration/S3ClientTest.php
+++ b/src/Service/S3/tests/Integration/S3ClientTest.php
@@ -14,6 +14,7 @@ use AsyncAws\S3\Input\CompleteMultipartUploadRequest;
 use AsyncAws\S3\Input\CopyObjectRequest;
 use AsyncAws\S3\Input\CreateBucketRequest;
 use AsyncAws\S3\Input\CreateMultipartUploadRequest;
+use AsyncAws\S3\Input\DeleteBucketCorsRequest;
 use AsyncAws\S3\Input\DeleteBucketRequest;
 use AsyncAws\S3\Input\DeleteObjectRequest;
 use AsyncAws\S3\Input\GetObjectAclRequest;
@@ -243,6 +244,20 @@ class S3ClientTest extends TestCase
         self::assertFalse($client->bucketExists(new HeadBucketRequest([
             'Bucket' => 'foo-exist',
         ]))->isSuccess());
+    }
+
+    public function testDeleteBucketCors(): void
+    {
+        self::markTestSkipped('The S3 Docker image does not implement DeleteBucketCors.');
+        $client = $this->getClient();
+        $bucket = 'foo';
+
+        $input = new DeleteBucketCorsRequest([
+            'Bucket' => $bucket,
+        ]);
+        $result = $client->DeleteBucketCors($input);
+
+        $result->resolve();
     }
 
     public function testDeleteObject(): void

--- a/src/Service/S3/tests/Unit/Input/DeleteBucketCorsRequestTest.php
+++ b/src/Service/S3/tests/Unit/Input/DeleteBucketCorsRequestTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AsyncAws\S3\Tests\Unit\Input;
+
+use AsyncAws\Core\Test\TestCase;
+use AsyncAws\S3\Input\DeleteBucketCorsRequest;
+
+class DeleteBucketCorsRequestTest extends TestCase
+{
+    public function testRequest(): void
+    {
+        $input = new DeleteBucketCorsRequest([
+            'Bucket' => 'bucket-name',
+            'ExpectedBucketOwner' => 'expected-owner',
+        ]);
+
+        // see example-1.json from SDK
+        $expected = '
+DELETE /bucket-name?cors HTTP/1.0
+Content-Type: application/xml
+x-amz-expected-bucket-owner: expected-owner
+';
+
+        self::assertRequestEqualsHttpRequest($expected, $input->request());
+    }
+}

--- a/src/Service/S3/tests/Unit/Input/GetBucketCorsRequestTest.php
+++ b/src/Service/S3/tests/Unit/Input/GetBucketCorsRequestTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AsyncAws\S3\Tests\Unit\Input;
+
+use AsyncAws\Core\Test\TestCase;
+use AsyncAws\S3\Input\GetBucketCorsRequest;
+
+class GetBucketCorsRequestTest extends TestCase
+{
+    public function testRequest(): void
+    {
+        $input = new GetBucketCorsRequest([
+            'Bucket' => 'bucket-name',
+            'ExpectedBucketOwner' => 'expected-owner',
+        ]);
+
+        // see example-1.json from SDK
+        $expected = '
+GET /bucket-name?cors HTTP/1.0
+Content-Type: application/xml
+x-amz-expected-bucket-owner: expected-owner
+';
+
+        self::assertRequestEqualsHttpRequest($expected, $input->request());
+    }
+}

--- a/src/Service/S3/tests/Unit/Input/PutBucketCorsRequestTest.php
+++ b/src/Service/S3/tests/Unit/Input/PutBucketCorsRequestTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace AsyncAws\S3\Tests\Unit\Input;
+
+use AsyncAws\Core\Test\TestCase;
+use AsyncAws\S3\Input\PutBucketCorsRequest;
+use AsyncAws\S3\ValueObject\CORSConfiguration;
+use AsyncAws\S3\ValueObject\CORSRule;
+
+class PutBucketCorsRequestTest extends TestCase
+{
+    public function testRequest(): void
+    {
+        $input = new PutBucketCorsRequest([
+            'Bucket' => 'bucket-name',
+            'CORSConfiguration' => new CORSConfiguration([
+                'CORSRules' => [new CORSRule([
+                    'AllowedHeaders' => ['*'],
+                    'AllowedMethods' => ['POST', 'DELETE'],
+                    'AllowedOrigins' => ['*'],
+                    'ExposeHeaders' => ['x-amz-server-side-encryption'],
+                    'MaxAgeSeconds' => 1337,
+                ])],
+            ]),
+            'ContentMD5' => 'change me',
+            'ExpectedBucketOwner' => 'ExpectedBucketOwner',
+        ]);
+
+        // see example-1.json from SDK
+        $expected = '
+PUT /bucket-name?cors HTTP/1.0
+Content-Type: application/xml
+Content-md5: change me
+x-amz-expected-bucket-owner: ExpectedBucketOwner
+
+<?xml version="1.0" encoding="UTF-8"?>
+<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+    <CORSRule>
+        <AllowedHeader>*</AllowedHeader>
+        <AllowedMethod>POST</AllowedMethod>
+        <AllowedMethod>DELETE</AllowedMethod>
+        <AllowedOrigin>*</AllowedOrigin>
+        <ExposeHeader>x-amz-server-side-encryption</ExposeHeader>
+        <MaxAgeSeconds>1337</MaxAgeSeconds>
+    </CORSRule>
+</CORSConfiguration>
+';
+        self::assertRequestEqualsHttpRequest($expected, $input->request());
+    }
+}

--- a/src/Service/S3/tests/Unit/Result/GetBucketCorsOutputTest.php
+++ b/src/Service/S3/tests/Unit/Result/GetBucketCorsOutputTest.php
@@ -13,31 +13,26 @@ class GetBucketCorsOutputTest extends TestCase
 {
     public function testGetBucketCorsOutput(): void
     {
-        self::markTestSkipped('Generated response don\'t seem to corresponds to reality');
-
-        // see example-1.json from SDK
-        $response = new SimpleMockedResponse('<CORSRules>
-          <CORSRule>
-            <AllowedHeaders>Authorization</AllowedHeaders>
-            <AllowedMethods>GET</AllowedMethods>
-            <AllowedOrigins>*</AllowedOrigins>
-            <MaxAgeSeconds>3000</MaxAgeSeconds>
-          </CORSRule>
-          <CORSRule>
-            <AllowedHeaders>*</AllowedHeaders>
-            <AllowedMethods>DELETE</AllowedMethods>
-            <AllowedOrigins>example.com</AllowedOrigins>
-          </CORSRule>
-        </CORSRules>');
+        $response = new SimpleMockedResponse('
+<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
+    <CORSRule>
+        <AllowedOrigin>*</AllowedOrigin>
+        <AllowedMethod>PUT</AllowedMethod>
+        <AllowedMethod>POST</AllowedMethod>
+        <AllowedMethod>GET</AllowedMethod>
+        <AllowedHeader>*</AllowedHeader>
+    </CORSRule>
+</CORSConfiguration>');
 
         $client = new MockHttpClient($response);
         $result = new GetBucketCorsOutput(new Response($client->request('POST', 'http://localhost'), $client, new NullLogger()));
 
-        self::assertCount(2, $result->getCORSRules());
+        self::assertCount(1, $result->getCORSRules());
 
         $firstRule = $result->getCORSRules()[0];
-//        self::assertSame('GET', $firstRule->);
-
-        // self::assertTODO(expected, $result->getCORSRules());
+        self::assertCount(3, $firstRule->getAllowedMethods());
+        self::assertSame('*', $firstRule->getAllowedOrigins()[0]);
+        self::assertCount(0, $firstRule->getExposeHeaders());
+        self::assertNull($firstRule->getMaxAgeSeconds());
     }
 }

--- a/src/Service/S3/tests/Unit/Result/GetBucketCorsOutputTest.php
+++ b/src/Service/S3/tests/Unit/Result/GetBucketCorsOutputTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace AsyncAws\S3\Tests\Unit\Result;
+
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Test\Http\SimpleMockedResponse;
+use AsyncAws\Core\Test\TestCase;
+use AsyncAws\S3\Result\GetBucketCorsOutput;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+
+class GetBucketCorsOutputTest extends TestCase
+{
+    public function testGetBucketCorsOutput(): void
+    {
+        self::markTestSkipped('Generated response don\'t seem to corresponds to reality');
+
+        // see example-1.json from SDK
+        $response = new SimpleMockedResponse('<CORSRules>
+          <CORSRule>
+            <AllowedHeaders>Authorization</AllowedHeaders>
+            <AllowedMethods>GET</AllowedMethods>
+            <AllowedOrigins>*</AllowedOrigins>
+            <MaxAgeSeconds>3000</MaxAgeSeconds>
+          </CORSRule>
+          <CORSRule>
+            <AllowedHeaders>*</AllowedHeaders>
+            <AllowedMethods>DELETE</AllowedMethods>
+            <AllowedOrigins>example.com</AllowedOrigins>
+          </CORSRule>
+        </CORSRules>');
+
+        $client = new MockHttpClient($response);
+        $result = new GetBucketCorsOutput(new Response($client->request('POST', 'http://localhost'), $client, new NullLogger()));
+
+        self::assertCount(2, $result->getCORSRules());
+
+        $firstRule = $result->getCORSRules()[0];
+//        self::assertSame('GET', $firstRule->);
+
+        // self::assertTODO(expected, $result->getCORSRules());
+    }
+}

--- a/src/Service/S3/tests/Unit/S3ClientTest.php
+++ b/src/Service/S3/tests/Unit/S3ClientTest.php
@@ -20,6 +20,7 @@ use AsyncAws\S3\Input\HeadObjectRequest;
 use AsyncAws\S3\Input\ListMultipartUploadsRequest;
 use AsyncAws\S3\Input\ListObjectsV2Request;
 use AsyncAws\S3\Input\ListPartsRequest;
+use AsyncAws\S3\Input\PutBucketCorsRequest;
 use AsyncAws\S3\Input\PutBucketNotificationConfigurationRequest;
 use AsyncAws\S3\Input\PutObjectAclRequest;
 use AsyncAws\S3\Input\PutObjectRequest;
@@ -41,6 +42,8 @@ use AsyncAws\S3\Result\PutObjectAclOutput;
 use AsyncAws\S3\Result\PutObjectOutput;
 use AsyncAws\S3\Result\UploadPartOutput;
 use AsyncAws\S3\S3Client;
+use AsyncAws\S3\ValueObject\CORSConfiguration;
+use AsyncAws\S3\ValueObject\CORSRule;
 use AsyncAws\S3\ValueObject\Delete;
 use AsyncAws\S3\ValueObject\FilterRule;
 use AsyncAws\S3\ValueObject\NotificationConfiguration;
@@ -301,6 +304,27 @@ class S3ClientTest extends TestCase
         $result = $client->ListParts($input);
 
         self::assertInstanceOf(ListPartsOutput::class, $result);
+        self::assertFalse($result->info()['resolved']);
+    }
+
+    public function testPutBucketCors(): void
+    {
+        $client = new S3Client([], new NullProvider(), new MockHttpClient());
+
+        $input = new PutBucketCorsRequest([
+            'Bucket' => 'bucket-name',
+            'CORSConfiguration' => new CORSConfiguration([
+                'CORSRules' => [new CORSRule([
+                    'AllowedHeaders' => ['*'],
+                    'AllowedMethods' => ['GET', 'PUT'],
+                    'AllowedOrigins' => ['test.example.com'],
+                ])],
+            ]),
+
+        ]);
+        $result = $client->PutBucketCors($input);
+
+        self::assertInstanceOf(Result::class, $result);
         self::assertFalse($result->info()['resolved']);
     }
 

--- a/src/Service/S3/tests/Unit/S3ClientTest.php
+++ b/src/Service/S3/tests/Unit/S3ClientTest.php
@@ -15,6 +15,7 @@ use AsyncAws\S3\Input\DeleteBucketCorsRequest;
 use AsyncAws\S3\Input\DeleteBucketRequest;
 use AsyncAws\S3\Input\DeleteObjectRequest;
 use AsyncAws\S3\Input\DeleteObjectsRequest;
+use AsyncAws\S3\Input\GetBucketCorsRequest;
 use AsyncAws\S3\Input\GetObjectAclRequest;
 use AsyncAws\S3\Input\GetObjectRequest;
 use AsyncAws\S3\Input\HeadObjectRequest;
@@ -33,6 +34,7 @@ use AsyncAws\S3\Result\CreateBucketOutput;
 use AsyncAws\S3\Result\CreateMultipartUploadOutput;
 use AsyncAws\S3\Result\DeleteObjectOutput;
 use AsyncAws\S3\Result\DeleteObjectsOutput;
+use AsyncAws\S3\Result\GetBucketCorsOutput;
 use AsyncAws\S3\Result\GetObjectAclOutput;
 use AsyncAws\S3\Result\GetObjectOutput;
 use AsyncAws\S3\Result\HeadObjectOutput;
@@ -236,6 +238,20 @@ class S3ClientTest extends TestCase
         $result = $client->DeleteObjects($input);
 
         self::assertInstanceOf(DeleteObjectsOutput::class, $result);
+        self::assertFalse($result->info()['resolved']);
+    }
+
+    public function testGetBucketCors(): void
+    {
+        $client = new S3Client([], new NullProvider(), new MockHttpClient());
+
+        $input = new GetBucketCorsRequest([
+            'Bucket' => 'example-bucket',
+
+        ]);
+        $result = $client->GetBucketCors($input);
+
+        self::assertInstanceOf(GetBucketCorsOutput::class, $result);
         self::assertFalse($result->info()['resolved']);
     }
 

--- a/src/Service/S3/tests/Unit/S3ClientTest.php
+++ b/src/Service/S3/tests/Unit/S3ClientTest.php
@@ -11,6 +11,7 @@ use AsyncAws\S3\Input\CompleteMultipartUploadRequest;
 use AsyncAws\S3\Input\CopyObjectRequest;
 use AsyncAws\S3\Input\CreateBucketRequest;
 use AsyncAws\S3\Input\CreateMultipartUploadRequest;
+use AsyncAws\S3\Input\DeleteBucketCorsRequest;
 use AsyncAws\S3\Input\DeleteBucketRequest;
 use AsyncAws\S3\Input\DeleteObjectRequest;
 use AsyncAws\S3\Input\DeleteObjectsRequest;
@@ -183,6 +184,20 @@ class S3ClientTest extends TestCase
             'Bucket' => 'my_bucket',
         ]);
         $result = $client->DeleteBucket($input);
+
+        self::assertInstanceOf(Result::class, $result);
+        self::assertFalse($result->info()['resolved']);
+    }
+
+    public function testDeleteBucketCors(): void
+    {
+        $client = new S3Client([], new NullProvider(), new MockHttpClient());
+
+        $input = new DeleteBucketCorsRequest([
+            'Bucket' => 'example-bucket',
+
+        ]);
+        $result = $client->DeleteBucketCors($input);
 
         self::assertInstanceOf(Result::class, $result);
         self::assertFalse($result->info()['resolved']);


### PR DESCRIPTION
This is not a 100% complete because what amazon says it returns when getting cors setting and what the generated code says are not the same.

According to [the documentation](https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketCors.html#API_GetBucketCors_ResponseSyntax) the response should look like this
```
<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <CORSRule>
      <AllowedHeader>string</AllowedHeader>
      <AllowedMethod>string</AllowedMethod>
      <AllowedOrigin>string</AllowedOrigin>
      <ExposeHeader>string</ExposeHeader>
      <MaxAgeSeconds>integer</MaxAgeSeconds>
   </CORSRule>
</CORSConfiguration>
```

But according to the generated code it should look like this:
```
<CORSConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/">
   <member>
      <AllowedHeader><member>string</member></AllowedHeader>
      <AllowedMethod><member>string</member></AllowedMethod>
      <AllowedOrigin><member>string</member></AllowedOrigin>
      <ExposeHeader><member>string</member></ExposeHeader>
      <MaxAgeSeconds>integer</MaxAgeSeconds>
   </member>
</CORSConfiguration>
```

I don't know how to resolve this. 

If we can't find a simple solution to this, I'm fine with removing the `GetBucketCors` method for now. 