### PR TITLE
Fixes dom class naming.

### DIFF
--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
@@ -84,7 +84,7 @@ class RestXmlSerializer implements Serializer
             $document->formatOutput = false;
             ' . $requestBody . '
             $body = $document->hasChildNodes() ? $document->saveXML() : "";
-        ',  true, ['node' => '\DOMNode']];
+        ',  true, ['node' => \DOMNode::class]];
     }
 
     public function generateRequestBuilder(StructureShape $shape): array
@@ -125,7 +125,7 @@ class RestXmlSerializer implements Serializer
             ]);
         }, $shape->getMembers()));
 
-        return ['void', $body, ['node' => '\DOMElement', 'document' => '\DOMDocument']];
+        return ['void', $body, ['node' => \DOMElement::class, 'document' => \DOMDocument::class]];
     }
 
     private function dumpXmlShape(Member $member, Shape $shape, string $output, string $input): string

--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
@@ -84,7 +84,7 @@ class RestXmlSerializer implements Serializer
             $document->formatOutput = false;
             ' . $requestBody . '
             $body = $document->hasChildNodes() ? $document->saveXML() : "";
-        ',  true, ['node' => '\DomNode']];
+        ',  true, ['node' => '\DOMNode']];
     }
 
     public function generateRequestBuilder(StructureShape $shape): array
@@ -125,7 +125,7 @@ class RestXmlSerializer implements Serializer
             ]);
         }, $shape->getMembers()));
 
-        return ['void', $body, ['node' => '\DomElement', 'document' => '\DomDocument']];
+        return ['void', $body, ['node' => '\DOMElement', 'document' => '\DOMDocument']];
     }
 
     private function dumpXmlShape(Member $member, Shape $shape, string $output, string $input): string

--- a/src/Service/CloudFront/src/Input/CreateInvalidationRequest.php
+++ b/src/Service/CloudFront/src/Input/CreateInvalidationRequest.php
@@ -104,7 +104,7 @@ final class CreateInvalidationRequest extends Input
         return $this;
     }
 
