### PR TITLE
Added CloudFormation DescribeStackDriftDetectionStatus

### DIFF
--- a/docs/clients/cf.md
+++ b/docs/clients/cf.md
@@ -37,3 +37,16 @@ foreach ($result->getStackEvents() as $event) {
     echo $event->getResourceType().'-'.$event->getResourceStatus().PHP_EOL;
 }
 ```
+
+### Detect Stack Drift Status
+
+```php
+use AsyncAws\CloudFormation\CloudFormationClient;
+use AsyncAws\CloudFormation\Input\DescribeStackEventsInput;
+
+$cloudFormation = new CloudFormationClient();
+
+$driftStatus = $cloudFormation->describeStackDriftDetectionStatus([
+    'StackDriftDetectionId' => 'b78ac9b0-dec1-11e7-a451-503a3example',
+]);
+```

--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,7 @@
             "example": "https://raw.githubusercontent.com/aws/aws-sdk-php/${LATEST}/src/data/cloudformation/2010-05-15/examples-1.json",
             "api-reference": "https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference",
             "methods": [
+                "DescribeStackDriftDetectionStatus",
                 "DescribeStackEvents",
                 "DescribeStacks"
             ]

--- a/src/Service/CloudFormation/CHANGELOG.md
+++ b/src/Service/CloudFormation/CHANGELOG.md
@@ -7,6 +7,7 @@
 - AWS api-change: Added `us-iso-west-1` region
 - AWS api-change: Use specific configuration for `us` regions
 - AWS enhancement: Documentation updates.
+- Added `describeStackDriftDetectionStatus` method.
 
 ## 1.1.0
 

--- a/src/Service/CloudFormation/src/CloudFormationClient.php
+++ b/src/Service/CloudFormation/src/CloudFormationClient.php
@@ -37,6 +37,7 @@ class CloudFormationClient extends AbstractApi
     {
         $input = DescribeStackDriftDetectionStatusInput::create($input);
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DescribeStackDriftDetectionStatus', 'region' => $input->getRegion()]));
+        
         return new DescribeStackDriftDetectionStatusOutput($response);
     }
 

--- a/src/Service/CloudFormation/src/CloudFormationClient.php
+++ b/src/Service/CloudFormation/src/CloudFormationClient.php
@@ -37,7 +37,7 @@ class CloudFormationClient extends AbstractApi
     {
         $input = DescribeStackDriftDetectionStatusInput::create($input);
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DescribeStackDriftDetectionStatus', 'region' => $input->getRegion()]));
-        
+
         return new DescribeStackDriftDetectionStatusOutput($response);
     }
 

--- a/src/Service/CloudFormation/src/CloudFormationClient.php
+++ b/src/Service/CloudFormation/src/CloudFormationClient.php
@@ -2,8 +2,10 @@
 
 namespace AsyncAws\CloudFormation;
 
+use AsyncAws\CloudFormation\Input\DescribeStackDriftDetectionStatusInput;
 use AsyncAws\CloudFormation\Input\DescribeStackEventsInput;
 use AsyncAws\CloudFormation\Input\DescribeStacksInput;
+use AsyncAws\CloudFormation\Result\DescribeStackDriftDetectionStatusOutput;
 use AsyncAws\CloudFormation\Result\DescribeStackEventsOutput;
 use AsyncAws\CloudFormation\Result\DescribeStacksOutput;
 use AsyncAws\CloudFormation\ValueObject\Stack;
@@ -15,6 +17,29 @@ use AsyncAws\Core\RequestContext;
 
 class CloudFormationClient extends AbstractApi
 {
+    /**
+     * Returns information about a stack drift detection operation. A stack drift detection operation detects whether a
+     * stack's actual configuration differs, or has *drifted*, from it's expected configuration, as defined in the stack
+     * template and any values specified as template parameters. A stack is considered to have drifted if one or more of its
+     * resources have drifted. For more information on stack and resource drift, see Detecting Unregulated Configuration
+     * Changes to Stacks and Resources.
+     *
+     * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-stack-drift.html
+     * @see https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DescribeStackDriftDetectionStatus.html
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-cloudformation-2010-05-15.html#describestackdriftdetectionstatus
+     *
+     * @param array{
+     *   StackDriftDetectionId: string,
+     *   @region?: string,
+     * }|DescribeStackDriftDetectionStatusInput $input
+     */
+    public function describeStackDriftDetectionStatus($input): DescribeStackDriftDetectionStatusOutput
+    {
+        $input = DescribeStackDriftDetectionStatusInput::create($input);
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DescribeStackDriftDetectionStatus', 'region' => $input->getRegion()]));
+        return new DescribeStackDriftDetectionStatusOutput($response);
+    }
+
     /**
      * Returns all stack related events for a specified stack in reverse chronological order. For more information about a
      * stack's event history, go to Stacks in the CloudFormation User Guide.

--- a/src/Service/CloudFormation/src/Enum/StackDriftDetectionStatus.php
+++ b/src/Service/CloudFormation/src/Enum/StackDriftDetectionStatus.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace AsyncAws\CloudFormation\Enum;
+
+/**
+ * The status of the stack drift detection operation.
+ *
+ * - `DETECTION_COMPLETE`: The stack drift detection operation has successfully completed for all resources in the stack
+ *   that support drift detection. (Resources that do not currently support stack detection remain unchecked.)
+ *   If you specified logical resource IDs for CloudFormation to use as a filter for the stack drift detection
+ *   operation, only the resources with those logical IDs are checked for drift.
+ * - `DETECTION_FAILED`: The stack drift detection operation has failed for at least one resource in the stack. Results
+ *   will be available for resources on which CloudFormation successfully completed drift detection.
+ * - `DETECTION_IN_PROGRESS`: The stack drift detection operation is currently in progress.
+ */
+final class StackDriftDetectionStatus
+{
+    public const DETECTION_COMPLETE = 'DETECTION_COMPLETE';
+    public const DETECTION_FAILED = 'DETECTION_FAILED';
+    public const DETECTION_IN_PROGRESS = 'DETECTION_IN_PROGRESS';
+
+    public static function exists(string $value): bool
+    {
+        return isset([
+            self::DETECTION_COMPLETE => true,
+            self::DETECTION_FAILED => true,
+            self::DETECTION_IN_PROGRESS => true,
+        ][$value]);
+    }
+}

--- a/src/Service/CloudFormation/src/Enum/StackDriftStatus.php
+++ b/src/Service/CloudFormation/src/Enum/StackDriftStatus.php
@@ -3,7 +3,7 @@
 namespace AsyncAws\CloudFormation\Enum;
 
 /**
- * Status of the stack's actual configuration compared to its expected template configuration.
+ * Status of the stack's actual configuration compared to its expected configuration.
  *
  * - `DRIFTED`: The stack differs from its expected template configuration. A stack is considered to have drifted if one
  *   or more of its resources have drifted.

--- a/src/Service/CloudFormation/src/Input/DescribeStackDriftDetectionStatusInput.php
+++ b/src/Service/CloudFormation/src/Input/DescribeStackDriftDetectionStatusInput.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace AsyncAws\CloudFormation\Input;
+
+use AsyncAws\Core\Exception\InvalidArgument;
+use AsyncAws\Core\Input;
+use AsyncAws\Core\Request;
+use AsyncAws\Core\Stream\StreamFactory;
+
+final class DescribeStackDriftDetectionStatusInput extends Input
+{
+    /**
+     * The ID of the drift detection results of this operation.
+     *
+     * @required
+     *
+     * @var string|null
+     */
+    private $stackDriftDetectionId;
+
+    /**
+     * @param array{
+     *   StackDriftDetectionId?: string,
+     *   @region?: string,
+     * } $input
+     */
+    public function __construct(array $input = [])
+    {
+        $this->stackDriftDetectionId = $input['StackDriftDetectionId'] ?? null;
+        parent::__construct($input);
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getStackDriftDetectionId(): ?string
+    {
+        return $this->stackDriftDetectionId;
+    }
+
+    /**
+     * @internal
+     */
+    public function request(): Request
+    {
+        // Prepare headers
+        $headers = ['content-type' => 'application/x-www-form-urlencoded'];
+
+        // Prepare query
+        $query = [];
+
+        // Prepare URI
+        $uriString = '/';
+
+        // Prepare Body
+        $body = http_build_query(['Action' => 'DescribeStackDriftDetectionStatus', 'Version' => '2010-05-15'] + $this->requestBody(), '', '&', \PHP_QUERY_RFC1738);
+
+        // Return the Request
+        return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));
+    }
+
+    public function setStackDriftDetectionId(?string $value): self
+    {
+        $this->stackDriftDetectionId = $value;
+
+        return $this;
+    }
+
+    private function requestBody(): array
+    {
+        $payload = [];
+        if (null === $v = $this->stackDriftDetectionId) {
+            throw new InvalidArgument(sprintf('Missing parameter "StackDriftDetectionId" for "%s". The value cannot be null.', __CLASS__));
+        }
+        $payload['StackDriftDetectionId'] = $v;
+
+        return $payload;
+    }
+}

--- a/src/Service/CloudFormation/src/Result/DescribeStackDriftDetectionStatusOutput.php
+++ b/src/Service/CloudFormation/src/Result/DescribeStackDriftDetectionStatusOutput.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace AsyncAws\CloudFormation\Result;
+
+use AsyncAws\CloudFormation\Enum\StackDriftDetectionStatus;
+use AsyncAws\CloudFormation\Enum\StackDriftStatus;
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Result;
+
+class DescribeStackDriftDetectionStatusOutput extends Result
+{
+    /**
+     * The ID of the stack.
+     */
+    private $stackId;
+
+    /**
+     * The ID of the drift detection results of this operation.
+     */
+    private $stackDriftDetectionId;
+
+    /**
+     * Status of the stack's actual configuration compared to its expected configuration.
+     */
+    private $stackDriftStatus;
+
+    /**
+     * The status of the stack drift detection operation.
+     */
+    private $detectionStatus;
+
+    /**
+     * The reason the stack drift detection operation has its current status.
+     */
+    private $detectionStatusReason;
+
+    /**
+     * Total number of stack resources that have drifted. This is NULL until the drift detection operation reaches a status
+     * of `DETECTION_COMPLETE`. This value will be 0 for stacks whose drift status is `IN_SYNC`.
+     */
+    private $driftedStackResourceCount;
+
+    /**
+     * Time at which the stack drift detection operation was initiated.
+     */
+    private $timestamp;
+
+    /**
+     * @return StackDriftDetectionStatus::*
+     */
+    public function getDetectionStatus(): string
+    {
+        $this->initialize();
+
+        return $this->detectionStatus;
+    }
+
+    public function getDetectionStatusReason(): ?string
+    {
+        $this->initialize();
+
+        return $this->detectionStatusReason;
+    }
+
+    public function getDriftedStackResourceCount(): ?int
+    {
+        $this->initialize();
+
+        return $this->driftedStackResourceCount;
+    }
+
+    public function getStackDriftDetectionId(): string
+    {
+        $this->initialize();
+
+        return $this->stackDriftDetectionId;
+    }
+
+    /**
+     * @return StackDriftStatus::*|null
+     */
+    public function getStackDriftStatus(): ?string
+    {
+        $this->initialize();
+
+        return $this->stackDriftStatus;
+    }
+
+    public function getStackId(): string
+    {
+        $this->initialize();
+
+        return $this->stackId;
+    }
+
+    public function getTimestamp(): \DateTimeImmutable
+    {
+        $this->initialize();
+
+        return $this->timestamp;
+    }
+
+    protected function populateResult(Response $response): void
+    {
+        $data = new \SimpleXMLElement($response->getContent());
+        $data = $data->DescribeStackDriftDetectionStatusResult;
+
+        $this->stackId = (string) $data->StackId;
+        $this->stackDriftDetectionId = (string) $data->StackDriftDetectionId;
+        $this->stackDriftStatus = ($v = $data->StackDriftStatus) ? (string) $v : null;
+        $this->detectionStatus = (string) $data->DetectionStatus;
+        $this->detectionStatusReason = ($v = $data->DetectionStatusReason) ? (string) $v : null;
+        $this->driftedStackResourceCount = ($v = $data->DriftedStackResourceCount) ? (int) (string) $v : null;
+        $this->timestamp = new \DateTimeImmutable((string) $data->Timestamp);
+    }
+}

--- a/src/Service/CloudFormation/tests/Integration/CloudFormationClientTest.php
+++ b/src/Service/CloudFormation/tests/Integration/CloudFormationClientTest.php
@@ -3,14 +3,39 @@
 namespace AsyncAws\CloudFormation\Tests\Integration;
 
 use AsyncAws\CloudFormation\CloudFormationClient;
+use AsyncAws\CloudFormation\Input\DescribeStackDriftDetectionStatusInput;
 use AsyncAws\CloudFormation\Input\DescribeStackEventsInput;
 use AsyncAws\CloudFormation\Input\DescribeStacksInput;
 use AsyncAws\Core\Credentials\Credentials;
 use AsyncAws\Core\Exception\Http\ClientException;
-use PHPUnit\Framework\TestCase;
+use AsyncAws\Core\Test\TestCase;
 
 class CloudFormationClientTest extends TestCase
 {
+    public function testDescribeStackDriftDetectionStatus(): void
+    {
+        self::markTestSkipped('The CloudFormation Docker image does not implement StackDrifts.');
+
+        $client = $this->getClient();
+
+        $input = new DescribeStackDriftDetectionStatusInput([
+            'StackDriftDetectionId' => 'b78ac9b0-dec1-11e7-a451-503a3example',
+        ]);
+
+        $result = $client->describeStackDriftDetectionStatus($input);
+
+        self::expectException(ClientException::class);
+
+        $result->resolve();
+
+        self::assertSame('changeIt', $result->getStackId());
+        self::assertSame('changeIt', $result->getStackDriftDetectionId());
+        self::assertSame('changeIt', $result->getStackDriftStatus());
+        self::assertSame('changeIt', $result->getDetectionStatus());
+        self::assertSame('changeIt', $result->getDetectionStatusReason());
+        self::assertSame(1337, $result->getDriftedStackResourceCount());
+    }
+
     public function testDescribeStackEvents(): void
     {
         $client = $this->getClient();

--- a/src/Service/CloudFormation/tests/Unit/CloudFormationClientTest.php
+++ b/src/Service/CloudFormation/tests/Unit/CloudFormationClientTest.php
@@ -3,16 +3,31 @@
 namespace AsyncAws\CloudFormation\Tests\Unit;
 
 use AsyncAws\CloudFormation\CloudFormationClient;
+use AsyncAws\CloudFormation\Input\DescribeStackDriftDetectionStatusInput;
 use AsyncAws\CloudFormation\Input\DescribeStackEventsInput;
 use AsyncAws\CloudFormation\Input\DescribeStacksInput;
+use AsyncAws\CloudFormation\Result\DescribeStackDriftDetectionStatusOutput;
 use AsyncAws\CloudFormation\Result\DescribeStackEventsOutput;
 use AsyncAws\CloudFormation\Result\DescribeStacksOutput;
 use AsyncAws\Core\Credentials\NullProvider;
-use PHPUnit\Framework\TestCase;
+use AsyncAws\Core\Test\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
 
 class CloudFormationClientTest extends TestCase
 {
+    public function testDescribeStackDriftDetectionStatus(): void
+    {
+        $client = new CloudFormationClient([], new NullProvider(), new MockHttpClient());
+
+        $input = new DescribeStackDriftDetectionStatusInput([
+            'StackDriftDetectionId' => 'b78ac9b0-dec1-11e7-a451-503a3example',
+        ]);
+        $result = $client->describeStackDriftDetectionStatus($input);
+
+        self::assertInstanceOf(DescribeStackDriftDetectionStatusOutput::class, $result);
+        self::assertFalse($result->info()['resolved']);
+    }
+
     public function testDescribeStackEvents(): void
     {
         $client = new CloudFormationClient([], new NullProvider(), new MockHttpClient());

--- a/src/Service/CloudFormation/tests/Unit/Input/DescribeStackDriftDetectionStatusInputTest.php
+++ b/src/Service/CloudFormation/tests/Unit/Input/DescribeStackDriftDetectionStatusInputTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AsyncAws\CloudFormation\Tests\Unit\Input;
+
+use AsyncAws\CloudFormation\Input\DescribeStackDriftDetectionStatusInput;
+use AsyncAws\Core\Test\TestCase;
+
+class DescribeStackDriftDetectionStatusInputTest extends TestCase
+{
+    public function testRequest(): void
+    {
+        $input = new DescribeStackDriftDetectionStatusInput([
+            'StackDriftDetectionId' => 'b78ac9b0-dec1-11e7-a451-503a3example',
+        ]);
+
+        // see https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_DescribeStackDriftDetectionStatus.html
+        $expected = '
+            POST / HTTP/1.0
+            Content-Type: application/x-www-form-urlencoded
+
+            Action=DescribeStackDriftDetectionStatus
+            &StackDriftDetectionId=b78ac9b0-dec1-11e7-a451-503a3example
+            &Version=2010-05-15
+                ';
+
+        self::assertRequestEqualsHttpRequest($expected, $input->request());
+    }
+}

--- a/src/Service/CloudFormation/tests/Unit/Result/DescribeStackDriftDetectionStatusOutputTest.php
+++ b/src/Service/CloudFormation/tests/Unit/Result/DescribeStackDriftDetectionStatusOutputTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace AsyncAws\CloudFormation\Tests\Unit\Result;
+
+use AsyncAws\CloudFormation\Result\DescribeStackDriftDetectionStatusOutput;
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Test\Http\SimpleMockedResponse;
+use AsyncAws\Core\Test\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+
+class DescribeStackDriftDetectionStatusOutputTest extends TestCase
+{
+    public function testDescribeStackDriftDetectionStatusOutput(): void
+    {
+        $response = new SimpleMockedResponse('<DescribeStackDriftDetectionStatusResponse xmlns="http://cloudformation.amazonaws.com/doc/2010-05-15/">
+  <DescribeStackDriftDetectionStatusResult>
+    <DetectionStatus>DETECTION_COMPLETE</DetectionStatus>
+    <StackDriftDetectionId>b78ac9b0-dec1-11e7-a451-503a3example</StackDriftDetectionId>
+    <DriftedStackResourceCount>0</DriftedStackResourceCount>
+    <StackId>arn:aws:cloudformation:us-east-1:012345678910:stack/example/cb438120-6cc7-11e7-998e-50example</StackId>
+    <StackDriftStatus>IN_SYNC</StackDriftStatus>
+    <Timestamp>2017-12-11T22:22:04.747Z</Timestamp>
+  </DescribeStackDriftDetectionStatusResult>
+  <ResponseMetadata>
+    <RequestId>f89bbda1-dec1-11e7-83c6-d92bexample</RequestId>
+  </ResponseMetadata>
+</DescribeStackDriftDetectionStatusResponse>');
+
+        $client = new MockHttpClient($response);
+        $result = new DescribeStackDriftDetectionStatusOutput(new Response($client->request('POST', 'http://localhost'), $client, new NullLogger()));
+
+        self::assertSame('arn:aws:cloudformation:us-east-1:012345678910:stack/example/cb438120-6cc7-11e7-998e-50example', $result->getStackId());
+        self::assertSame('b78ac9b0-dec1-11e7-a451-503a3example', $result->getStackDriftDetectionId());
+        self::assertSame('IN_SYNC', $result->getStackDriftStatus());
+        self::assertSame('DETECTION_COMPLETE', $result->getDetectionStatus());
+        self::assertNull($result->getDetectionStatusReason());
+        self::assertSame(0, $result->getDriftedStackResourceCount());
+    }
+}


### PR DESCRIPTION
Hi,

Just putting this into draft first to ensure I have covered everything that is expected. This PR is to implement the `DescribeStackDriftDetectionStatusInput` API call on CloudFormation.  

I used the generate tool to generate the code, and updated the stubs for both the input and output tests to match what is defined in the AWS example. 

I ran through the tests locally but have had to mark the feature test as skipped, as drifts are currently not supported by LocalStack. https://docs.localstack.cloud/aws/feature-coverage/

I have also linked this to an existing project where I wanted to use this API call and it all worked as I expected. 

If this is ok, I can also try to add more of the cloud formation calls such as `DescribeStackResourceDrifts` in another PR.