### PR TITLE
Do not initialize array property

### DIFF
--- a/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
@@ -116,7 +116,6 @@ class PopulatorGenerator
                 }
 
                 $nullable = false;
-                $property->setValue([]);
             } elseif ($memberShape instanceof ListShape) {
                 $memberShape->getMember()->getShape();
 
@@ -128,7 +127,6 @@ class PopulatorGenerator
                 }
 
                 $nullable = false;
-                $property->setValue([]);
             } elseif ($member->isStreaming()) {
                 $returnType = ResultStream::class;
                 $parameterType = ResultStream::class;

--- a/src/Service/CloudFormation/src/Result/DescribeStackEventsOutput.php
+++ b/src/Service/CloudFormation/src/Result/DescribeStackEventsOutput.php
@@ -19,7 +19,7 @@ class DescribeStackEventsOutput extends Result implements \IteratorAggregate
     /**
      * A list of `StackEvents` structures.
      */
-    private $stackEvents = [];
+    private $stackEvents;
 
     /**
      * If the output exceeds 1 MB in size, a string that identifies the next page of events. If no additional page exists,

--- a/src/Service/CloudFormation/src/Result/DescribeStacksOutput.php
+++ b/src/Service/CloudFormation/src/Result/DescribeStacksOutput.php
@@ -26,7 +26,7 @@ class DescribeStacksOutput extends Result implements \IteratorAggregate
     /**
      * A list of stack structures.
      */
-    private $stacks = [];
+    private $stacks;
 
     /**
      * If the output exceeds 1 MB in size, a string that identifies the next page of stacks. If no additional page exists,

--- a/src/Service/CloudWatchLogs/src/Result/DescribeLogStreamsResponse.php
+++ b/src/Service/CloudWatchLogs/src/Result/DescribeLogStreamsResponse.php
@@ -17,7 +17,7 @@ class DescribeLogStreamsResponse extends Result implements \IteratorAggregate
     /**
      * The log streams.
      */
-    private $logStreams = [];
+    private $logStreams;
 
     private $nextToken;
 

--- a/src/Service/CognitoIdentityProvider/src/Result/AdminGetUserResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/AdminGetUserResponse.php
@@ -21,7 +21,7 @@ class AdminGetUserResponse extends Result
     /**
      * An array of name-value pairs representing user attributes.
      */
-    private $userAttributes = [];
+    private $userAttributes;
 
     /**
      * The date the user was created.
@@ -48,7 +48,7 @@ class AdminGetUserResponse extends Result
      * doesn't provide information about TOTP software token MFA configurations. To look up information about either type of
      * MFA configuration, use UserMFASettingList instead.
      */
-    private $mfaOptions = [];
+    private $mfaOptions;
 
     /**
      * The user's preferred MFA setting.
@@ -59,7 +59,7 @@ class AdminGetUserResponse extends Result
      * The MFA options that are enabled for the user. The possible values in this list are `SMS_MFA` and
      * `SOFTWARE_TOKEN_MFA`.
      */
-    private $userMfaSettingList = [];
+    private $userMfaSettingList;
 
     public function getEnabled(): ?bool
     {

--- a/src/Service/CognitoIdentityProvider/src/Result/AdminInitiateAuthResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/AdminInitiateAuthResponse.php
@@ -32,7 +32,7 @@ class AdminInitiateAuthResponse extends Result
      * challenge. The responses in this parameter should be used to compute inputs to the next call
      * (`AdminRespondToAuthChallenge`).
      */
-    private $challengeParameters = [];
+    private $challengeParameters;
 
     /**
      * The result of the authentication response. This is only returned if the caller does not need to pass another

--- a/src/Service/CognitoIdentityProvider/src/Result/InitiateAuthResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/InitiateAuthResponse.php
@@ -31,7 +31,7 @@ class InitiateAuthResponse extends Result
      * challenge. The responses in this parameter should be used to compute inputs to the next call
      * (`RespondToAuthChallenge`).
      */
-    private $challengeParameters = [];
+    private $challengeParameters;
 
     /**
      * The result of the authentication response. This is only returned if the caller does not need to pass another

--- a/src/Service/CognitoIdentityProvider/src/Result/ListUsersResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/ListUsersResponse.php
@@ -21,7 +21,7 @@ class ListUsersResponse extends Result implements \IteratorAggregate
     /**
      * The users returned in the request to list users.
      */
-    private $users = [];
+    private $users;
 
     /**
      * An identifier that was returned from the previous call to this operation, which can be used to return the next set of

--- a/src/Service/CognitoIdentityProvider/src/Result/RespondToAuthChallengeResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/RespondToAuthChallengeResponse.php
@@ -32,7 +32,7 @@ class RespondToAuthChallengeResponse extends Result
      *
      * @see https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_InitiateAuth.html
      */
-    private $challengeParameters = [];
+    private $challengeParameters;
 
     /**
      * The result returned by the server in response to the request to respond to the authentication challenge.

--- a/src/Service/DynamoDb/src/Result/BatchGetItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/BatchGetItemOutput.php
@@ -23,19 +23,19 @@ class BatchGetItemOutput extends Result implements \IteratorAggregate
      * A map of table name to a list of items. Each object in `Responses` consists of a table name, along with a map of
      * attribute data consisting of the data type and attribute value.
      */
-    private $responses = [];
+    private $responses;
 
     /**
      * A map of tables and their respective keys that were not processed with the current response. The `UnprocessedKeys`
      * value is in the same form as `RequestItems`, so the value can be provided directly to a subsequent `BatchGetItem`
      * operation. For more information, see `RequestItems` in the Request Parameters section.
      */
-    private $unprocessedKeys = [];
+    private $unprocessedKeys;
 
     /**
      * The read capacity units consumed by the entire `BatchGetItem` operation.
      */
-    private $consumedCapacity = [];
+    private $consumedCapacity;
 
     /**
      * @param bool $currentPageOnly When true, iterates over items of the current page. Otherwise also fetch items in the next pages.

--- a/src/Service/DynamoDb/src/Result/BatchWriteItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/BatchWriteItemOutput.php
@@ -22,18 +22,18 @@ class BatchWriteItemOutput extends Result
      * same form as `RequestItems`, so you can provide this value directly to a subsequent `BatchGetItem` operation. For
      * more information, see `RequestItems` in the Request Parameters section.
      */
-    private $unprocessedItems = [];
+    private $unprocessedItems;
 
     /**
      * A list of tables that were processed by `BatchWriteItem` and, for each table, information about any item collections
      * that were affected by individual `DeleteItem` or `PutItem` operations.
      */
-    private $itemCollectionMetrics = [];
+    private $itemCollectionMetrics;
 
     /**
      * The capacity units consumed by the entire `BatchWriteItem` operation.
      */
-    private $consumedCapacity = [];
+    private $consumedCapacity;
 
     /**
      * @return ConsumedCapacity[]

--- a/src/Service/DynamoDb/src/Result/DeleteItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/DeleteItemOutput.php
@@ -18,7 +18,7 @@ class DeleteItemOutput extends Result
      * A map of attribute names to `AttributeValue` objects, representing the item as it appeared before the `DeleteItem`
      * operation. This map appears in the response only if `ReturnValues` was specified as `ALL_OLD` in the request.
      */
-    private $attributes = [];
+    private $attributes;
 
     /**
      * The capacity units consumed by the `DeleteItem` operation. The data returned includes the total provisioned

--- a/src/Service/DynamoDb/src/Result/GetItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/GetItemOutput.php
@@ -16,7 +16,7 @@ class GetItemOutput extends Result
     /**
      * A map of attribute names to `AttributeValue` objects, as specified by `ProjectionExpression`.
      */
-    private $item = [];
+    private $item;
 
     /**
      * The capacity units consumed by the `GetItem` operation. The data returned includes the total provisioned throughput

--- a/src/Service/DynamoDb/src/Result/ListTablesOutput.php
+++ b/src/Service/DynamoDb/src/Result/ListTablesOutput.php
@@ -19,7 +19,7 @@ class ListTablesOutput extends Result implements \IteratorAggregate
      * The names of the tables associated with the current account at the current endpoint. The maximum size of this array
      * is 100.
      */
-    private $tableNames = [];
+    private $tableNames;
 
     /**
      * The name of the last table in the current page of results. Use this value as the `ExclusiveStartTableName` in a new

--- a/src/Service/DynamoDb/src/Result/PutItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/PutItemOutput.php
@@ -18,7 +18,7 @@ class PutItemOutput extends Result
      * The attribute values as they appeared before the `PutItem` operation, but only if `ReturnValues` is specified as
      * `ALL_OLD` in the request. Each element consists of an attribute name and an attribute value.
      */
-    private $attributes = [];
+    private $attributes;
 
     /**
      * The capacity units consumed by the `PutItem` operation. The data returned includes the total provisioned throughput

--- a/src/Service/DynamoDb/src/Result/QueryOutput.php
+++ b/src/Service/DynamoDb/src/Result/QueryOutput.php
@@ -22,7 +22,7 @@ class QueryOutput extends Result implements \IteratorAggregate
      * An array of item attributes that match the query criteria. Each element in this array consists of an attribute name
      * and the value for that attribute.
      */
-    private $items = [];
+    private $items;
 
     /**
      * The number of items in the response.
@@ -42,7 +42,7 @@ class QueryOutput extends Result implements \IteratorAggregate
      * The primary key of the item where the operation stopped, inclusive of the previous result set. Use this value to
      * start a new operation, excluding this value in the new request.
      */
-    private $lastEvaluatedKey = [];
+    private $lastEvaluatedKey;
 
     /**
      * The capacity units consumed by the `Query` operation. The data returned includes the total provisioned throughput

--- a/src/Service/DynamoDb/src/Result/ScanOutput.php
+++ b/src/Service/DynamoDb/src/Result/ScanOutput.php
@@ -22,7 +22,7 @@ class ScanOutput extends Result implements \IteratorAggregate
      * An array of item attributes that match the scan criteria. Each element in this array consists of an attribute name
      * and the value for that attribute.
      */
-    private $items = [];
+    private $items;
 
     /**
      * The number of items in the response.
@@ -42,7 +42,7 @@ class ScanOutput extends Result implements \IteratorAggregate
      * The primary key of the item where the operation stopped, inclusive of the previous result set. Use this value to
      * start a new operation, excluding this value in the new request.
      */
-    private $lastEvaluatedKey = [];
+    private $lastEvaluatedKey;
 
     /**
      * The capacity units consumed by the `Scan` operation. The data returned includes the total provisioned throughput

--- a/src/Service/DynamoDb/src/Result/UpdateItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/UpdateItemOutput.php
@@ -18,7 +18,7 @@ class UpdateItemOutput extends Result
      * A map of attribute values as they appear before or after the `UpdateItem` operation, as determined by the
      * `ReturnValues` parameter.
      */
-    private $attributes = [];
+    private $attributes;
 
     /**
      * The capacity units consumed by the `UpdateItem` operation. The data returned includes the total provisioned

--- a/src/Service/Ecr/src/Result/GetAuthorizationTokenResponse.php
+++ b/src/Service/Ecr/src/Result/GetAuthorizationTokenResponse.php
@@ -11,7 +11,7 @@ class GetAuthorizationTokenResponse extends Result
     /**
      * A list of authorization token data objects that correspond to the `registryIds` values in the request.
      */
-    private $authorizationData = [];
+    private $authorizationData;
 
     /**
      * @return AuthorizationData[]

--- a/src/Service/EventBridge/src/Result/PutEventsResponse.php
+++ b/src/Service/EventBridge/src/Result/PutEventsResponse.php
@@ -17,7 +17,7 @@ class PutEventsResponse extends Result
      * The successfully and unsuccessfully ingested events results. If the ingestion was successful, the entry has the event
      * ID in it. Otherwise, you can use the error code and error message to identify the problem with the entry.
      */
-    private $entries = [];
+    private $entries;
 
     /**
      * @return PutEventsResultEntry[]

--- a/src/Service/Firehose/src/Result/PutRecordBatchOutput.php
+++ b/src/Service/Firehose/src/Result/PutRecordBatchOutput.php
@@ -23,7 +23,7 @@ class PutRecordBatchOutput extends Result
      * The results array. For each record, the index of the response element is the same as the index used in the request
      * array.
      */
-    private $requestResponses = [];
+    private $requestResponses;
 
     public function getEncrypted(): ?bool
     {

--- a/src/Service/Iam/src/Result/ListUsersResponse.php
+++ b/src/Service/Iam/src/Result/ListUsersResponse.php
@@ -21,7 +21,7 @@ class ListUsersResponse extends Result implements \IteratorAggregate
     /**
      * A list of users.
      */
-    private $users = [];
+    private $users;
 
     /**
      * A flag that indicates whether there are more items to return. If your results were truncated, you can make a

--- a/src/Service/Kinesis/src/Result/EnhancedMonitoringOutput.php
+++ b/src/Service/Kinesis/src/Result/EnhancedMonitoringOutput.php
@@ -19,12 +19,12 @@ class EnhancedMonitoringOutput extends Result
     /**
      * Represents the current state of the metrics that are in the enhanced state before the operation.
      */
-    private $currentShardLevelMetrics = [];
+    private $currentShardLevelMetrics;
 
     /**
      * Represents the list of all the metrics that would be in the enhanced state after the operation.
      */
-    private $desiredShardLevelMetrics = [];
+    private $desiredShardLevelMetrics;
 
     /**
      * @return list<MetricsName::*>

--- a/src/Service/Kinesis/src/Result/GetRecordsOutput.php
+++ b/src/Service/Kinesis/src/Result/GetRecordsOutput.php
@@ -14,7 +14,7 @@ class GetRecordsOutput extends Result
     /**
      * The data records retrieved from the shard.
      */
-    private $records = [];
+    private $records;
 
     /**
      * The next position in the shard from which to start sequentially reading data records. If set to `null`, the shard has

--- a/src/Service/Kinesis/src/Result/ListShardsOutput.php
+++ b/src/Service/Kinesis/src/Result/ListShardsOutput.php
@@ -15,7 +15,7 @@ class ListShardsOutput extends Result
      * and the shard that's adjacent to the shard's parent. Each object also contains the starting and ending hash keys and
      * the starting and ending sequence numbers for the shard.
      */
-    private $shards = [];
+    private $shards;
 
     /**
      * When the number of shards in the data stream is greater than the default value for the `MaxResults` parameter, or if

--- a/src/Service/Kinesis/src/Result/ListStreamConsumersOutput.php
+++ b/src/Service/Kinesis/src/Result/ListStreamConsumersOutput.php
@@ -17,7 +17,7 @@ class ListStreamConsumersOutput extends Result implements \IteratorAggregate
     /**
      * An array of JSON objects. Each object represents one registered consumer.
      */
-    private $consumers = [];
+    private $consumers;
 
     /**
      * When the number of consumers that are registered with the data stream is greater than the default value for the

--- a/src/Service/Kinesis/src/Result/ListStreamsOutput.php
+++ b/src/Service/Kinesis/src/Result/ListStreamsOutput.php
@@ -18,7 +18,7 @@ class ListStreamsOutput extends Result implements \IteratorAggregate
     /**
      * The names of the streams that are associated with the AWS account making the `ListStreams` request.
      */
-    private $streamNames = [];
+    private $streamNames;
 
     /**
      * If set to `true`, there are more streams available to list.

--- a/src/Service/Kinesis/src/Result/ListTagsForStreamOutput.php
+++ b/src/Service/Kinesis/src/Result/ListTagsForStreamOutput.php
@@ -15,7 +15,7 @@ class ListTagsForStreamOutput extends Result
      * A list of tags associated with `StreamName`, starting with the first tag after `ExclusiveStartTagKey` and up to the
      * specified `Limit`.
      */
-    private $tags = [];
+    private $tags;
 
     /**
      * If set to `true`, more tags are available. To request additional tags, set `ExclusiveStartTagKey` to the key of the

--- a/src/Service/Kinesis/src/Result/PutRecordsOutput.php
+++ b/src/Service/Kinesis/src/Result/PutRecordsOutput.php
@@ -22,7 +22,7 @@ class PutRecordsOutput extends Result
      * ordering. A record that is successfully added to a stream includes `SequenceNumber` and `ShardId` in the result. A
      * record that fails to be added to a stream includes `ErrorCode` and `ErrorMessage` in the result.
      */
-    private $records = [];
+    private $records;
 
     /**
      * The encryption type used on the records. This parameter can be one of the following values:.

--- a/src/Service/Lambda/src/Result/ListFunctionsResponse.php
+++ b/src/Service/Lambda/src/Result/ListFunctionsResponse.php
@@ -34,7 +34,7 @@ class ListFunctionsResponse extends Result implements \IteratorAggregate
     /**
      * A list of Lambda functions.
      */
-    private $functions = [];
+    private $functions;
 
     /**
      * @param bool $currentPageOnly When true, iterates over items of the current page. Otherwise also fetch items in the next pages.

--- a/src/Service/Lambda/src/Result/ListLayerVersionsResponse.php
+++ b/src/Service/Lambda/src/Result/ListLayerVersionsResponse.php
@@ -23,7 +23,7 @@ class ListLayerVersionsResponse extends Result implements \IteratorAggregate
     /**
      * A list of versions.
      */
-    private $layerVersions = [];
+    private $layerVersions;
 
     /**
      * Iterates over LayerVersions.

--- a/src/Service/Lambda/src/Result/ListVersionsByFunctionResponse.php
+++ b/src/Service/Lambda/src/Result/ListVersionsByFunctionResponse.php
@@ -32,7 +32,7 @@ class ListVersionsByFunctionResponse extends Result implements \IteratorAggregat
     /**
      * A list of Lambda function versions.
      */
-    private $versions = [];
+    private $versions;
 
     /**
      * Iterates over Versions.

--- a/src/Service/Lambda/src/Result/PublishLayerVersionResponse.php
+++ b/src/Service/Lambda/src/Result/PublishLayerVersionResponse.php
@@ -44,7 +44,7 @@ class PublishLayerVersionResponse extends Result
     /**
      * The layer's compatible runtimes.
      */
-    private $compatibleRuntimes = [];
+    private $compatibleRuntimes;
 
     /**
      * The layer's software license.

--- a/src/Service/RdsDataService/src/Result/BatchExecuteStatementResponse.php
+++ b/src/Service/RdsDataService/src/Result/BatchExecuteStatementResponse.php
@@ -16,7 +16,7 @@ class BatchExecuteStatementResponse extends Result
     /**
      * The execution results of each batch entry.
      */
-    private $updateResults = [];
+    private $updateResults;
 
     /**
      * @return UpdateResult[]

--- a/src/Service/RdsDataService/src/Result/ExecuteStatementResponse.php
+++ b/src/Service/RdsDataService/src/Result/ExecuteStatementResponse.php
@@ -16,12 +16,12 @@ class ExecuteStatementResponse extends Result
     /**
      * Metadata for the columns included in the results.
      */
-    private $columnMetadata = [];
+    private $columnMetadata;
 
     /**
      * Values for fields generated during the request.
      */
-    private $generatedFields = [];
+    private $generatedFields;
 
     /**
      * The number of records updated by the request.
@@ -31,7 +31,7 @@ class ExecuteStatementResponse extends Result
     /**
      * The records returned by the SQL statement.
      */
-    private $records = [];
+    private $records;
 
     /**
      * @return ColumnMetadata[]

--- a/src/Service/Rekognition/src/Result/DetectFacesResponse.php
+++ b/src/Service/Rekognition/src/Result/DetectFacesResponse.php
@@ -26,7 +26,7 @@ class DetectFacesResponse extends Result
     /**
      * Details of each face found in the image.
      */
-    private $faceDetails = [];
+    private $faceDetails;
 
     /**
      * The value of `OrientationCorrection` is always null.

--- a/src/Service/Rekognition/src/Result/GetCelebrityInfoResponse.php
+++ b/src/Service/Rekognition/src/Result/GetCelebrityInfoResponse.php
@@ -11,7 +11,7 @@ class GetCelebrityInfoResponse extends Result
     /**
      * An array of URLs pointing to additional celebrity information.
      */
-    private $urls = [];
+    private $urls;
 
     /**
      * The name of the celebrity.

--- a/src/Service/Rekognition/src/Result/IndexFacesResponse.php
+++ b/src/Service/Rekognition/src/Result/IndexFacesResponse.php
@@ -31,7 +31,7 @@ class IndexFacesResponse extends Result
      * An array of faces detected and added to the collection. For more information, see Searching Faces in a Collection in
      * the Amazon Rekognition Developer Guide.
      */
-    private $faceRecords = [];
+    private $faceRecords;
 
     /**
      * If your collection is associated with a face detection model that's later than version 3.0, the value of
@@ -49,7 +49,7 @@ class IndexFacesResponse extends Result
      * filter identified them as low quality, or the `MaxFaces` request parameter filtered them out. To use the quality
      * filter, you specify the `QualityFilter` request parameter.
      */
-    private $unindexedFaces = [];
+    private $unindexedFaces;
 
     public function getFaceModelVersion(): ?string
     {

--- a/src/Service/Rekognition/src/Result/ListCollectionsResponse.php
+++ b/src/Service/Rekognition/src/Result/ListCollectionsResponse.php
@@ -16,7 +16,7 @@ class ListCollectionsResponse extends Result implements \IteratorAggregate
     /**
      * An array of collection IDs.
      */
-    private $collectionIds = [];
+    private $collectionIds;
 
     /**
      * If the result is truncated, the response provides a `NextToken` that you can use in the subsequent request to fetch
@@ -29,7 +29,7 @@ class ListCollectionsResponse extends Result implements \IteratorAggregate
      * example, the value of `FaceModelVersions[2]` is the version number for the face detection model used by the
      * collection in `CollectionId[2]`.
      */
-    private $faceModelVersions = [];
+    private $faceModelVersions;
 
     /**
      * @param bool $currentPageOnly When true, iterates over items of the current page. Otherwise also fetch items in the next pages.

--- a/src/Service/Rekognition/src/Result/RecognizeCelebritiesResponse.php
+++ b/src/Service/Rekognition/src/Result/RecognizeCelebritiesResponse.php
@@ -22,12 +22,12 @@ class RecognizeCelebritiesResponse extends Result
      * image. Each celebrity object includes the following attributes: `Face`, `Confidence`, `Emotions`, `Landmarks`,
      * `Pose`, `Quality`, `Smile`, `Id`, `KnownGender`, `MatchConfidence`, `Name`, `Urls`.
      */
-    private $celebrityFaces = [];
+    private $celebrityFaces;
 
     /**
      * Details about each unrecognized face in the image.
      */
-    private $unrecognizedFaces = [];
+    private $unrecognizedFaces;
 
     /**
      * > Support for estimating image orientation using the the OrientationCorrection field has ceased as of August 2021.

--- a/src/Service/Rekognition/src/Result/SearchFacesByImageResponse.php
+++ b/src/Service/Rekognition/src/Result/SearchFacesByImageResponse.php
@@ -23,7 +23,7 @@ class SearchFacesByImageResponse extends Result
     /**
      * An array of faces that match the input face, along with the confidence in the match.
      */
-    private $faceMatches = [];
+    private $faceMatches;
 
     /**
      * Version number of the face detection model associated with the input collection (`CollectionId`).

--- a/src/Service/Route53/src/Exception/InvalidChangeBatchException.php
+++ b/src/Service/Route53/src/Exception/InvalidChangeBatchException.php
@@ -11,7 +11,7 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  */
 final class InvalidChangeBatchException extends ClientException
 {
-    private $messages = [];
+    private $messages;
 
     /**
      * @return string[]

--- a/src/Service/Route53/src/Result/ListHostedZonesByNameResponse.php
+++ b/src/Service/Route53/src/Result/ListHostedZonesByNameResponse.php
@@ -16,7 +16,7 @@ class ListHostedZonesByNameResponse extends Result
     /**
      * A complex type that contains general information about the hosted zone.
      */
-    private $hostedZones = [];
+    private $hostedZones;
 
     /**
      * For the second and subsequent calls to `ListHostedZonesByName`, `DNSName` is the value that you specified for the

--- a/src/Service/Route53/src/Result/ListHostedZonesResponse.php
+++ b/src/Service/Route53/src/Result/ListHostedZonesResponse.php
@@ -19,7 +19,7 @@ class ListHostedZonesResponse extends Result implements \IteratorAggregate
     /**
      * A complex type that contains general information about the hosted zone.
      */
-    private $hostedZones = [];
+    private $hostedZones;
 
     /**
      * For the second and subsequent calls to `ListHostedZones`, `Marker` is the value that you specified for the `marker`

--- a/src/Service/Route53/src/Result/ListResourceRecordSetsResponse.php
+++ b/src/Service/Route53/src/Result/ListResourceRecordSetsResponse.php
@@ -23,7 +23,7 @@ class ListResourceRecordSetsResponse extends Result implements \IteratorAggregat
     /**
      * Information about multiple resource record sets.
      */
-    private $resourceRecordSets = [];
+    private $resourceRecordSets;
 
     /**
      * A flag that indicates whether more resource record sets remain to be listed. If your results were truncated, you can

--- a/src/Service/S3/src/Result/DeleteObjectsOutput.php
+++ b/src/Service/S3/src/Result/DeleteObjectsOutput.php
@@ -13,7 +13,7 @@ class DeleteObjectsOutput extends Result
     /**
      * Container element for a successful delete. It identifies the object that was successfully deleted.
      */
-    private $deleted = [];
+    private $deleted;
 
     private $requestCharged;
 
@@ -21,7 +21,7 @@ class DeleteObjectsOutput extends Result
      * Container for a failed delete action that describes the object that Amazon S3 attempted to delete and the error it
      * encountered.
      */
-    private $errors = [];
+    private $errors;
 
     /**
      * @return DeletedObject[]

--- a/src/Service/S3/src/Result/GetBucketCorsOutput.php
+++ b/src/Service/S3/src/Result/GetBucketCorsOutput.php
@@ -12,7 +12,7 @@ class GetBucketCorsOutput extends Result
      * A set of origins and methods (cross-origin access that you want to allow). You can add up to 100 rules to the
      * configuration.
      */
-    private $corsRules = [];
+    private $corsRules;
 
     /**
      * @return CORSRule[]

--- a/src/Service/S3/src/Result/GetObjectAclOutput.php
+++ b/src/Service/S3/src/Result/GetObjectAclOutput.php
@@ -19,7 +19,7 @@ class GetObjectAclOutput extends Result
     /**
      * A list of grants.
      */
-    private $grants = [];
+    private $grants;
 
     private $requestCharged;
 

--- a/src/Service/S3/src/Result/GetObjectOutput.php
+++ b/src/Service/S3/src/Result/GetObjectOutput.php
@@ -119,7 +119,7 @@ class GetObjectOutput extends Result
     /**
      * A map of metadata to store with the object in S3.
      */
-    private $metadata = [];
+    private $metadata;
 
     /**
      * If server-side encryption with a customer-provided encryption key was requested, the response will include this

--- a/src/Service/S3/src/Result/HeadObjectOutput.php
+++ b/src/Service/S3/src/Result/HeadObjectOutput.php
@@ -119,7 +119,7 @@ class HeadObjectOutput extends Result
     /**
      * A map of metadata to store with the object in S3.
      */
-    private $metadata = [];
+    private $metadata;
 
     /**
      * If server-side encryption with a customer-provided encryption key was requested, the response will include this

--- a/src/Service/S3/src/Result/ListMultipartUploadsOutput.php
+++ b/src/Service/S3/src/Result/ListMultipartUploadsOutput.php
@@ -74,13 +74,13 @@ class ListMultipartUploadsOutput extends Result implements \IteratorAggregate
      * Container for elements related to a particular multipart upload. A response can contain zero or more `Upload`
      * elements.
      */
-    private $uploads = [];
+    private $uploads;
 
     /**
      * If you specify a delimiter in the request, then the result returns each distinct key prefix containing the delimiter
      * in a `CommonPrefixes` element. The distinct key prefixes are returned in the `Prefix` child element.
      */
-    private $commonPrefixes = [];
+    private $commonPrefixes;
 
     /**
      * Encoding type used by Amazon S3 to encode object keys in the response.

--- a/src/Service/S3/src/Result/ListObjectsV2Output.php
+++ b/src/Service/S3/src/Result/ListObjectsV2Output.php
@@ -26,7 +26,7 @@ class ListObjectsV2Output extends Result implements \IteratorAggregate
     /**
      * Metadata about each object returned.
      */
-    private $contents = [];
+    private $contents;
 
     /**
      * The bucket name.
@@ -55,7 +55,7 @@ class ListObjectsV2Output extends Result implements \IteratorAggregate
      * All of the keys (up to 1,000) rolled up into a common prefix count as a single return when calculating the number of
      * returns.
      */
-    private $commonPrefixes = [];
+    private $commonPrefixes;
 
     /**
      * Encoding type used by Amazon S3 to encode object key names in the XML response.

--- a/src/Service/S3/src/Result/ListPartsOutput.php
+++ b/src/Service/S3/src/Result/ListPartsOutput.php
@@ -76,7 +76,7 @@ class ListPartsOutput extends Result implements \IteratorAggregate
     /**
      * Container for elements related to a particular part. A response can contain zero or more `Part` elements.
      */
-    private $parts = [];
+    private $parts;
 
     /**
      * Container element that identifies who initiated the multipart upload. If the initiator is an Amazon Web Services

--- a/src/Service/SecretsManager/src/Result/CreateSecretResponse.php
+++ b/src/Service/SecretsManager/src/Result/CreateSecretResponse.php
@@ -26,7 +26,7 @@ class CreateSecretResponse extends Result
     /**
      * Describes a list of replication status objects as `InProgress`, `Failed` or `InSync`.
      */
-    private $replicationStatus = [];
+    private $replicationStatus;
 
     public function getArn(): ?string
     {

--- a/src/Service/SecretsManager/src/Result/GetSecretValueResponse.php
+++ b/src/Service/SecretsManager/src/Result/GetSecretValueResponse.php
@@ -38,7 +38,7 @@ class GetSecretValueResponse extends Result
     /**
      * A list of all of the staging labels currently attached to this version of the secret.
      */
-    private $versionStages = [];
+    private $versionStages;
 
     /**
      * The date and time that this version of the secret was created.

--- a/src/Service/SecretsManager/src/Result/ListSecretsResponse.php
+++ b/src/Service/SecretsManager/src/Result/ListSecretsResponse.php
@@ -19,7 +19,7 @@ class ListSecretsResponse extends Result implements \IteratorAggregate
     /**
      * A list of the secrets in the account.
      */
-    private $secretList = [];
+    private $secretList;
 
     /**
      * If present in the response, this value indicates that there's more output available than included in the current

--- a/src/Service/SecretsManager/src/Result/PutSecretValueResponse.php
+++ b/src/Service/SecretsManager/src/Result/PutSecretValueResponse.php
@@ -26,7 +26,7 @@ class PutSecretValueResponse extends Result
      * The list of staging labels that are currently attached to this version of the secret. Staging labels are used to
      * track a version as it progresses through the secret rotation process.
      */
-    private $versionStages = [];
+    private $versionStages;
 
     public function getArn(): ?string
     {

--- a/src/Service/Sns/src/Result/ListSubscriptionsByTopicResponse.php
+++ b/src/Service/Sns/src/Result/ListSubscriptionsByTopicResponse.php
@@ -19,7 +19,7 @@ class ListSubscriptionsByTopicResponse extends Result implements \IteratorAggreg
     /**
      * A list of subscriptions.
      */
-    private $subscriptions = [];
+    private $subscriptions;
 
     /**
      * Token to pass along to the next `ListSubscriptionsByTopic` request. This element is returned if there are more

--- a/src/Service/Sqs/src/Result/GetQueueAttributesResult.php
+++ b/src/Service/Sqs/src/Result/GetQueueAttributesResult.php
@@ -14,7 +14,7 @@ class GetQueueAttributesResult extends Result
     /**
      * A map of attributes to their respective values.
      */
-    private $attributes = [];
+    private $attributes;
 
     /**
      * @return array<QueueAttributeName::*, string>

--- a/src/Service/Sqs/src/Result/ListQueuesResult.php
+++ b/src/Service/Sqs/src/Result/ListQueuesResult.php
@@ -18,7 +18,7 @@ class ListQueuesResult extends Result implements \IteratorAggregate
     /**
      * A list of queue URLs, up to 1,000 entries, or the value of MaxResults that you sent in the request.
      */
-    private $queueUrls = [];
+    private $queueUrls;
 
     /**
      * Pagination token to include in the next request. Token value is `null` if there are no additional results to request,

--- a/src/Service/Sqs/src/Result/ReceiveMessageResult.php
+++ b/src/Service/Sqs/src/Result/ReceiveMessageResult.php
@@ -16,7 +16,7 @@ class ReceiveMessageResult extends Result
     /**
      * A list of messages.
      */
-    private $messages = [];
+    private $messages;
 
     /**
      * @return Message[]

--- a/src/Service/Ssm/src/Result/GetParametersByPathResult.php
+++ b/src/Service/Ssm/src/Result/GetParametersByPathResult.php
@@ -17,7 +17,7 @@ class GetParametersByPathResult extends Result implements \IteratorAggregate
     /**
      * A list of parameters found in the specified hierarchy.
      */
-    private $parameters = [];
+    private $parameters;
 
     /**
      * The token for the next set of items to return. Use this token to get the next set of results.

--- a/src/Service/Ssm/src/Result/GetParametersResult.php
+++ b/src/Service/Ssm/src/Result/GetParametersResult.php
@@ -11,12 +11,12 @@ class GetParametersResult extends Result
     /**
      * A list of details for a parameter.
      */
-    private $parameters = [];
+    private $parameters;
 
     /**
      * A list of parameters that aren't formatted correctly or don't run during an execution.
      */
-    private $invalidParameters = [];
+    private $invalidParameters;
 
     /**
      * @return string[]


### PR DESCRIPTION
remove redundant property initialization (ie. `private $attributes = [];`) because the property is over-hidden in object populator