### PR TITLE
Remove invalid reference

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,6 @@
             "AsyncAws\\CodeDeploy\\Tests\\": "src/Service/CodeDeploy/tests",
             "AsyncAws\\CognitoIdentityProvider\\Tests\\": "src/Service/CognitoIdentityProvider/tests",
             "AsyncAws\\DynamoDb\\Tests\\": "src/Service/DynamoDb/tests",
-            "AsyncAws\\CodeGenerator\\Tests\\": "src/CodeGenerator/tests",
             "AsyncAws\\Core\\Tests\\": "src/Core/tests",
             "AsyncAws\\Ecr\\Tests\\": "src/Service/Ecr/tests",
             "AsyncAws\\ElastiCache\\Tests\\": "src/Service/ElastiCache/tests",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,7 +16,6 @@
   <testsuites>
     <testsuite name="Test Suite">
       <directory>./tests/</directory>
-      <directory>./src/CodeGenerator/tests/</directory>
       <directory>./src/Core/tests/</directory>
       <directory>./src/Service/*/tests/</directory>
       <directory>./src/Integration/*/tests/</directory>


### PR DESCRIPTION
Fixes 
```
PHPUnit 9.5.10 by Sebastian Bergmann and contributors.

Test directory "/home/runner/work/aws/aws/./src/CodeGenerator/tests/" not found
Error: Process completed with exit code 2.
```