### PR TITLE
Fix type check on list of map

### DIFF
--- a/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
@@ -226,7 +226,7 @@ class RestJsonParser implements Parser
             // prevent recursion
             $this->functions[$functionName] = true;
 
-            if ($shapeMember->getShape() instanceof StructureShape) {
+            if ($shapeMember->getShape() instanceof StructureShape || $shapeMember->getShape() instanceof ListShape || $shapeMember->getShape() instanceof MapShape) {
                 $listAccessorRequired = true;
                 $body = '
                     $items = [];

--- a/src/Service/DynamoDb/src/Result/BatchGetItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/BatchGetItemOutput.php
@@ -191,10 +191,7 @@ class BatchGetItemOutput extends Result implements \IteratorAggregate
     {
         $items = [];
         foreach ($json as $item) {
-            $a = empty($item) ? [] : $this->populateResultAttributeMap($item);
-            if (null !== $a) {
-                $items[] = $a;
-            }
+            $items[] = $this->populateResultAttributeMap($item);
         }
 
         return $items;

--- a/src/Service/DynamoDb/src/Result/QueryOutput.php
+++ b/src/Service/DynamoDb/src/Result/QueryOutput.php
@@ -182,10 +182,7 @@ class QueryOutput extends Result implements \IteratorAggregate
     {
         $items = [];
         foreach ($json as $item) {
-            $a = empty($item) ? [] : $this->populateResultAttributeMap($item);
-            if (null !== $a) {
-                $items[] = $a;
-            }
+            $items[] = $this->populateResultAttributeMap($item);
         }
 
         return $items;

--- a/src/Service/DynamoDb/src/Result/ScanOutput.php
+++ b/src/Service/DynamoDb/src/Result/ScanOutput.php
@@ -182,10 +182,7 @@ class ScanOutput extends Result implements \IteratorAggregate
     {
         $items = [];
         foreach ($json as $item) {
-            $a = empty($item) ? [] : $this->populateResultAttributeMap($item);
-            if (null !== $a) {
-                $items[] = $a;
-            }
+            $items[] = $this->populateResultAttributeMap($item);
         }
 
         return $items;

--- a/src/Service/RdsDataService/src/Result/ExecuteStatementResponse.php
+++ b/src/Service/RdsDataService/src/Result/ExecuteStatementResponse.php
@@ -209,10 +209,7 @@ class ExecuteStatementResponse extends Result
     {
         $items = [];
         foreach ($json as $item) {
-            $a = empty($item) ? [] : $this->populateResultFieldList($item);
-            if (null !== $a) {
-                $items[] = $a;
-            }
+            $items[] = $this->populateResultFieldList($item);
         }
 
         return $items;


### PR DESCRIPTION
In a list (and map), objects are always added to the list even when they are null.

In the same way, map and list should also be added even when they are empty