-    private function requestBody(\DomNode $node, \DomDocument $document): void
+    private function requestBody(\DOMNode $node, \DOMDocument $document): void
     {
         if (null === $v = $this->invalidationBatch) {
             throw new InvalidArgument(sprintf('Missing parameter "InvalidationBatch" for "%s". The value cannot be null.', __CLASS__));

--- a/src/Service/CloudFront/src/ValueObject/InvalidationBatch.php
+++ b/src/Service/CloudFront/src/ValueObject/InvalidationBatch.php
@@ -55,7 +55,7 @@ final class InvalidationBatch
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null === $v = $this->paths) {
             throw new InvalidArgument(sprintf('Missing parameter "Paths" for "%s". The value cannot be null.', __CLASS__));

--- a/src/Service/CloudFront/src/ValueObject/Paths.php
+++ b/src/Service/CloudFront/src/ValueObject/Paths.php
@@ -55,7 +55,7 @@ final class Paths
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null === $v = $this->quantity) {
             throw new InvalidArgument(sprintf('Missing parameter "Quantity" for "%s". The value cannot be null.', __CLASS__));

--- a/src/Service/Route53/src/Input/ChangeResourceRecordSetsRequest.php
+++ b/src/Service/Route53/src/Input/ChangeResourceRecordSetsRequest.php
@@ -107,7 +107,7 @@ final class ChangeResourceRecordSetsRequest extends Input
         return $this;
     }
 
-    private function requestBody(\DomNode $node, \DomDocument $document): void
+    private function requestBody(\DOMNode $node, \DOMDocument $document): void
     {
         if (null === $v = $this->changeBatch) {
             throw new InvalidArgument(sprintf('Missing parameter "ChangeBatch" for "%s". The value cannot be null.', __CLASS__));

--- a/src/Service/Route53/src/Input/CreateHostedZoneRequest.php
+++ b/src/Service/Route53/src/Input/CreateHostedZoneRequest.php
@@ -174,7 +174,7 @@ final class CreateHostedZoneRequest extends Input
         return $this;
     }
 
-    private function requestBody(\DomNode $node, \DomDocument $document): void
+    private function requestBody(\DOMNode $node, \DOMDocument $document): void
     {
         if (null === $v = $this->name) {
             throw new InvalidArgument(sprintf('Missing parameter "Name" for "%s". The value cannot be null.', __CLASS__));

--- a/src/Service/Route53/src/ValueObject/AliasTarget.php
+++ b/src/Service/Route53/src/ValueObject/AliasTarget.php
@@ -74,7 +74,7 @@ final class AliasTarget
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null === $v = $this->hostedZoneId) {
             throw new InvalidArgument(sprintf('Missing parameter "HostedZoneId" for "%s". The value cannot be null.', __CLASS__));

--- a/src/Service/Route53/src/ValueObject/Change.php
+++ b/src/Service/Route53/src/ValueObject/Change.php
@@ -53,7 +53,7 @@ final class Change
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null === $v = $this->action) {
             throw new InvalidArgument(sprintf('Missing parameter "Action" for "%s". The value cannot be null.', __CLASS__));

--- a/src/Service/Route53/src/ValueObject/ChangeBatch.php
+++ b/src/Service/Route53/src/ValueObject/ChangeBatch.php
@@ -52,7 +52,7 @@ final class ChangeBatch
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->comment) {
             $node->appendChild($document->createElement('Comment', $v));

--- a/src/Service/Route53/src/ValueObject/GeoLocation.php
+++ b/src/Service/Route53/src/ValueObject/GeoLocation.php
@@ -88,7 +88,7 @@ final class GeoLocation
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->continentCode) {
             $node->appendChild($document->createElement('ContinentCode', $v));

--- a/src/Service/Route53/src/ValueObject/HostedZoneConfig.php
+++ b/src/Service/Route53/src/ValueObject/HostedZoneConfig.php
@@ -52,7 +52,7 @@ final class HostedZoneConfig
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->comment) {
             $node->appendChild($document->createElement('Comment', $v));

--- a/src/Service/Route53/src/ValueObject/ResourceRecord.php
+++ b/src/Service/Route53/src/ValueObject/ResourceRecord.php
@@ -43,7 +43,7 @@ final class ResourceRecord
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null === $v = $this->value) {
             throw new InvalidArgument(sprintf('Missing parameter "Value" for "%s". The value cannot be null.', __CLASS__));

--- a/src/Service/Route53/src/ValueObject/ResourceRecordSet.php
+++ b/src/Service/Route53/src/ValueObject/ResourceRecordSet.php
@@ -221,7 +221,7 @@ final class ResourceRecordSet
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null === $v = $this->name) {
             throw new InvalidArgument(sprintf('Missing parameter "Name" for "%s". The value cannot be null.', __CLASS__));

--- a/src/Service/Route53/src/ValueObject/VPC.php
+++ b/src/Service/Route53/src/ValueObject/VPC.php
@@ -55,7 +55,7 @@ final class VPC
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->vpcRegion) {
             if (!VPCRegion::exists($v)) {

--- a/src/Service/S3/src/Input/CompleteMultipartUploadRequest.php
+++ b/src/Service/S3/src/Input/CompleteMultipartUploadRequest.php
@@ -210,7 +210,7 @@ final class CompleteMultipartUploadRequest extends Input
         return $this;
     }
 
-    private function requestBody(\DomNode $node, \DomDocument $document): void
+    private function requestBody(\DOMNode $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->multipartUpload) {
             $node->appendChild($child = $document->createElement('CompleteMultipartUpload'));

--- a/src/Service/S3/src/Input/CreateBucketRequest.php
+++ b/src/Service/S3/src/Input/CreateBucketRequest.php
@@ -277,7 +277,7 @@ final class CreateBucketRequest extends Input
         return $this;
     }
 
-    private function requestBody(\DomNode $node, \DomDocument $document): void
+    private function requestBody(\DOMNode $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->createBucketConfiguration) {
             $node->appendChild($child = $document->createElement('CreateBucketConfiguration'));

--- a/src/Service/S3/src/Input/DeleteObjectsRequest.php
+++ b/src/Service/S3/src/Input/DeleteObjectsRequest.php
@@ -209,7 +209,7 @@ final class DeleteObjectsRequest extends Input
         return $this;
     }
 
-    private function requestBody(\DomNode $node, \DomDocument $document): void
+    private function requestBody(\DOMNode $node, \DOMDocument $document): void
     {
         if (null === $v = $this->delete) {
             throw new InvalidArgument(sprintf('Missing parameter "Delete" for "%s". The value cannot be null.', __CLASS__));

--- a/src/Service/S3/src/Input/PutBucketCorsRequest.php
+++ b/src/Service/S3/src/Input/PutBucketCorsRequest.php
@@ -155,7 +155,7 @@ final class PutBucketCorsRequest extends Input
         return $this;
     }
 
-    private function requestBody(\DomNode $node, \DomDocument $document): void
+    private function requestBody(\DOMNode $node, \DOMDocument $document): void
     {
         if (null === $v = $this->corsConfiguration) {
             throw new InvalidArgument(sprintf('Missing parameter "CORSConfiguration" for "%s". The value cannot be null.', __CLASS__));

--- a/src/Service/S3/src/Input/PutBucketNotificationConfigurationRequest.php
+++ b/src/Service/S3/src/Input/PutBucketNotificationConfigurationRequest.php
@@ -124,7 +124,7 @@ final class PutBucketNotificationConfigurationRequest extends Input
         return $this;
     }
 
-    private function requestBody(\DomNode $node, \DomDocument $document): void
+    private function requestBody(\DOMNode $node, \DOMDocument $document): void
     {
         if (null === $v = $this->notificationConfiguration) {
             throw new InvalidArgument(sprintf('Missing parameter "NotificationConfiguration" for "%s". The value cannot be null.', __CLASS__));

--- a/src/Service/S3/src/Input/PutObjectAclRequest.php
+++ b/src/Service/S3/src/Input/PutObjectAclRequest.php
@@ -392,7 +392,7 @@ final class PutObjectAclRequest extends Input
         return $this;
     }
 
-    private function requestBody(\DomNode $node, \DomDocument $document): void
+    private function requestBody(\DOMNode $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->accessControlPolicy) {
             $node->appendChild($child = $document->createElement('AccessControlPolicy'));

--- a/src/Service/S3/src/ValueObject/AccessControlPolicy.php
+++ b/src/Service/S3/src/ValueObject/AccessControlPolicy.php
@@ -50,7 +50,7 @@ final class AccessControlPolicy
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->grants) {
             $node->appendChild($nodeList = $document->createElement('AccessControlList'));

--- a/src/Service/S3/src/ValueObject/CORSConfiguration.php
+++ b/src/Service/S3/src/ValueObject/CORSConfiguration.php
@@ -44,7 +44,7 @@ final class CORSConfiguration
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null === $v = $this->corsRules) {
             throw new InvalidArgument(sprintf('Missing parameter "CORSRules" for "%s". The value cannot be null.', __CLASS__));

--- a/src/Service/S3/src/ValueObject/CORSRule.php
+++ b/src/Service/S3/src/ValueObject/CORSRule.php
@@ -112,7 +112,7 @@ final class CORSRule
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->id) {
             $node->appendChild($document->createElement('ID', $v));

--- a/src/Service/S3/src/ValueObject/CompletedMultipartUpload.php
+++ b/src/Service/S3/src/ValueObject/CompletedMultipartUpload.php
@@ -38,7 +38,7 @@ final class CompletedMultipartUpload
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->parts) {
             foreach ($v as $item) {

--- a/src/Service/S3/src/ValueObject/CompletedPart.php
+++ b/src/Service/S3/src/ValueObject/CompletedPart.php
@@ -47,7 +47,7 @@ final class CompletedPart
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->etag) {
             $node->appendChild($document->createElement('ETag', $v));

--- a/src/Service/S3/src/ValueObject/CreateBucketConfiguration.php
+++ b/src/Service/S3/src/ValueObject/CreateBucketConfiguration.php
@@ -42,7 +42,7 @@ final class CreateBucketConfiguration
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->locationConstraint) {
             if (!BucketLocationConstraint::exists($v)) {

--- a/src/Service/S3/src/ValueObject/Delete.php
+++ b/src/Service/S3/src/ValueObject/Delete.php
@@ -52,7 +52,7 @@ final class Delete
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null === $v = $this->objects) {
             throw new InvalidArgument(sprintf('Missing parameter "Objects" for "%s". The value cannot be null.', __CLASS__));

--- a/src/Service/S3/src/ValueObject/FilterRule.php
+++ b/src/Service/S3/src/ValueObject/FilterRule.php
@@ -57,7 +57,7 @@ final class FilterRule
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->name) {
             if (!FilterRuleName::exists($v)) {

--- a/src/Service/S3/src/ValueObject/Grant.php
+++ b/src/Service/S3/src/ValueObject/Grant.php
@@ -53,7 +53,7 @@ final class Grant
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->grantee) {
             $node->appendChild($child = $document->createElement('Grantee'));

--- a/src/Service/S3/src/ValueObject/Grantee.php
+++ b/src/Service/S3/src/ValueObject/Grantee.php
@@ -89,7 +89,7 @@ final class Grantee
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->displayName) {
             $node->appendChild($document->createElement('DisplayName', $v));

--- a/src/Service/S3/src/ValueObject/LambdaFunctionConfiguration.php
+++ b/src/Service/S3/src/ValueObject/LambdaFunctionConfiguration.php
@@ -74,7 +74,7 @@ final class LambdaFunctionConfiguration
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->id) {
             $node->appendChild($document->createElement('Id', $v));

--- a/src/Service/S3/src/ValueObject/NotificationConfiguration.php
+++ b/src/Service/S3/src/ValueObject/NotificationConfiguration.php
@@ -65,7 +65,7 @@ final class NotificationConfiguration
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->topicConfigurations) {
             foreach ($v as $item) {

--- a/src/Service/S3/src/ValueObject/NotificationConfigurationFilter.php
+++ b/src/Service/S3/src/ValueObject/NotificationConfigurationFilter.php
@@ -29,7 +29,7 @@ final class NotificationConfigurationFilter
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->key) {
             $node->appendChild($child = $document->createElement('S3Key'));

--- a/src/Service/S3/src/ValueObject/ObjectIdentifier.php
+++ b/src/Service/S3/src/ValueObject/ObjectIdentifier.php
@@ -49,7 +49,7 @@ final class ObjectIdentifier
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null === $v = $this->key) {
             throw new InvalidArgument(sprintf('Missing parameter "Key" for "%s". The value cannot be null.', __CLASS__));

--- a/src/Service/S3/src/ValueObject/Owner.php
+++ b/src/Service/S3/src/ValueObject/Owner.php
@@ -47,7 +47,7 @@ final class Owner
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->displayName) {
             $node->appendChild($document->createElement('DisplayName', $v));

--- a/src/Service/S3/src/ValueObject/QueueConfiguration.php
+++ b/src/Service/S3/src/ValueObject/QueueConfiguration.php
@@ -73,7 +73,7 @@ final class QueueConfiguration
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->id) {
             $node->appendChild($document->createElement('Id', $v));

--- a/src/Service/S3/src/ValueObject/S3KeyFilter.php
+++ b/src/Service/S3/src/ValueObject/S3KeyFilter.php
@@ -32,7 +32,7 @@ final class S3KeyFilter
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->filterRules) {
             foreach ($v as $item) {

--- a/src/Service/S3/src/ValueObject/TopicConfiguration.php
+++ b/src/Service/S3/src/ValueObject/TopicConfiguration.php
@@ -76,7 +76,7 @@ final class TopicConfiguration
     /**
      * @internal
      */
-    public function requestBody(\DomElement $node, \DomDocument $document): void
+    public function requestBody(\DOMElement $node, \DOMDocument $document): void
     {
         if (null !== $v = $this->id) {
             $node->appendChild($document->createElement('Id', $v));


### PR DESCRIPTION
This pull request replaces all instances of DomDocument, DomElement and DomNode with DOMDocument, DOMElement and DOMNode respectively, in order to prevent PHP scoper issues as described here: humbug/php-scoper#367, and here: humbug/php-scoper#393.

At the same time the naming of these classes is more correct, see https://www.php.net/manual/en/book.dom.