### PR TITLE
Fix invalid operation names

### DIFF
--- a/src/CodeGenerator/src/Definition/Operation.php
+++ b/src/CodeGenerator/src/Definition/Operation.php
@@ -7,6 +7,11 @@ namespace AsyncAws\CodeGenerator\Definition;
 class Operation
 {
     /**
+     * @var string
+     */
+    private $name;
+
+    /**
      * @var array
      */
     private $data;
@@ -35,9 +40,10 @@ class Operation
     {
     }
 
-    public static function create(array $data, ServiceDefinition $service, ?Pagination $pagination, Example $example, \Closure $shapeLocator): self
+    public static function create(string $name, array $data, ServiceDefinition $service, ?Pagination $pagination, Example $example, \Closure $shapeLocator): self
     {
         $operation = new self();
+        $operation->name = $name;
         $operation->data = $data;
         $operation->service = $service;
         $operation->pagination = $pagination;
@@ -52,7 +58,7 @@ class Operation
      */
     public function getName(): string
     {
-        return $this->data['name'];
+        return $this->name;
     }
 
     public function getMethodName(): string

--- a/src/CodeGenerator/src/Definition/ServiceDefinition.php
+++ b/src/CodeGenerator/src/Definition/ServiceDefinition.php
@@ -55,6 +55,7 @@ class ServiceDefinition
     {
         if (isset($this->definition['operations'][$name])) {
             return Operation::create(
+                $name,
                 $this->definition['operations'][$name] + [
                     '_documentation' => $this->documentation['operations'][$name] ?? null,
                     '_apiVersion' => $this->definition['metadata']['apiVersion'],

--- a/src/Service/CloudFront/src/CloudFrontClient.php
+++ b/src/Service/CloudFront/src/CloudFrontClient.php
@@ -23,7 +23,7 @@ class CloudFrontClient extends AbstractApi
      * Create a new invalidation.
      *
      * @see https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_CreateInvalidation2019_03_26.html
-     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-cloudfront-2019-03-26.html#createinvalidation2019_03_26
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-cloudfront-2019-03-26.html#createinvalidation
      *
      * @param array{
      *   DistributionId: string,
@@ -42,7 +42,7 @@ class CloudFrontClient extends AbstractApi
     public function createInvalidation($input): CreateInvalidationResult
     {
         $input = CreateInvalidationRequest::create($input);
-        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateInvalidation2019_03_26', 'region' => $input->getRegion(), 'exceptionMapping' => [
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CreateInvalidation', 'region' => $input->getRegion(), 'exceptionMapping' => [
             'AccessDenied' => AccessDeniedException::class,
             'MissingBody' => MissingBodyException::class,
             'InvalidArgument' => InvalidArgumentException::class,


### PR DESCRIPTION
While working on fixing the pagination I discovered that services like `CloudFront` have invalid operation names in the `api2.json` file.