### PR TITLE
Fix forming signature with multiple space

### DIFF
--- a/src/Core/src/Signer/SignerV4.php
+++ b/src/Core/src/Signer/SignerV4.php
@@ -273,7 +273,7 @@ class SignerV4 implements Signer
                 continue;
             }
 
-            $canonicalHeaders[$key] = "$key:$value";
+            $canonicalHeaders[$key] = $key . ':' . preg_replace('/\s+/', ' ', $value);
         }
         ksort($canonicalHeaders);
 


### PR DESCRIPTION
Ref https://github.com/aws/aws-sdk-php/blob/master/src/Signature/SignatureV4.php#L301

Problem example:

```php
$s3->copyObject([
  'Bucket' => 'target',
  'Key' => '1.txt',
  'CopySource' => 'source/1  2.txt', // double space
]);
```