### PR TITLE
[Core][Mock] Make sure we signal that $bodyDownloaded=true

### DIFF
--- a/src/Core/src/Test/ResultMockFactory.php
+++ b/src/Core/src/Test/ResultMockFactory.php
@@ -263,7 +263,12 @@ class ResultMockFactory
     {
         $reflectionClass = new \ReflectionClass(Response::class);
         $response = $reflectionClass->newInstanceWithoutConstructor();
+
         $property = $reflectionClass->getProperty('resolveResult');
+        $property->setAccessible(true);
+        $property->setValue($response, true);
+
+        $property = $reflectionClass->getProperty('bodyDownloaded');
         $property->setAccessible(true);
         $property->setValue($response, true);
 


### PR DESCRIPTION
I need to be able to run this code with mocked results: 

```
foreach (Result::wait($results, 5.0, true) as $uuid => $result) {
```

With this PR it will work with `true` as third argument. (download full response)