### PR TITLE
Add a hook system to handle Route53 paramter trim

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -300,6 +300,28 @@
                 "ListHostedZones",
                 "ListHostedZonesByName",
                 "ListResourceRecordSets"
+            ],
+            "hooks": [
+                {
+                    "target": "uri_parameters",
+                    "options": {
+                        "filters": [
+                            "Id",
+                            "HostedZoneId",
+                            "DelegationSetId"
+                        ],
+                        "action": {
+                            "type": "remove_left",
+                            "options": {
+                                "values": [
+                                    "/hostedzone/",
+                                    "/change/",
+                                    "/delegationset/"
+                                ]
+                            }
+                        }
+                    }
+                }
             ]
         },
         "S3": {

--- a/src/CodeGenerator/src/Command/GenerateCommand.php
+++ b/src/CodeGenerator/src/Command/GenerateCommand.php
@@ -263,7 +263,7 @@ class GenerateCommand extends Command
         }
 
         $managedOperations = array_unique(array_merge($manifest['services'][$serviceName]['methods'], $operationNames));
-        $definition = new ServiceDefinition($serviceName, $endpoints, $definitionArray, $documentationArray, $paginationArray, $waiterArray, $exampleArray, $manifest['services'][$serviceName]['api-reference'] ?? null);
+        $definition = new ServiceDefinition($serviceName, $endpoints, $definitionArray, $documentationArray, $paginationArray, $waiterArray, $exampleArray, $manifest['services'][$serviceName]['hooks'] ?? [], $manifest['services'][$serviceName]['api-reference'] ?? null);
         $serviceGenerator = $this->generator->service($namespace = $manifest['services'][$serviceName]['namespace'] ?? sprintf('AsyncAws\\%s', $serviceName), $managedOperations);
 
         $clientClass = $serviceGenerator->client()->generate($definition);

--- a/src/CodeGenerator/src/Definition/Hook.php
+++ b/src/CodeGenerator/src/Definition/Hook.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\CodeGenerator\Definition;
+
+class Hook
+{
+    /**
+     * @var array
+     */
+    protected $data;
+
+    public function __construct(array $data)
+    {
+        $this->data = $data;
+    }
+
+    public function getFilters(): array
+    {
+        return $this->data['filters'] ?? [];
+    }
+
+    public function getAction(): ?string
+    {
+        return $this->data['action']['type'] ?? null;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->data['action']['options'] ?? [];
+    }
+}

--- a/src/CodeGenerator/src/Definition/ServiceDefinition.php
+++ b/src/CodeGenerator/src/Definition/ServiceDefinition.php
@@ -27,9 +27,13 @@ class ServiceDefinition
 
     private $example;
 
+    private $hooks;
+
+    private $hooksByTarget;
+
     private $apiReferenceUrl;
 
-    public function __construct(string $name, array $endpoints, array $definition, array $documentation, array $pagination, array $waiter, array $example, string $apiReferenceUrl)
+    public function __construct(string $name, array $endpoints, array $definition, array $documentation, array $pagination, array $waiter, array $example, array $hooks, string $apiReferenceUrl)
     {
         $this->name = $name;
         $this->endpoints = $endpoints;
@@ -39,6 +43,7 @@ class ServiceDefinition
         $this->waiter = $waiter;
         $this->example = $example;
         $this->apiReferenceUrl = $apiReferenceUrl;
+        $this->hooks = $hooks;
     }
 
     public function getName(): string
@@ -108,6 +113,21 @@ class ServiceDefinition
     public function getApiReferenceUrl(): string
     {
         return $this->apiReferenceUrl;
+    }
+
+    /**
+     * @return Hook[]
+     */
+    public function getHooks(string $target): array
+    {
+        if (null === $this->hooksByTarget) {
+            $this->hooksByTarget = [];
+            foreach ($this->hooks as $hook) {
+                $this->hooksByTarget[$hook['target']][] = new Hook($hook['options']);
+            }
+        }
+
+        return $this->hooksByTarget[$target] ?? [];
     }
 
     private function getPagination(string $name): ?Pagination

--- a/src/CodeGenerator/src/Generator/HookGenerator.php
+++ b/src/CodeGenerator/src/Generator/HookGenerator.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\CodeGenerator\Generator;
+
+use AsyncAws\CodeGenerator\Definition\Hook;
+
+/**
+ * Generate Hook code.
+ *
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal
+ */
+class HookGenerator
+{
+    /**
+     * Generate code for hooks.
+     */
+    public function generate(Hook $hook, string $input): string
+    {
+        switch ($hook->getAction()) {
+            case 'remove_left':
+                return $this->removeLeft($hook->getOptions()['values'] ?? [], $input);
+        }
+
+        throw new \RuntimeException('Hook ' . $hook->getAction() . ' is not yet implemented');
+    }
+
+    private function removeLeft(array $values, $input): string
+    {
+        return strtr('VALUE = preg_replace("#^(VALUES)#", "", VALUE);', [
+            'VALUES' => implode('|', array_map(function ($value) {
+                return preg_quote($value, '#');
+            }, $values)),
+            'INPUT' => $input,
+        ]);
+    }
+}

--- a/src/CodeGenerator/src/Generator/ServiceGenerator.php
+++ b/src/CodeGenerator/src/Generator/ServiceGenerator.php
@@ -69,6 +69,11 @@ class ServiceGenerator
     private $enum;
 
     /**
+     * @var HookGenerator
+     */
+    private $hook;
+
+    /**
      * @var ObjectGenerator
      */
     private $object;
