### PR TITLE
Fix refresh code when changelog is missing

### DIFF
--- a/.github/workflows/bin/refresh
+++ b/.github/workflows/bin/refresh
@@ -86,8 +86,13 @@ foreach ($versions as $version) {
         break;
     }
     console_log('Fetching CHANGELOG for '. $version['version']);
-    $versionChanges = json_decode(file_get_contents('https://raw.githubusercontent.com/aws/aws-sdk-php/'.$lastVersion.'/.changes/'.$version['version']), true);
-    $changes = array_merge($changes, $versionChanges);
+
+    $versionContent = @file_get_contents('https://raw.githubusercontent.com/aws/aws-sdk-php/'.$lastVersion.'/.changes/'.$version['version']);
+    if (false === $versionContent) {
+        continue;
+    }
+
+    $changes = array_merge($changes, json_decode($versionContent, true));
 }
 $changesByService = [];
 foreach ($changes as $change) {


### PR DESCRIPTION
For unknown reason, no changelog has been published for the `3.187.1` version of AWS (see https://github.com/aws/aws-sdk-php/tree/master/.changes)
Leading to an exception when the bot tries to generated our changelog.

This PR fixes the issue by ignoring exceptions thrown by `file_get_contents`