### PR TITLE
[CI 8.1] Allow more indirect deprecations

### DIFF
--- a/src/Integration/Laravel/Queue/phpunit.xml.dist
+++ b/src/Integration/Laravel/Queue/phpunit.xml.dist
@@ -13,7 +13,7 @@
     </include>
   </coverage>
   <php>
-    <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=2" />
+    <server name="SYMFONY_DEPRECATIONS_HELPER" value="disabled=1" />
     <ini name="error_reporting" value="-1"/>
   </php>
   <testsuites>

--- a/src/Integration/Laravel/Queue/phpunit.xml.dist
+++ b/src/Integration/Laravel/Queue/phpunit.xml.dist
@@ -7,15 +7,13 @@
          failOnRisky="true"
          failOnWarning="true"
 >
-  <php>
-    <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[indirect]=2" />
-  </php>
   <coverage>
     <include>
       <directory>./src</directory>
     </include>
   </coverage>
   <php>
+    <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[indirect]=2" />
     <ini name="error_reporting" value="-1"/>
   </php>
   <testsuites>

--- a/src/Integration/Laravel/Queue/phpunit.xml.dist
+++ b/src/Integration/Laravel/Queue/phpunit.xml.dist
@@ -7,6 +7,9 @@
          failOnRisky="true"
          failOnWarning="true"
 >
+  <php>
+    <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[indirect]=2" />
+  </php>
   <coverage>
     <include>
       <directory>./src</directory>

--- a/src/Integration/Laravel/Queue/phpunit.xml.dist
+++ b/src/Integration/Laravel/Queue/phpunit.xml.dist
@@ -13,7 +13,7 @@
     </include>
   </coverage>
   <php>
-    <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
+    <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=2" />
     <ini name="error_reporting" value="-1"/>
   </php>
   <testsuites>

--- a/src/Integration/Laravel/Queue/phpunit.xml.dist
+++ b/src/Integration/Laravel/Queue/phpunit.xml.dist
@@ -13,7 +13,7 @@
     </include>
   </coverage>
   <php>
-    <server name="SYMFONY_DEPRECATIONS_HELPER" value="disabled=1" />
+    <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
     <ini name="error_reporting" value="-1"/>
   </php>
   <testsuites>

--- a/src/Integration/Laravel/Queue/phpunit.xml.dist
+++ b/src/Integration/Laravel/Queue/phpunit.xml.dist
@@ -13,7 +13,7 @@
     </include>
   </coverage>
   <php>
-    <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[indirect]=2" />
+    <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
     <ini name="error_reporting" value="-1"/>
   </php>
   <testsuites>

--- a/src/Integration/Laravel/Queue/phpunit.xml.dist
+++ b/src/Integration/Laravel/Queue/phpunit.xml.dist
@@ -13,7 +13,7 @@
     </include>
   </coverage>
   <php>
-    <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=2" />
+    <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=2" />
     <ini name="error_reporting" value="-1"/>
   </php>
   <testsuites>

--- a/src/Integration/Symfony/Bundle/phpunit.xml.dist
+++ b/src/Integration/Symfony/Bundle/phpunit.xml.dist
@@ -7,9 +7,6 @@
          failOnRisky="true"
          failOnWarning="true"
 >
-  <php>
-    <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[indirect]=2" />
-  </php>
   <coverage>
     <include>
       <directory>./src</directory>
@@ -17,7 +14,7 @@
   </coverage>
   <php>
     <ini name="error_reporting" value="-1"/>
-    <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[direct]=0" />
+    <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0" />
   </php>
   <testsuites>
     <testsuite name="Test Suite">

--- a/src/Integration/Symfony/Bundle/phpunit.xml.dist
+++ b/src/Integration/Symfony/Bundle/phpunit.xml.dist
@@ -7,6 +7,9 @@
          failOnRisky="true"
          failOnWarning="true"
 >
+  <php>
+    <server name="SYMFONY_DEPRECATIONS_HELPER" value="max[indirect]=2" />
+  </php>
   <coverage>
     <include>
       <directory>./src</directory>


### PR DESCRIPTION
I make this PR to get a green CI on 8.1

We "allow" PHP deprecations in Ramsey/uuid and Symfony. 