### PR TITLE
Enforce JSON validity

### DIFF
--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestJsonSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestJsonSerializer.php
@@ -53,7 +53,7 @@ class RestJsonSerializer implements Serializer
             ]), false];
         }
 
-        return ['$bodyPayload = $this->requestBody(); $body = empty($bodyPayload) ? "{}" : json_encode($bodyPayload);', true];
+        return ['$bodyPayload = $this->requestBody(); $body = empty($bodyPayload) ? "{}" : \json_encode($bodyPayload, ' . \JSON_THROW_ON_ERROR . ');', true];
     }
 
     public function generateRequestBuilder(StructureShape $shape): array
@@ -269,4 +269,8 @@ if (empty(INPUT)) {
             'INPUT' => ($isRequired || false === strpos($input, '->')) ? $input : $input . ' ?? \'\'',
         ]);
     }
+}
+
+if (!\defined('JSON_THROW_ON_ERROR')) {
+    \define('JSON_THROW_ON_ERROR', 4194304);
 }

--- a/src/Service/CloudWatchLogs/CHANGELOG.md
+++ b/src/Service/CloudWatchLogs/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Fixed
+
+- Assert the provided Input can be json-encoded.
+
 ## 1.1.0
 
 ### Added

--- a/src/Service/CloudWatchLogs/src/Input/CreateLogGroupRequest.php
+++ b/src/Service/CloudWatchLogs/src/Input/CreateLogGroupRequest.php
@@ -93,7 +93,7 @@ final class CreateLogGroupRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CloudWatchLogs/src/Input/DescribeLogStreamsRequest.php
+++ b/src/Service/CloudWatchLogs/src/Input/DescribeLogStreamsRequest.php
@@ -135,7 +135,7 @@ final class DescribeLogStreamsRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CloudWatchLogs/src/Input/PutLogEventsRequest.php
+++ b/src/Service/CloudWatchLogs/src/Input/PutLogEventsRequest.php
@@ -114,7 +114,7 @@ final class PutLogEventsRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CodeDeploy/CHANGELOG.md
+++ b/src/Service/CodeDeploy/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - AWS api-change: Improve documentation
 
+### Fixed
+
+- Assert the provided Input can be json-encoded.
+
 ## 1.2.0
 
 ### Added

--- a/src/Service/CodeDeploy/src/Input/PutLifecycleEventHookExecutionStatusInput.php
+++ b/src/Service/CodeDeploy/src/Input/PutLifecycleEventHookExecutionStatusInput.php
@@ -91,7 +91,7 @@ final class PutLifecycleEventHookExecutionStatusInput extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/CHANGELOG.md
+++ b/src/Service/CognitoIdentityProvider/CHANGELOG.md
@@ -7,6 +7,10 @@
 - AWS api-change: TODO
 - AWS enhancement: Documentation updates for cognito-idp
 
