### PR TITLE
Remove dupplicated code in paginated response

### DIFF
--- a/src/CodeGenerator/src/Generator/PaginationGenerator.php
+++ b/src/CodeGenerator/src/Generator/PaginationGenerator.php
@@ -161,11 +161,20 @@ class PaginationGenerator
 
         $iteratorType = implode('|', $iteratorTypes);
 
+        if (1 === \count($resultKeys)) {
+            $body = strtr('yield from $this->PROPERTY_ACCESSOR();
+            ', [
+                'PROPERTY_ACCESSOR' => 'get' . ucfirst(GeneratorHelper::normalizeName($resultKeys[0])),
+            ]);
+        } else {
+            $body = $this->generateOutputPaginationLoader($iteratorBody, $pagination, $classBuilder, $operation);
+        }
+
         $classBuilder->addMethod('getIterator')
             ->setReturnType(\Traversable::class)
-            ->addComment('Iterates over ' . implode(' then ', $resultKeys))
+            ->addComment('Iterates over ' . implode(' and ', $resultKeys))
             ->addComment("@return \Traversable<$iteratorType>")
-            ->setBody($this->generateOutputPaginationLoader($iteratorBody, $pagination, $classBuilder, $operation))
+            ->setBody($body)
         ;
         $classBuilder->addComment("@implements \IteratorAggregate<$iteratorType>");
     }

