### PR TITLE
Simplify HttpClient injection

### DIFF
--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Make the injected HttpClient decorated by our  `RetryableHttpClient`
 - Support for KMS
 
 ## 1.13.0

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -74,15 +74,15 @@ abstract class AbstractApi
         $this->awsErrorFactory = $this->getAwsErrorFactory();
         if (!isset($httpClient)) {
             $httpClient = HttpClient::create();
-            if (class_exists(RetryableHttpClient::class)) {
-                /** @psalm-suppress MissingDependency */
-                $httpClient = new RetryableHttpClient(
-                    $httpClient,
-                    new AwsRetryStrategy(AwsRetryStrategy::DEFAULT_RETRY_STATUS_CODES, 1000, 2.0, 0, 0.1, $this->awsErrorFactory),
-                    3,
-                    $this->logger
-                );
-            }
+        }
+        if (class_exists(RetryableHttpClient::class) && !$httpClient instanceof RetryableHttpClient) {
+            /** @psalm-suppress MissingDependency */
+            $httpClient = new RetryableHttpClient(
+                $httpClient,
+                new AwsRetryStrategy(AwsRetryStrategy::DEFAULT_RETRY_STATUS_CODES, 1000, 2.0, 0, 0.1, $this->awsErrorFactory),
+                3,
+                $this->logger
+            );
         }
         $this->httpClient = $httpClient;
         $this->configuration = $configuration;


### PR DESCRIPTION
This PR fix #1159 by making the API to always decorate the HttpClient with the RetryableHttpClient, even when it has been injected by the user.

Given it does not change the behavior of the component when no error occurred, I think it does no harm.

IHMO the worst cast is people injecting an homemade RetryableHttpClient. In this case, the client will be decorated twice, making the request retried `N*M`. But I think this case is rare enough to make it acceptable.

It also allows people to easily inject a custom HttpClient (let's say TracableHttpClient in dev mode) without handling all the stuff about Retry logic + awsErrorFactory
