### PR TITLE
Fix PHP-Stan dependency versions

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -73,6 +73,12 @@ jobs:
     name: Psalm
     runs-on: Ubuntu-20.04
     steps:
+      - name: Set up PHP
+        uses: shivammathur/setup-php@2.7.0
+        with:
+          php-version: '7.4'
+          coverage: none
+
       - name: Checkout code
         uses: actions/checkout@v2
 


### PR DESCRIPTION
psalm run composer with PHP 7.4 which conflict with the PHP versions used by our `download dependencies` step