--- a/src/Service/CloudFormation/src/Result/DescribeStackEventsOutput.php
+++ b/src/Service/CloudFormation/src/Result/DescribeStackEventsOutput.php
@@ -34,33 +34,7 @@ class DescribeStackEventsOutput extends Result implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof CloudFormationClient) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof DescribeStackEventsInput) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getNextToken()) {
-                $input->setNextToken($page->getNextToken());
-
-                $this->registerPrefetch($nextPage = $client->describeStackEvents($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getStackEvents(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getStackEvents();
     }
 
     public function getNextToken(): ?string

--- a/src/Service/CloudFormation/src/Result/DescribeStacksOutput.php
+++ b/src/Service/CloudFormation/src/Result/DescribeStacksOutput.php
@@ -41,33 +41,7 @@ class DescribeStacksOutput extends Result implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof CloudFormationClient) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof DescribeStacksInput) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getNextToken()) {
-                $input->setNextToken($page->getNextToken());
-
-                $this->registerPrefetch($nextPage = $client->describeStacks($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getStacks(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getStacks();
     }
 
     public function getNextToken(): ?string

--- a/src/Service/CloudWatchLogs/src/Result/DescribeLogStreamsResponse.php
+++ b/src/Service/CloudWatchLogs/src/Result/DescribeLogStreamsResponse.php
@@ -28,33 +28,7 @@ class DescribeLogStreamsResponse extends Result implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof CloudWatchLogsClient) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof DescribeLogStreamsRequest) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getNextToken()) {
-                $input->setNextToken($page->getNextToken());
-
-                $this->registerPrefetch($nextPage = $client->describeLogStreams($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getLogStreams(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getLogStreams();
     }
 
     /**

--- a/src/Service/CognitoIdentityProvider/src/Result/ListUsersResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/ListUsersResponse.php
@@ -36,33 +36,7 @@ class ListUsersResponse extends Result implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof CognitoIdentityProviderClient) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof ListUsersRequest) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getPaginationToken()) {
-                $input->setPaginationToken($page->getPaginationToken());
-
-                $this->registerPrefetch($nextPage = $client->listUsers($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getUsers(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getUsers();
     }
 
     public function getPaginationToken(): ?string

--- a/src/Service/DynamoDb/src/Result/BatchGetItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/BatchGetItemOutput.php
@@ -87,33 +87,7 @@ class BatchGetItemOutput extends Result implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof DynamoDbClient) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof BatchGetItemInput) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getUnprocessedKeys()) {
-                $input->setRequestItems($page->getUnprocessedKeys());
-
-                $this->registerPrefetch($nextPage = $client->batchGetItem($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getConsumedCapacity(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getConsumedCapacity();
     }
 
     /**

--- a/src/Service/DynamoDb/src/Result/ListTablesOutput.php
+++ b/src/Service/DynamoDb/src/Result/ListTablesOutput.php
@@ -34,33 +34,7 @@ class ListTablesOutput extends Result implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof DynamoDbClient) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof ListTablesInput) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getLastEvaluatedTableName()) {
-                $input->setExclusiveStartTableName($page->getLastEvaluatedTableName());
-
-                $this->registerPrefetch($nextPage = $client->listTables($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getTableNames(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getTableNames();
     }
 
     public function getLastEvaluatedTableName(): ?string

--- a/src/Service/DynamoDb/src/Result/QueryOutput.php
+++ b/src/Service/DynamoDb/src/Result/QueryOutput.php
@@ -118,33 +118,7 @@ class QueryOutput extends Result implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof DynamoDbClient) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof QueryInput) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getLastEvaluatedKey()) {
-                $input->setExclusiveStartKey($page->getLastEvaluatedKey());
-
-                $this->registerPrefetch($nextPage = $client->query($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getItems(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getItems();
     }
 
     /**

--- a/src/Service/DynamoDb/src/Result/ScanOutput.php
+++ b/src/Service/DynamoDb/src/Result/ScanOutput.php
@@ -118,33 +118,7 @@ class ScanOutput extends Result implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof DynamoDbClient) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof ScanInput) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getLastEvaluatedKey()) {
-                $input->setExclusiveStartKey($page->getLastEvaluatedKey());
-
-                $this->registerPrefetch($nextPage = $client->scan($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getItems(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getItems();
     }
 
     /**

--- a/src/Service/Iam/src/Result/ListUsersResponse.php
+++ b/src/Service/Iam/src/Result/ListUsersResponse.php
@@ -51,33 +51,7 @@ class ListUsersResponse extends Result implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof IamClient) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof ListUsersRequest) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getIsTruncated()) {
-                $input->setMarker($page->getMarker());
-
-                $this->registerPrefetch($nextPage = $client->listUsers($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getUsers(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getUsers();
     }
 
     public function getMarker(): ?string

--- a/src/Service/Lambda/src/Result/ListFunctionsResponse.php
+++ b/src/Service/Lambda/src/Result/ListFunctionsResponse.php
@@ -86,33 +86,7 @@ class ListFunctionsResponse extends Result implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof LambdaClient) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof ListFunctionsRequest) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getNextMarker()) {
-                $input->setMarker($page->getNextMarker());
-
-                $this->registerPrefetch($nextPage = $client->listFunctions($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getFunctions(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getFunctions();
     }
 
     public function getNextMarker(): ?string

--- a/src/Service/Lambda/src/Result/ListLayerVersionsResponse.php
+++ b/src/Service/Lambda/src/Result/ListLayerVersionsResponse.php
@@ -32,33 +32,7 @@ class ListLayerVersionsResponse extends Result implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof LambdaClient) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof ListLayerVersionsRequest) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getNextMarker()) {
-                $input->setMarker($page->getNextMarker());
-
-                $this->registerPrefetch($nextPage = $client->listLayerVersions($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getLayerVersions(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getLayerVersions();
     }
 
     /**

--- a/src/Service/Lambda/src/Result/ListVersionsByFunctionResponse.php
+++ b/src/Service/Lambda/src/Result/ListVersionsByFunctionResponse.php
@@ -41,33 +41,7 @@ class ListVersionsByFunctionResponse extends Result implements \IteratorAggregat
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof LambdaClient) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof ListVersionsByFunctionRequest) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getNextMarker()) {
-                $input->setMarker($page->getNextMarker());
-
-                $this->registerPrefetch($nextPage = $client->listVersionsByFunction($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getVersions(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getVersions();
     }
 
     public function getNextMarker(): ?string

--- a/src/Service/Rekognition/src/Result/ListCollectionsResponse.php
+++ b/src/Service/Rekognition/src/Result/ListCollectionsResponse.php
@@ -91,33 +91,7 @@ class ListCollectionsResponse extends Result implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof RekognitionClient) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof ListCollectionsRequest) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getNextToken()) {
-                $input->setNextToken($page->getNextToken());
-
-                $this->registerPrefetch($nextPage = $client->listCollections($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getCollectionIds(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getCollectionIds();
     }
 
     public function getNextToken(): ?string

--- a/src/Service/Route53/src/Result/ListHostedZonesResponse.php
+++ b/src/Service/Route53/src/Result/ListHostedZonesResponse.php
@@ -104,33 +104,7 @@ class ListHostedZonesResponse extends Result implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof Route53Client) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof ListHostedZonesRequest) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getIsTruncated()) {
-                $input->setMarker($page->getNextMarker());
-
-                $this->registerPrefetch($nextPage = $client->listHostedZones($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getHostedZones(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getHostedZones();
     }
 
     public function getMarker(): string

--- a/src/Service/S3/src/Result/ListMultipartUploadsOutput.php
+++ b/src/Service/S3/src/Result/ListMultipartUploadsOutput.php
@@ -163,7 +163,7 @@ class ListMultipartUploadsOutput extends Result implements \IteratorAggregate
     }
 
     /**
-     * Iterates over Uploads then CommonPrefixes.
+     * Iterates over Uploads and CommonPrefixes.
      *
      * @return \Traversable<MultipartUpload|CommonPrefix>
      */

--- a/src/Service/S3/src/Result/ListObjectsV2Output.php
+++ b/src/Service/S3/src/Result/ListObjectsV2Output.php
@@ -203,7 +203,7 @@ class ListObjectsV2Output extends Result implements \IteratorAggregate
     }
 
     /**
-     * Iterates over Contents then CommonPrefixes.
+     * Iterates over Contents and CommonPrefixes.
      *
      * @return \Traversable<AwsObject|CommonPrefix>
      */

--- a/src/Service/S3/src/Result/ListPartsOutput.php
+++ b/src/Service/S3/src/Result/ListPartsOutput.php
@@ -139,33 +139,7 @@ class ListPartsOutput extends Result implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof S3Client) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof ListPartsRequest) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getIsTruncated()) {
-                $input->setPartNumberMarker($page->getNextPartNumberMarker());
-
-                $this->registerPrefetch($nextPage = $client->listParts($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getParts(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getParts();
     }
 
     public function getKey(): ?string

--- a/src/Service/Sns/src/Result/ListSubscriptionsByTopicResponse.php
+++ b/src/Service/Sns/src/Result/ListSubscriptionsByTopicResponse.php
@@ -34,33 +34,7 @@ class ListSubscriptionsByTopicResponse extends Result implements \IteratorAggreg
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof SnsClient) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof ListSubscriptionsByTopicInput) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getNextToken()) {
-                $input->setNextToken($page->getNextToken());
-
-                $this->registerPrefetch($nextPage = $client->listSubscriptionsByTopic($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getSubscriptions(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getSubscriptions();
     }
 
     public function getNextToken(): ?string

--- a/src/Service/Sqs/src/Result/ListQueuesResult.php
+++ b/src/Service/Sqs/src/Result/ListQueuesResult.php
@@ -33,33 +33,7 @@ class ListQueuesResult extends Result implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof SqsClient) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof ListQueuesRequest) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getNextToken()) {
-                $input->setNextToken($page->getNextToken());
-
-                $this->registerPrefetch($nextPage = $client->listQueues($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getQueueUrls(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getQueueUrls();
     }
 
     public function getNextToken(): ?string

--- a/src/Service/Ssm/src/Result/GetParametersByPathResult.php
+++ b/src/Service/Ssm/src/Result/GetParametersByPathResult.php
@@ -31,33 +31,7 @@ class GetParametersByPathResult extends Result implements \IteratorAggregate
      */
     public function getIterator(): \Traversable
     {
-        $client = $this->awsClient;
-        if (!$client instanceof SsmClient) {
-            throw new InvalidArgument('missing client injected in paginated result');
-        }
-        if (!$this->input instanceof GetParametersByPathRequest) {
-            throw new InvalidArgument('missing last request injected in paginated result');
-        }
-        $input = clone $this->input;
-        $page = $this;
-        while (true) {
-            if ($page->getNextToken()) {
-                $input->setNextToken($page->getNextToken());
-
-                $this->registerPrefetch($nextPage = $client->getParametersByPath($input));
-            } else {
-                $nextPage = null;
-            }
-
-            yield from $page->getParameters(true);
-
-            if (null === $nextPage) {
-                break;
-            }
-
-            $this->unregisterPrefetch($nextPage);
-            $page = $nextPage;
-        }
+        yield from $this->getParameters();
     }
 
     public function getNextToken(): ?string


### PR DESCRIPTION
When the pagination iterator over only one result (in opposite to S3::listObject that iterate over Contents and CommonPrefixes)
We can reduce code by removing the duplicate code in `getIterator` to rely on the getter instead.