@@ -148,7 +153,7 @@ class ServiceGenerator
 
     public function input(): InputGenerator
     {
-        return $this->input ?? $this->input = new InputGenerator($this->classRegistry, $this->namespaceRegistry, $this->requirementsRegistry, $this->object(), $this->type(), $this->enum());
+        return $this->input ?? $this->input = new InputGenerator($this->classRegistry, $this->namespaceRegistry, $this->requirementsRegistry, $this->object(), $this->type(), $this->enum(), $this->hook());
     }
 
     public function type(): TypeGenerator
@@ -159,6 +164,11 @@ class ServiceGenerator
     public function enum(): EnumGenerator
     {
         return $this->enum ?? $this->enum = new EnumGenerator($this->classRegistry, $this->namespaceRegistry);
+    }
+
+    public function hook(): HookGenerator
+    {
+        return $this->hook ?? $this->hook = new HookGenerator();
     }
 
     public function object(): ObjectGenerator

--- a/src/Service/Route53/src/Input/ChangeResourceRecordSetsRequest.php
+++ b/src/Service/Route53/src/Input/ChangeResourceRecordSetsRequest.php
@@ -77,6 +77,7 @@ final class ChangeResourceRecordSetsRequest extends Input
         if (null === $v = $this->hostedZoneId) {
             throw new InvalidArgument(sprintf('Missing parameter "HostedZoneId" for "%s". The value cannot be null.', __CLASS__));
         }
+        $v = preg_replace('#^(/hostedzone/|/change/|/delegationset/)#', '', $v);
         $uri['Id'] = $v;
         $uriString = '/2013-04-01/hostedzone/' . rawurlencode($uri['Id']) . '/rrset/';
 

--- a/src/Service/Route53/src/Input/DeleteHostedZoneRequest.php
+++ b/src/Service/Route53/src/Input/DeleteHostedZoneRequest.php
@@ -59,6 +59,7 @@ final class DeleteHostedZoneRequest extends Input
         if (null === $v = $this->id) {
             throw new InvalidArgument(sprintf('Missing parameter "Id" for "%s". The value cannot be null.', __CLASS__));
         }
+        $v = preg_replace('#^(/hostedzone/|/change/|/delegationset/)#', '', $v);
         $uri['Id'] = $v;
         $uriString = '/2013-04-01/hostedzone/' . rawurlencode($uri['Id']);
 

--- a/src/Service/Route53/src/Input/ListResourceRecordSetsRequest.php
+++ b/src/Service/Route53/src/Input/ListResourceRecordSetsRequest.php
@@ -141,6 +141,7 @@ final class ListResourceRecordSetsRequest extends Input
         if (null === $v = $this->hostedZoneId) {
             throw new InvalidArgument(sprintf('Missing parameter "HostedZoneId" for "%s". The value cannot be null.', __CLASS__));
         }
+        $v = preg_replace('#^(/hostedzone/|/change/|/delegationset/)#', '', $v);
         $uri['Id'] = $v;
         $uriString = '/2013-04-01/hostedzone/' . rawurlencode($uri['Id']) . '/rrset';
 

--- a/src/Service/Route53/tests/Integration/Route53ClientTest.php
+++ b/src/Service/Route53/tests/Integration/Route53ClientTest.php
@@ -36,7 +36,7 @@ class Route53ClientTest extends TestCase
         $result = $client->createHostedZone($input);
 
         $input = new ChangeResourceRecordSetsRequest([
-            'HostedZoneId' => $this->formatId($result->getHostedZone()->getId()),
+            'HostedZoneId' => $result->getHostedZone()->getId(),
             'ChangeBatch' => new ChangeBatch([
                 'Changes' => [
                     new Change([
@@ -112,7 +112,7 @@ class Route53ClientTest extends TestCase
         $zonesBefore = \count(iterator_to_array($client->ListHostedZones()->getHostedZones()));
 
         $input = new DeleteHostedZoneRequest([
-            'Id' => $this->formatId($result->getHostedZone()->getId()),
+            'Id' => $result->getHostedZone()->getId(),
         ]);
         $result = $client->deleteHostedZone($input);
         $result->resolve();
@@ -174,7 +174,7 @@ class Route53ClientTest extends TestCase
         $hostedZoneId = $result->getHostedZone()->getId();
 
         $input = new ChangeResourceRecordSetsRequest([
-            'HostedZoneId' => $this->formatId($hostedZoneId),
+            'HostedZoneId' => $hostedZoneId,
             'ChangeBatch' => new ChangeBatch([
                 'Changes' => [
                     new Change([
@@ -213,7 +213,7 @@ class Route53ClientTest extends TestCase
         $result->resolve();
 
         $input = new ListResourceRecordSetsRequest([
-            'HostedZoneId' => $this->formatId($hostedZoneId),
+            'HostedZoneId' => $hostedZoneId,
             'MaxItems' => '5',
         ]);
         $result = $client->listResourceRecordSets($input);
@@ -231,14 +231,9 @@ class Route53ClientTest extends TestCase
 
         foreach ($client->ListHostedZones()->getHostedZones() as $zone) {
             if ($zone->getName() === $domain) {
-                $client->deleteHostedZone(['Id' => $this->formatId($zone->getId())]);
+                $client->deleteHostedZone(['Id' => $zone->getId()]);
             }
         }
-    }
-
-    private function formatId(string $id): string
-    {
-        return ltrim($id, '/hostedzone/');
     }
 
     private function getClient(): Route53Client


### PR DESCRIPTION
The official Route53 client have a special custom code that trim some fields:

https://github.com/aws/aws-sdk-php/blob/39b13305a310099a8a9bc27b4770c382f0157c2e/src/Route53/Route53Client.php#L148-L167
