### PR TITLE
Fix wrong ContentEncoding for chunked stream

### DIFF
--- a/src/Service/S3/src/Signer/SignerV4ForS3.php
+++ b/src/Service/S3/src/Signer/SignerV4ForS3.php
@@ -118,7 +118,7 @@ class SignerV4ForS3 extends SignerV4
         // Add content-encoding for chunked stream if available
         $customEncoding = $context->getRequest()->getHeader('content-encoding');
         $contentEncoding = 'aws-chunked';
-        if($customEncoding){
+        if ($customEncoding) {
             $contentEncoding .= sprintf(', %s', $customEncoding);
         }
 

--- a/src/Service/S3/src/Signer/SignerV4ForS3.php
+++ b/src/Service/S3/src/Signer/SignerV4ForS3.php
@@ -116,14 +116,10 @@ class SignerV4ForS3 extends SignerV4
         }
 
         // Add content-encoding for chunked stream if available
-        $customEncoding = $context->getRequest()->getHeader('content-encoding');
-        $contentEncoding = 'aws-chunked';
-        if ($customEncoding) {
-            $contentEncoding .= sprintf(', %s', $customEncoding);
-        }
+        $customEncoding = $request->getHeader('content-encoding');
 
         // Convert the body into a chunked stream
-        $request->setHeader('content-encoding', $contentEncoding);
+        $request->setHeader('content-encoding', $customEncoding ? "aws-chunked, $customEncoding" : 'aws-chunked');
         $request->setHeader('x-amz-decoded-content-length', (string) $contentLength);
         $request->setHeader('x-amz-content-sha256', 'STREAMING-' . self::ALGORITHM_CHUNK);
 

--- a/src/Service/S3/src/Signer/SignerV4ForS3.php
+++ b/src/Service/S3/src/Signer/SignerV4ForS3.php
@@ -115,8 +115,15 @@ class SignerV4ForS3 extends SignerV4
             return;
         }
 
+        // Add content-encoding for chunked stream if available
+        $customEncoding = $context->getRequest()->getHeader('content-encoding');
+        $contentEncoding = 'aws-chunked';
+        if($customEncoding){
+            $contentEncoding .= sprintf(', %s', $customEncoding);
+        }
+
         // Convert the body into a chunked stream
-        $request->setHeader('content-encoding', 'aws-chunked');
+        $request->setHeader('content-encoding', $contentEncoding);
         $request->setHeader('x-amz-decoded-content-length', (string) $contentLength);
         $request->setHeader('x-amz-content-sha256', 'STREAMING-' . self::ALGORITHM_CHUNK);
 

