### PR TITLE
Avoid breaking php-generator version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "league/mime-type-detection": "^1.0",
         "matthiasnoback/symfony-config-test": "^4.1",
         "monolog/monolog": "^1.1 || ^2.0",
-        "nette/php-generator": "^3.3",
+        "nette/php-generator": "^3.3,!=3.6.3",
         "nette/utils": "^3.0",
         "nyholm/symfony-bundle-test": "^1.6.1",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",


### PR DESCRIPTION
The last version of php-generator breaks the returnType name.
See https://github.com/nette/php-generator/pull/94

This PR prevents us to upgrade to this version.