### PR TITLE
Allow symfony/contracts v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,9 +12,9 @@
         "ext-json": "*",
         "psr/log": "~1.0",
         "symfony/http-client": "^4.4.16 || ^5.1.7,!=5.2.0 || ^6.0",
-        "symfony/http-client-contracts": "^1.0 || ^2.0",
+        "symfony/http-client-contracts": "^1.0 || ^2.0 || ^3.0",
         "symfony/process": "^4.4 || ^5.0 || ^6.0",
-        "symfony/service-contracts": "^1.0 || ^2.0"
+        "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "3.0.0",
@@ -36,7 +36,7 @@
         "symfony/config": "^4.4 || ^5.0 || ^6.0",
         "symfony/console": "^4.4 || ^5.0 || ^6.0",
         "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0",
-        "symfony/deprecation-contracts": "^2.1",
+        "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/filesystem": "^5.0 || ^6.0",
         "symfony/finder": "^4.4 || ^5.0 || ^6.0",
         "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0",

--- a/src/CodeGenerator/composer.json
+++ b/src/CodeGenerator/composer.json
@@ -13,9 +13,9 @@
         "nette/utils": "^3.0",
         "symfony/console": "^4.4 || ^5.0 || ^6.0",
         "symfony/http-client": "^4.4 || ^5.0 || ^6.0",
-        "symfony/http-client-contracts": "^1.0 || ^2.0",
+        "symfony/http-client-contracts": "^1.0 || ^2.0 || ^3.0",
         "symfony/process": "^4.4 || ^5.0 || ^6.0",
-        "symfony/service-contracts": "^2.0"
+        "symfony/service-contracts": "^2.0 || ^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -17,10 +17,10 @@
         "ext-json": "*",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/log": "^1.0",
-        "symfony/deprecation-contracts": "^2.1",
+        "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/http-client": "^4.4.16 || ^5.1.7,!=5.2.0 || ^6.0",
-        "symfony/http-client-contracts": "^1.1.8 || ^2.0",
-        "symfony/service-contracts": "^1.0 || ^2.0"
+        "symfony/http-client-contracts": "^1.1.8 || ^2.0 || ^3.0",
+        "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
     },
     "conflict": {
         "async-aws/s3": "<1.1"


### PR DESCRIPTION
To unlock the Symfony CI.
This package is not affected by the planned BC breaks.
Needed for https://github.com/symfony/symfony/pull/42088