### PR TITLE
illuminate-mail: merge config from services.ses

### DIFF
--- a/src/Integration/Laravel/Mail/src/ServiceProvider.php
+++ b/src/Integration/Laravel/Mail/src/ServiceProvider.php
@@ -22,6 +22,12 @@ class ServiceProvider extends AbstractServiceProvider
     public function createTransport(array $config): AsyncAwsSesTransport
     {
         $clientConfig = [];
+
+        $config = array_merge(
+            $this->app['config']->get('services.ses', []),
+            $config
+        );
+
         if (isset($config['key']) && isset($config['secret'])) {
             $clientConfig['accessKeyId'] = $config['key'] ?? null;
             $clientConfig['accessKeySecret'] = $config['secret'] ?? null;


### PR DESCRIPTION
Fixes https://github.com/async-aws/aws/issues/1152

Laravel is using MAILER concept since v7.x, merging the config wont break it on v6.x

https://github.com/laravel/framework/blob/972538f7071e73dcff429c1cb0ec143d66d82dc1/src/Illuminate/Mail/MailManager.php?_pjax=%23js-repo-pjax-container%2C%20div%5Bitemtype%3D%22http%3A%2F%2Fschema.org%2FSoftwareSourceCode%22%5D%20main%2C%20%5Bdata-pjax-container%5D#L266-L270