### PR TITLE
RequestContext should not be internal

### DIFF
--- a/src/Core/src/RequestContext.php
+++ b/src/Core/src/RequestContext.php
@@ -8,8 +8,6 @@ use AsyncAws\Core\Exception\InvalidArgument;
  * Contains contextual information alongside a request.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
- *
- * @internal
  */
 class RequestContext
 {


### PR DESCRIPTION
The `Signer` interface uses the internal class `RequestContext` is its methods signature. Consequently the `SignerV4` cannot be used outside of library whereas it is not explicitly tagged with `@internal` annotation.

My actual use-case is signing an STS request to authenticate against a Vault server.
https://gist.github.com/GromNaN/7477b475a23bd1be682ac98f6767d4bd 