### PR TITLE
Fix rewinded s3 signer

### DIFF
--- a/src/Service/S3/CHANGELOG.md
+++ b/src/Service/S3/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Fixed
+
+- Fix issue when a request to upload a file is retried
+
 ### Added
 
 - AWS enhancement: Documentation updates for Amazon S3


### PR DESCRIPTION
fixes #950

The Body sent to the HttpClient MUST be rewindable, because, if the HttpClient decides to retry a request, it needs to rewind the stream.