+### Fixed
+
+- Assert the provided Input can be json-encoded.
+
 ## 1.2.0
 
 ### Added

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminConfirmSignUpRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminConfirmSignUpRequest.php
@@ -95,7 +95,7 @@ final class AdminConfirmSignUpRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminCreateUserRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminCreateUserRequest.php
@@ -205,7 +205,7 @@ final class AdminCreateUserRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminDeleteUserRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminDeleteUserRequest.php
@@ -78,7 +78,7 @@ final class AdminDeleteUserRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminGetUserRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminGetUserRequest.php
@@ -78,7 +78,7 @@ final class AdminGetUserRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminInitiateAuthRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminInitiateAuthRequest.php
@@ -164,7 +164,7 @@ final class AdminInitiateAuthRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminSetUserPasswordRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminSetUserPasswordRequest.php
@@ -105,7 +105,7 @@ final class AdminSetUserPasswordRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminUpdateUserAttributesRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminUpdateUserAttributesRequest.php
@@ -115,7 +115,7 @@ final class AdminUpdateUserAttributesRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/src/Input/AssociateSoftwareTokenRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AssociateSoftwareTokenRequest.php
@@ -71,7 +71,7 @@ final class AssociateSoftwareTokenRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/src/Input/ChangePasswordRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/ChangePasswordRequest.php
@@ -94,7 +94,7 @@ final class ChangePasswordRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/src/Input/ConfirmForgotPasswordRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/ConfirmForgotPasswordRequest.php
@@ -175,7 +175,7 @@ final class ConfirmForgotPasswordRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/src/Input/ForgotPasswordRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/ForgotPasswordRequest.php
@@ -141,7 +141,7 @@ final class ForgotPasswordRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/src/Input/InitiateAuthRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/InitiateAuthRequest.php
@@ -148,7 +148,7 @@ final class InitiateAuthRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/src/Input/ListUsersRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/ListUsersRequest.php
@@ -124,7 +124,7 @@ final class ListUsersRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/src/Input/ResendConfirmationCodeRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/ResendConfirmationCodeRequest.php
@@ -141,7 +141,7 @@ final class ResendConfirmationCodeRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/src/Input/RespondToAuthChallengeRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/RespondToAuthChallengeRequest.php
@@ -165,7 +165,7 @@ final class RespondToAuthChallengeRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/src/Input/SetUserMFAPreferenceRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/SetUserMFAPreferenceRequest.php
@@ -89,7 +89,7 @@ final class SetUserMFAPreferenceRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/src/Input/SignUpRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/SignUpRequest.php
@@ -192,7 +192,7 @@ final class SignUpRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/CognitoIdentityProvider/src/Input/VerifySoftwareTokenRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/VerifySoftwareTokenRequest.php
@@ -102,7 +102,7 @@ final class VerifySoftwareTokenRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/DynamoDb/CHANGELOG.md
+++ b/src/Service/DynamoDb/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Fixed
+
+- Assert the provided Input can be json-encoded.
+
 ## 1.1.0
 
 ### Added

--- a/src/Service/DynamoDb/src/Input/BatchGetItemInput.php
+++ b/src/Service/DynamoDb/src/Input/BatchGetItemInput.php
@@ -88,7 +88,7 @@ final class BatchGetItemInput extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/DynamoDb/src/Input/BatchWriteItemInput.php
+++ b/src/Service/DynamoDb/src/Input/BatchWriteItemInput.php
@@ -108,7 +108,7 @@ final class BatchWriteItemInput extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/DynamoDb/src/Input/CreateTableInput.php
+++ b/src/Service/DynamoDb/src/Input/CreateTableInput.php
@@ -229,7 +229,7 @@ final class CreateTableInput extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/DynamoDb/src/Input/DeleteItemInput.php
+++ b/src/Service/DynamoDb/src/Input/DeleteItemInput.php
@@ -246,7 +246,7 @@ final class DeleteItemInput extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/DynamoDb/src/Input/DeleteTableInput.php
+++ b/src/Service/DynamoDb/src/Input/DeleteTableInput.php
@@ -62,7 +62,7 @@ final class DeleteTableInput extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/DynamoDb/src/Input/DescribeTableInput.php
+++ b/src/Service/DynamoDb/src/Input/DescribeTableInput.php
@@ -62,7 +62,7 @@ final class DescribeTableInput extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/DynamoDb/src/Input/GetItemInput.php
+++ b/src/Service/DynamoDb/src/Input/GetItemInput.php
@@ -172,7 +172,7 @@ final class GetItemInput extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/DynamoDb/src/Input/ListTablesInput.php
+++ b/src/Service/DynamoDb/src/Input/ListTablesInput.php
@@ -74,7 +74,7 @@ final class ListTablesInput extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/DynamoDb/src/Input/PutItemInput.php
+++ b/src/Service/DynamoDb/src/Input/PutItemInput.php
@@ -247,7 +247,7 @@ final class PutItemInput extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/DynamoDb/src/Input/QueryInput.php
+++ b/src/Service/DynamoDb/src/Input/QueryInput.php
@@ -368,7 +368,7 @@ final class QueryInput extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/DynamoDb/src/Input/ScanInput.php
+++ b/src/Service/DynamoDb/src/Input/ScanInput.php
@@ -344,7 +344,7 @@ final class ScanInput extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/DynamoDb/src/Input/UpdateItemInput.php
+++ b/src/Service/DynamoDb/src/Input/UpdateItemInput.php
@@ -288,7 +288,7 @@ final class UpdateItemInput extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/DynamoDb/src/Input/UpdateTableInput.php
+++ b/src/Service/DynamoDb/src/Input/UpdateTableInput.php
@@ -184,7 +184,7 @@ final class UpdateTableInput extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/DynamoDb/src/Input/UpdateTimeToLiveInput.php
+++ b/src/Service/DynamoDb/src/Input/UpdateTimeToLiveInput.php
@@ -79,7 +79,7 @@ final class UpdateTimeToLiveInput extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Ecr/CHANGELOG.md
+++ b/src/Service/Ecr/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Fixed
+
+- Assert the provided Input can be json-encoded.
+
 ### Added
 
 - AWS api-change: Added `ap-northeast-3` region