--- a/src/Service/S3/tests/Unit/Signer/SignerV4ForS3Test.php
+++ b/src/Service/S3/tests/Unit/Signer/SignerV4ForS3Test.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\S3\Tests\Unit\Signer;
+
+use AsyncAws\Core\Configuration;
+use AsyncAws\Core\Credentials\Credentials;
+use AsyncAws\Core\Request;
+use AsyncAws\Core\RequestContext;
+use AsyncAws\Core\Stream\StringStream;
+use AsyncAws\S3\Signer\SignerV4ForS3;
+use PHPUnit\Framework\TestCase;
+
+class SignerV4ForS3Test extends TestCase
+{
+    public function testSignWithChunkedStream()
+    {
+        $signer = new SignerV4ForS3('sqs', 'eu-west-1', [Configuration::OPTION_SEND_CHUNKED_BODY => true]);
+
+        $request = new Request('POST', '/foo', ['arg' => 'bar'], [], StringStream::create(StringStream::create(str_repeat('a', 65536))));
+        $request->setEndpoint('http://localhost:1234/foo?arg=bar');
+        $context = new RequestContext(['currentDate' => new \DateTimeImmutable('2020-01-01T00:00:00Z')]);
+        $credentials = new Credentials('key', 'secret', 'token');
+
+        $signer->sign($request, $credentials, $context);
+
+        $expectedHeaders = [
+            'content-encoding' => 'aws-chunked',
+            'content-md5' => 'LWGqVLWMLpRAP7CSw9vAJw==',
+            'x-amz-content-sha256' => 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD',
+            'host' => 'localhost:1234',
+            'x-amz-security-token' => 'token',
+            'x-amz-date' => '20200101T000000Z',
+            'x-amz-decoded-content-length' => '65536',
+            'content-length' => '65712',
+            'authorization' => 'AWS4-HMAC-SHA256 Credential=key/20200101/eu-west-1/sqs/aws4_request, SignedHeaders=content-encoding;content-md5;host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length;x-amz-security-token, Signature=1f3faed8211c41b38ff9a2077b5ec6790219d369d07b6e21da5a70e24a2fb4d0',
+        ];
+
+        self::assertEqualsCanonicalizing($expectedHeaders, $request->getHeaders());
+    }
+
+    public function testSignWithChunkedStreamAndCustomEncoding()
+    {
+        $signer = new SignerV4ForS3('sqs', 'eu-west-1', [Configuration::OPTION_SEND_CHUNKED_BODY => true]);
+
+        $request = new Request('POST', '/foo', ['arg' => 'bar'], ['content-encoding' => 'UTF-8'], StringStream::create(StringStream::create(str_repeat('a', 65536))));
+        $request->setEndpoint('http://localhost:1234/foo?arg=bar');
+        $context = new RequestContext(['currentDate' => new \DateTimeImmutable('2020-01-01T00:00:00Z')]);
+        $credentials = new Credentials('key', 'secret', 'token');
+
+        $signer->sign($request, $credentials, $context);
+
+        $expectedHeaders = [
+            'content-encoding' => 'aws-chunked, UTF-8',
+            'content-md5' => 'LWGqVLWMLpRAP7CSw9vAJw==',
+            'x-amz-content-sha256' => 'STREAMING-AWS4-HMAC-SHA256-PAYLOAD',
+            'host' => 'localhost:1234',
+            'x-amz-security-token' => 'token',
+            'x-amz-date' => '20200101T000000Z',
+            'x-amz-decoded-content-length' => '65536',
+            'content-length' => '65712',
+            'authorization' => 'AWS4-HMAC-SHA256 Credential=key/20200101/eu-west-1/sqs/aws4_request, SignedHeaders=content-encoding;content-md5;host;x-amz-content-sha256;x-amz-date;x-amz-decoded-content-length;x-amz-security-token, Signature=f754ab44e4a82320490de388b37506d833e4458de7f767a74d1b973b53c92d79',
+        ];
+
+        self::assertEqualsCanonicalizing($expectedHeaders, $request->getHeaders());
+    }
+
+    public function testSignWithCustomEncoding()
+    {
+        $signer = new SignerV4ForS3('sqs', 'eu-west-1', [Configuration::OPTION_SEND_CHUNKED_BODY => true]);
+
+        $request = new Request('POST', '/foo', ['arg' => 'bar'], ['content-encoding' => 'UTF-8'], StringStream::create(StringStream::create(str_repeat('a', 1000))));
+        $request->setEndpoint('http://localhost:1234/foo?arg=bar');
+        $context = new RequestContext(['currentDate' => new \DateTimeImmutable('2020-01-01T00:00:00Z')]);
+        $credentials = new Credentials('key', 'secret', 'token');
+
+        $signer->sign($request, $credentials, $context);
+
+        $expectedHeaders = [
+            'content-encoding' => 'UTF-8',
+            'content-md5' => 'yr5F3MmuW2a6hmAMymuLqA==',
+            'x-amz-content-sha256' => '41edece42d63e8d9bf515a9ba6932e1c20cbc9f5a5d134645adb5db1b9737ea3',
+            'host' => 'localhost:1234',
+            'x-amz-security-token' => 'token',
+            'x-amz-date' => '20200101T000000Z',
+            'authorization' => 'AWS4-HMAC-SHA256 Credential=key/20200101/eu-west-1/sqs/aws4_request, SignedHeaders=content-encoding;content-md5;host;x-amz-content-sha256;x-amz-date;x-amz-security-token, Signature=8292648a7c5ebef873efa6ba32ed70cbe9ce76506f65c8d5ba43b0877e3982c9',
+        ];
+
+        self::assertEqualsCanonicalizing($expectedHeaders, $request->getHeaders());
+    }
+}


### PR DESCRIPTION
problem
if I specify `ContentEncoding` for a file bigger than `64kb` .. the `Content-Encoding` option will be ignored
![Screenshot 2021-03-22 at 14 02 00](https://user-images.githubusercontent.com/2089749/111993880-692d0980-8b17-11eb-8c4b-450c71559d69.png)

it will appear empty in S3
![Screenshot 2021-03-22 at 14 00 34](https://user-images.githubusercontent.com/2089749/111993732-400c7900-8b17-11eb-9070-922e0fcd3f8c.png)

according to https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-streaming.html
we can add multiple ContentEncoding so I check the request & add the right `ContentEncoding` if available

Actual Result after this PR
![Screenshot 2021-03-22 at 13 54 57](https://user-images.githubusercontent.com/2089749/111993993-8c57b900-8b17-11eb-9401-05e0bacb443e.png)

