### PR TITLE
Update year in license file

### DIFF
--- a/src/Service/.template/LICENSE
+++ b/src/Service/.template/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Jérémy Derussé, Tobias Nyholm
+Copyright (c) 2021 Jérémy Derussé, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Service/Route53/LICENSE
+++ b/src/Service/Route53/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Jérémy Derussé, Tobias Nyholm
+Copyright (c) 2021 Jérémy Derussé, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Service/SecretsManager/LICENSE
+++ b/src/Service/SecretsManager/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 Jérémy Derussé, Tobias Nyholm
+Copyright (c) 2021 Jérémy Derussé, Tobias Nyholm
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
We should use the year that we create the package. 

This will also trigger push to SecretsManager