### PR TITLE
Fix className format

### DIFF
--- a/website/Twig/AsyncAwsTwigExtension.php
+++ b/website/Twig/AsyncAwsTwigExtension.php
@@ -38,6 +38,9 @@ class AsyncAwsTwigExtension extends AbstractExtension
         return [
             new TwigFilter('asset', [$this, 'parseAssetUrls']),
             new TwigFilter('lcfirst', function($str) { return lcfirst($str);}),
+            new TwigFilter('cleanClassName', [$this, 'cleanClassName'], [
+                'is_safe' => ['html'],
+            ]),
             new TwigFilter('printHLJSUseStatement', [$this, 'printHighlightUseStatement'], [
                 'is_safe' => ['html'],
             ]),
@@ -75,6 +78,14 @@ class AsyncAwsTwigExtension extends AbstractExtension
     {
         return $this->renderTag($name, 'js', '<script src="%s"></script>');
     }
+
+    public function cleanClassName(string $name)
+    {
+        return preg_replace_callback('/([A-Z])([A-Z]+)(\d|[A-Z][a-z]|$)/', function($matches) {
+            return $matches[1].strtolower($matches[2]).$matches[3];
+        }, $name);
+    }
+
     public function printHighlightUseStatement(string $name)
     {
         $parts = explode('\\', $name);

--- a/website/template/client.twig
+++ b/website/template/client.twig
@@ -17,7 +17,8 @@
 
     <pre><code class="language-shell hljs">composer require {{ package }}</code></pre>
 
-    {% set clientFqcn = fqcn|default('AsyncAws\\'~name~'\\'~name~'Client') %}
+    {% set className = name|cleanClassName %}
+    {% set clientFqcn = fqcn|default('AsyncAws\\'~className~'\\'~className~'Client') %}
 
     <p>
         A new client object may be instantiated by:
@@ -25,7 +26,7 @@
 
     <pre><code class="language-php hljs">{{ clientFqcn|printHLJSUseStatement }}
 
-${{ name|lcfirst }} = <span class="hljs-keyword">new</span> {{ name }}Client();
+${{ className|lcfirst }} = <span class="hljs-keyword">new</span> {{ className }}Client();
 </code></pre>
 
     <p>
@@ -35,7 +36,7 @@ ${{ name|lcfirst }} = <span class="hljs-keyword">new</span> {{ name }}Client();
 
     <pre><code class="language-php hljs">{{ clientFqcn|printHLJSUseStatement }}
 
-${{ name|lcfirst }} = <span class="hljs-keyword">new</span> {{ name }}Client([
+${{ className|lcfirst }} = <span class="hljs-keyword">new</span> {{ className }}Client([
     <span class="hljs-string">'accessKeyId'</span> => <span class="hljs-string">'my_access_key'</span>,
     <span class="hljs-string">'accessKeySecret'</span> => <span class="hljs-string">'my_access_secret'</span>,
     <span class="hljs-string">'region'</span> => <span class="hljs-string">'eu-central-1'</span>,


### PR DESCRIPTION
Fixes #984 

`SQS` => `Sqs`
`S3` => `S3`
`EC2` => `Ec2`
`FooBar` => `FooBar`
`FOOBar` => `FooBar`
`FooBAR` => `FooBar`