### PR TITLE
Indicate compatibility with psr/cache 2 and 3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "nette/php-generator": "^3.3",
         "nette/utils": "^3.0",
         "nyholm/symfony-bundle-test": "^1.6.1",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "swaggest/json-diff": "^3.7",
         "symfony/cache": "^4.4 || ^5.0",
         "symfony/config": "^4.4 || ^5.0",

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -15,7 +15,7 @@
         "ext-SimpleXML": "*",
         "ext-hash": "*",
         "ext-json": "*",
-        "psr/cache": "^1.0",
+        "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/log": "^1.0",
         "symfony/deprecation-contracts": "^2.1",
         "symfony/http-client": "^4.4.16 || ^5.1.7,!=5.2.0",


### PR DESCRIPTION
The PSR cache interfaces have been updated with type declarations. Let's welcome the shiny new typed caches by updating our composer.json. 🙂 