--- a/src/Service/Ecr/src/Input/GetAuthorizationTokenRequest.php
+++ b/src/Service/Ecr/src/Input/GetAuthorizationTokenRequest.php
@@ -64,7 +64,7 @@ final class GetAuthorizationTokenRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/EventBridge/CHANGELOG.md
+++ b/src/Service/EventBridge/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Fixed
+
+- Assert the provided Input can be json-encoded.
+
 ### Added
 
 - AWS api-change: Adds TraceHeader to PutEventsRequestEntry to support AWS X-Ray trace-ids on events generated using the PutEvents operation.

--- a/src/Service/EventBridge/src/Input/PutEventsRequest.php
+++ b/src/Service/EventBridge/src/Input/PutEventsRequest.php
@@ -64,7 +64,7 @@ final class PutEventsRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Lambda/CHANGELOG.md
+++ b/src/Service/Lambda/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Fixed
+
+- Assert the provided Input can be json-encoded.
+
 ## 1.4.0
 
 ### Added

--- a/src/Service/Lambda/src/Input/AddLayerVersionPermissionRequest.php
+++ b/src/Service/Lambda/src/Input/AddLayerVersionPermissionRequest.php
@@ -161,7 +161,7 @@ final class AddLayerVersionPermissionRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Lambda/src/Input/PublishLayerVersionRequest.php
+++ b/src/Service/Lambda/src/Input/PublishLayerVersionRequest.php
@@ -126,7 +126,7 @@ final class PublishLayerVersionRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/RdsDataService/CHANGELOG.md
+++ b/src/Service/RdsDataService/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Fixed
+
+- Assert the provided Input can be json-encoded.
+
 ### Added
 
 - AWS api-change: With the Data API, you can now use UUID and JSON data types as input to your database.

--- a/src/Service/RdsDataService/src/Input/BatchExecuteStatementRequest.php
+++ b/src/Service/RdsDataService/src/Input/BatchExecuteStatementRequest.php
@@ -154,7 +154,7 @@ final class BatchExecuteStatementRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/RdsDataService/src/Input/BeginTransactionRequest.php
+++ b/src/Service/RdsDataService/src/Input/BeginTransactionRequest.php
@@ -103,7 +103,7 @@ final class BeginTransactionRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/RdsDataService/src/Input/CommitTransactionRequest.php
+++ b/src/Service/RdsDataService/src/Input/CommitTransactionRequest.php
@@ -91,7 +91,7 @@ final class CommitTransactionRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/RdsDataService/src/Input/ExecuteStatementRequest.php
+++ b/src/Service/RdsDataService/src/Input/ExecuteStatementRequest.php
@@ -196,7 +196,7 @@ final class ExecuteStatementRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/RdsDataService/src/Input/RollbackTransactionRequest.php
+++ b/src/Service/RdsDataService/src/Input/RollbackTransactionRequest.php
@@ -91,7 +91,7 @@ final class RollbackTransactionRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Rekognition/CHANGELOG.md
+++ b/src/Service/Rekognition/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - AWS api-change: Add AWS tagging support for Amazon Rekognition collections, stream processors, and Custom Label models
 
+### Fixed
+
+- Assert the provided Input can be json-encoded.
+
 ## 0.1.4
 
 ### Added

--- a/src/Service/Rekognition/src/Input/CreateCollectionRequest.php
+++ b/src/Service/Rekognition/src/Input/CreateCollectionRequest.php
@@ -76,7 +76,7 @@ final class CreateCollectionRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Rekognition/src/Input/CreateProjectRequest.php
+++ b/src/Service/Rekognition/src/Input/CreateProjectRequest.php
@@ -59,7 +59,7 @@ final class CreateProjectRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Rekognition/src/Input/DeleteCollectionRequest.php
+++ b/src/Service/Rekognition/src/Input/DeleteCollectionRequest.php
@@ -59,7 +59,7 @@ final class DeleteCollectionRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Rekognition/src/Input/DeleteProjectRequest.php
+++ b/src/Service/Rekognition/src/Input/DeleteProjectRequest.php
@@ -59,7 +59,7 @@ final class DeleteProjectRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Rekognition/src/Input/DetectFacesRequest.php
+++ b/src/Service/Rekognition/src/Input/DetectFacesRequest.php
@@ -82,7 +82,7 @@ final class DetectFacesRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Rekognition/src/Input/GetCelebrityInfoRequest.php
+++ b/src/Service/Rekognition/src/Input/GetCelebrityInfoRequest.php
@@ -60,7 +60,7 @@ final class GetCelebrityInfoRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Rekognition/src/Input/IndexFacesRequest.php
+++ b/src/Service/Rekognition/src/Input/IndexFacesRequest.php
@@ -150,7 +150,7 @@ final class IndexFacesRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Rekognition/src/Input/ListCollectionsRequest.php
+++ b/src/Service/Rekognition/src/Input/ListCollectionsRequest.php
@@ -70,7 +70,7 @@ final class ListCollectionsRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Rekognition/src/Input/RecognizeCelebritiesRequest.php
+++ b/src/Service/Rekognition/src/Input/RecognizeCelebritiesRequest.php
@@ -61,7 +61,7 @@ final class RecognizeCelebritiesRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Rekognition/src/Input/SearchFacesByImageRequest.php
+++ b/src/Service/Rekognition/src/Input/SearchFacesByImageRequest.php
@@ -130,7 +130,7 @@ final class SearchFacesByImageRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Ses/CHANGELOG.md
+++ b/src/Service/Ses/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Fixed
+
+- Assert the provided Input can be json-encoded.
+
 ## 1.4.0
 
 ### Added

--- a/src/Service/Ses/src/Input/SendEmailRequest.php
+++ b/src/Service/Ses/src/Input/SendEmailRequest.php
@@ -210,7 +210,7 @@ final class SendEmailRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Ssm/CHANGELOG.md
+++ b/src/Service/Ssm/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Fixed
+
+- Assert the provided Input can be json-encoded.
+
 ### Changed
 
 - AWS api-change: Reword docblock

--- a/src/Service/Ssm/src/Input/DeleteParameterRequest.php
+++ b/src/Service/Ssm/src/Input/DeleteParameterRequest.php
@@ -59,7 +59,7 @@ final class DeleteParameterRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Ssm/src/Input/GetParameterRequest.php
+++ b/src/Service/Ssm/src/Input/GetParameterRequest.php
@@ -73,7 +73,7 @@ final class GetParameterRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Ssm/src/Input/GetParametersByPathRequest.php
+++ b/src/Service/Ssm/src/Input/GetParametersByPathRequest.php
@@ -137,7 +137,7 @@ final class GetParametersByPathRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Ssm/src/Input/GetParametersRequest.php
+++ b/src/Service/Ssm/src/Input/GetParametersRequest.php
@@ -77,7 +77,7 @@ final class GetParametersRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));

--- a/src/Service/Ssm/src/Input/PutParameterRequest.php
+++ b/src/Service/Ssm/src/Input/PutParameterRequest.php
@@ -223,7 +223,7 @@ final class PutParameterRequest extends Input
 
         // Prepare Body
         $bodyPayload = $this->requestBody();
-        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload);
+        $body = empty($bodyPayload) ? '{}' : \json_encode($bodyPayload, 4194304);
 
         // Return the Request
         return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));


### PR DESCRIPTION
Fixes #993

When people provide an invalid input, we could (when PHP >= 7.3) easily throw an exception and let people understand their mistake.

I choose to NOT provide backward compatibility to PHP < 7.3 to avoid unnecessary complex code