### PR TITLE
Add new operation CloudWatchLogs::filterLogEvents

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -69,6 +69,7 @@
             "methods": [
                 "CreateLogGroup",
                 "DescribeLogStreams",
+                "FilterLogEvents",
                 "PutLogEvents"
             ]
         },

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -132,6 +132,11 @@
       <code>(bool) $v</code>
     </RedundantCastGivenDocblockType>
   </file>
+  <file src="src/Service/CloudWatchLogs/src/Input/FilterLogEventsRequest.php">
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(bool) $v</code>
+    </RedundantCastGivenDocblockType>
+  </file>
   <file src="src/Service/CodeDeploy/src/Input/CreateDeploymentInput.php">
     <RedundantCastGivenDocblockType occurrences="2">
       <code>(bool) $v</code>

--- a/src/Service/CloudWatchLogs/CHANGELOG.md
+++ b/src/Service/CloudWatchLogs/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - AWS api-change: Added `us-iso-west-1` region
 - AWS api-change: Use specific configuration for `us` regions
+- Added operation `filterLogEvents`
 
 ## 1.2.0
 

--- a/src/Service/CloudWatchLogs/composer.json
+++ b/src/Service/CloudWatchLogs/composer.json
@@ -13,6 +13,7 @@
     ],
     "require": {
         "php": "^7.2.5 || ^8.0",
+        "ext-filter": "*",
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },

--- a/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
+++ b/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
@@ -14,8 +14,10 @@ use AsyncAws\CloudWatchLogs\Exception\ServiceUnavailableException;
 use AsyncAws\CloudWatchLogs\Exception\UnrecognizedClientException;
 use AsyncAws\CloudWatchLogs\Input\CreateLogGroupRequest;
 use AsyncAws\CloudWatchLogs\Input\DescribeLogStreamsRequest;
+use AsyncAws\CloudWatchLogs\Input\FilterLogEventsRequest;
 use AsyncAws\CloudWatchLogs\Input\PutLogEventsRequest;
 use AsyncAws\CloudWatchLogs\Result\DescribeLogStreamsResponse;
+use AsyncAws\CloudWatchLogs\Result\FilterLogEventsResponse;
 use AsyncAws\CloudWatchLogs\Result\PutLogEventsResponse;
 use AsyncAws\CloudWatchLogs\ValueObject\InputLogEvent;
 use AsyncAws\Core\AbstractApi;
@@ -91,6 +93,42 @@ class CloudWatchLogsClient extends AbstractApi
         ]]));
 
         return new DescribeLogStreamsResponse($response, $this, $input);
+    }
+
+    /**
+     * Lists log events from the specified log group. You can list all the log events or filter the results using a filter
+     * pattern, a time range, and the name of the log stream.
+     *
+     * @see https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_FilterLogEvents.html
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-logs-2014-03-28.html#filterlogevents
+     *
+     * @param array{
+     *   logGroupName: string,
+     *   logStreamNames?: string[],
+     *   logStreamNamePrefix?: string,
+     *   startTime?: string,
+     *   endTime?: string,
+     *   filterPattern?: string,
+     *   nextToken?: string,
+     *   limit?: int,
+     *   interleaved?: bool,
+     *   @region?: string,
+     * }|FilterLogEventsRequest $input
+     *
+     * @throws InvalidParameterException
+     * @throws ResourceNotFoundException
+     * @throws ServiceUnavailableException
+     */
+    public function filterLogEvents($input): FilterLogEventsResponse
+    {
+        $input = FilterLogEventsRequest::create($input);
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'FilterLogEvents', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InvalidParameterException' => InvalidParameterException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'ServiceUnavailableException' => ServiceUnavailableException::class,
+        ]]));
+
+        return new FilterLogEventsResponse($response, $this, $input);
     }
 
     /**

--- a/src/Service/CloudWatchLogs/src/Input/FilterLogEventsRequest.php
+++ b/src/Service/CloudWatchLogs/src/Input/FilterLogEventsRequest.php
@@ -1,0 +1,304 @@
+<?php
+
+namespace AsyncAws\CloudWatchLogs\Input;
+
+use AsyncAws\Core\Exception\InvalidArgument;
+use AsyncAws\Core\Input;
+use AsyncAws\Core\Request;
+use AsyncAws\Core\Stream\StreamFactory;
+
+final class FilterLogEventsRequest extends Input
+{
+    /**
+     * The name of the log group to search.
+     *
+     * @required
+     *
+     * @var string|null
+     */
+    private $logGroupName;
+
+    /**
+     * Filters the results to only logs from the log streams in this list.
+     *
+     * @var string[]|null
+     */
+    private $logStreamNames;
+
+    /**
+     * Filters the results to include only events from log streams that have names starting with this prefix.
+     *
+     * @var string|null
+     */
+    private $logStreamNamePrefix;
+
+    /**
+     * The start of the time range, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC. Events with a
+     * timestamp before this time are not returned.
+     *
+     * @var string|null
+     */
+    private $startTime;
+
+    /**
+     * The end of the time range, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC. Events with a
+     * timestamp later than this time are not returned.
+     *
+     * @var string|null
+     */
+    private $endTime;
+
+    /**
+     * The filter pattern to use. For more information, see Filter and Pattern Syntax.
+     *
+     * @see https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html
+     *
+     * @var string|null
+     */
+    private $filterPattern;
+
+    /**
+     * The token for the next set of events to return. (You received this token from a previous call.).
+     *
+     * @var string|null
+     */
+    private $nextToken;
+
+    /**
+     * The maximum number of events to return. The default is 10,000 events.
+     *
+     * @var int|null
+     */
+    private $limit;
+
+    /**
+     * If the value is true, the operation makes a best effort to provide responses that contain events from multiple log
+     * streams within the log group, interleaved in a single response. If the value is false, all the matched log events in
+     * the first log stream are searched first, then those in the next log stream, and so on. The default is false.
+     *
+     * @var bool|null
+     */
+    private $interleaved;
+
+    /**
+     * @param array{
+     *   logGroupName?: string,
+     *   logStreamNames?: string[],
+     *   logStreamNamePrefix?: string,
+     *   startTime?: string,
+     *   endTime?: string,
+     *   filterPattern?: string,
+     *   nextToken?: string,
+     *   limit?: int,
+     *   interleaved?: bool,
+     *   @region?: string,
+     * } $input
+     */
+    public function __construct(array $input = [])
+    {
+        $this->logGroupName = $input['logGroupName'] ?? null;
+        $this->logStreamNames = $input['logStreamNames'] ?? null;
+        $this->logStreamNamePrefix = $input['logStreamNamePrefix'] ?? null;
+        $this->startTime = $input['startTime'] ?? null;
+        $this->endTime = $input['endTime'] ?? null;
+        $this->filterPattern = $input['filterPattern'] ?? null;
+        $this->nextToken = $input['nextToken'] ?? null;
+        $this->limit = $input['limit'] ?? null;
+        $this->interleaved = $input['interleaved'] ?? null;
+        parent::__construct($input);
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getEndTime(): ?string
+    {
+        return $this->endTime;
+    }
+
+    public function getFilterPattern(): ?string
+    {
+        return $this->filterPattern;
+    }
+
+    /**
+     * @deprecated
+     */
+    public function getInterleaved(): ?bool
+    {
+        @trigger_error(sprintf('The property "interleaved" of "%s" is deprecated by AWS.', __CLASS__), \E_USER_DEPRECATED);
+
+        return $this->interleaved;
+    }
+
+    public function getLimit(): ?int
+    {
+        return $this->limit;
+    }
+
+    public function getLogGroupName(): ?string
+    {
+        return $this->logGroupName;
+    }
+
+    public function getLogStreamNamePrefix(): ?string
+    {
+        return $this->logStreamNamePrefix;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getLogStreamNames(): array
+    {
+        return $this->logStreamNames ?? [];
+    }
+
+    public function getNextToken(): ?string
+    {
+        return $this->nextToken;
+    }
+
+    public function getStartTime(): ?string
+    {
+        return $this->startTime;
+    }
+
+    /**
+     * @internal
+     */
+    public function request(): Request
+    {
+        // Prepare headers
+        $headers = [
+            'Content-Type' => 'application/x-amz-json-1.1',
+            'X-Amz-Target' => 'Logs_20140328.FilterLogEvents',
+        ];
+
+        // Prepare query
+        $query = [];
+
+        // Prepare URI
+        $uriString = '/';
+
+        // Prepare Body
+        $bodyPayload = $this->requestBody();
+        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload, 4194304);
+
+        // Return the Request
+        return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));
+    }
+
+    public function setEndTime(?string $value): self
+    {
+        $this->endTime = $value;
+
+        return $this;
+    }
+
+    public function setFilterPattern(?string $value): self
+    {
+        $this->filterPattern = $value;
+
+        return $this;
+    }
+
+    /**
+     * @deprecated
+     */
+    public function setInterleaved(?bool $value): self
+    {
+        @trigger_error(sprintf('The property "interleaved" of "%s" is deprecated by AWS.', __CLASS__), \E_USER_DEPRECATED);
+        $this->interleaved = $value;
+
+        return $this;
+    }
+
+    public function setLimit(?int $value): self
+    {
+        $this->limit = $value;
+
+        return $this;
+    }
+
+    public function setLogGroupName(?string $value): self
+    {
+        $this->logGroupName = $value;
+
+        return $this;
+    }
+
+    public function setLogStreamNamePrefix(?string $value): self
+    {
+        $this->logStreamNamePrefix = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param string[] $value
+     */
+    public function setLogStreamNames(array $value): self
+    {
+        $this->logStreamNames = $value;
+
+        return $this;
+    }
+
+    public function setNextToken(?string $value): self
+    {
+        $this->nextToken = $value;
+
+        return $this;
+    }
+
+    public function setStartTime(?string $value): self
+    {
+        $this->startTime = $value;
+
+        return $this;
+    }
+
+    private function requestBody(): array
+    {
+        $payload = [];
+        if (null === $v = $this->logGroupName) {
+            throw new InvalidArgument(sprintf('Missing parameter "logGroupName" for "%s". The value cannot be null.', __CLASS__));
+        }
+        $payload['logGroupName'] = $v;
+        if (null !== $v = $this->logStreamNames) {
+            $index = -1;
+            $payload['logStreamNames'] = [];
+            foreach ($v as $listValue) {
+                ++$index;
+                $payload['logStreamNames'][$index] = $listValue;
+            }
+        }
+        if (null !== $v = $this->logStreamNamePrefix) {
+            $payload['logStreamNamePrefix'] = $v;
+        }
+        if (null !== $v = $this->startTime) {
+            $payload['startTime'] = $v;
+        }
+        if (null !== $v = $this->endTime) {
+            $payload['endTime'] = $v;
+        }
+        if (null !== $v = $this->filterPattern) {
+            $payload['filterPattern'] = $v;
+        }
+        if (null !== $v = $this->nextToken) {
+            $payload['nextToken'] = $v;
+        }
+        if (null !== $v = $this->limit) {
+            $payload['limit'] = $v;
+        }
+        if (null !== $v = $this->interleaved) {
+            @trigger_error(sprintf('The property "interleaved" of "%s" is deprecated by AWS.', __CLASS__), \E_USER_DEPRECATED);
+            $payload['interleaved'] = (bool) $v;
+        }
+
+        return $payload;
+    }
+}

--- a/src/Service/CloudWatchLogs/src/Result/FilterLogEventsResponse.php
+++ b/src/Service/CloudWatchLogs/src/Result/FilterLogEventsResponse.php
@@ -1,0 +1,210 @@
+<?php
+
+namespace AsyncAws\CloudWatchLogs\Result;
+
+use AsyncAws\CloudWatchLogs\CloudWatchLogsClient;
+use AsyncAws\CloudWatchLogs\Input\FilterLogEventsRequest;
+use AsyncAws\CloudWatchLogs\ValueObject\FilteredLogEvent;
+use AsyncAws\CloudWatchLogs\ValueObject\SearchedLogStream;
+use AsyncAws\Core\Exception\InvalidArgument;
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Result;
+
+/**
+ * @implements \IteratorAggregate<FilteredLogEvent|SearchedLogStream>
+ */
+class FilterLogEventsResponse extends Result implements \IteratorAggregate
+{
+    /**
+     * The matched events.
+     */
+    private $events;
+
+    /**
+     * **IMPORTANT** Starting on May 15, 2020, this parameter will be deprecated. This parameter will be an empty list after
+     * the deprecation occurs.
+     */
+    private $searchedLogStreams;
+
+    /**
+     * The token to use when requesting the next set of items. The token expires after 24 hours.
+     */
+    private $nextToken;
+
+    /**
+     * @param bool $currentPageOnly When true, iterates over items of the current page. Otherwise also fetch items in the next pages.
+     *
+     * @return iterable<FilteredLogEvent>
+     */
+    public function getEvents(bool $currentPageOnly = false): iterable
+    {
+        if ($currentPageOnly) {
+            $this->initialize();
+            yield from $this->events;
+
+            return;
+        }
+
+        $client = $this->awsClient;
+        if (!$client instanceof CloudWatchLogsClient) {
+            throw new InvalidArgument('missing client injected in paginated result');
+        }
+        if (!$this->input instanceof FilterLogEventsRequest) {
+            throw new InvalidArgument('missing last request injected in paginated result');
+        }
+        $input = clone $this->input;
+        $page = $this;
+        while (true) {
+            $page->initialize();
+            if ($page->nextToken) {
+                $input->setNextToken($page->nextToken);
+
+                $this->registerPrefetch($nextPage = $client->filterLogEvents($input));
+            } else {
+                $nextPage = null;
+            }
+
+            yield from $page->events;
+
+            if (null === $nextPage) {
+                break;
+            }
+
+            $this->unregisterPrefetch($nextPage);
+            $page = $nextPage;
+        }
+    }
+
+    /**
+     * Iterates over events and searchedLogStreams.
+     *
+     * @return \Traversable<FilteredLogEvent|SearchedLogStream>
+     */
+    public function getIterator(): \Traversable
+    {
+        $client = $this->awsClient;
+        if (!$client instanceof CloudWatchLogsClient) {
+            throw new InvalidArgument('missing client injected in paginated result');
+        }
+        if (!$this->input instanceof FilterLogEventsRequest) {
+            throw new InvalidArgument('missing last request injected in paginated result');
+        }
+        $input = clone $this->input;
+        $page = $this;
+        while (true) {
+            $page->initialize();
+            if ($page->nextToken) {
+                $input->setNextToken($page->nextToken);
+
+                $this->registerPrefetch($nextPage = $client->filterLogEvents($input));
+            } else {
+                $nextPage = null;
+            }
+
+            yield from $page->getEvents(true);
+            yield from $page->getSearchedLogStreams(true);
+
+            if (null === $nextPage) {
+                break;
+            }
+
+            $this->unregisterPrefetch($nextPage);
+            $page = $nextPage;
+        }
+    }
+
+    public function getNextToken(): ?string
+    {
+        $this->initialize();
+
+        return $this->nextToken;
+    }
+
+    /**
+     * @param bool $currentPageOnly When true, iterates over items of the current page. Otherwise also fetch items in the next pages.
+     *
+     * @return iterable<SearchedLogStream>
+     */
+    public function getSearchedLogStreams(bool $currentPageOnly = false): iterable
+    {
+        if ($currentPageOnly) {
+            $this->initialize();
+            yield from $this->searchedLogStreams;
+
+            return;
+        }
+
+        $client = $this->awsClient;
+        if (!$client instanceof CloudWatchLogsClient) {
+            throw new InvalidArgument('missing client injected in paginated result');
+        }
+        if (!$this->input instanceof FilterLogEventsRequest) {
+            throw new InvalidArgument('missing last request injected in paginated result');
+        }
+        $input = clone $this->input;
+        $page = $this;
+        while (true) {
+            $page->initialize();
+            if ($page->nextToken) {
+                $input->setNextToken($page->nextToken);
+
+                $this->registerPrefetch($nextPage = $client->filterLogEvents($input));
+            } else {
+                $nextPage = null;
+            }
+
+            yield from $page->searchedLogStreams;
+
+            if (null === $nextPage) {
+                break;
+            }
+
+            $this->unregisterPrefetch($nextPage);
+            $page = $nextPage;
+        }
+    }
+
+    protected function populateResult(Response $response): void
+    {
+        $data = $response->toArray();
+
+        $this->events = empty($data['events']) ? [] : $this->populateResultFilteredLogEvents($data['events']);
+        $this->searchedLogStreams = empty($data['searchedLogStreams']) ? [] : $this->populateResultSearchedLogStreams($data['searchedLogStreams']);
+        $this->nextToken = isset($data['nextToken']) ? (string) $data['nextToken'] : null;
+    }
+
+    /**
+     * @return FilteredLogEvent[]
+     */
+    private function populateResultFilteredLogEvents(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new FilteredLogEvent([
+                'logStreamName' => isset($item['logStreamName']) ? (string) $item['logStreamName'] : null,
+                'timestamp' => isset($item['timestamp']) ? (string) $item['timestamp'] : null,
+                'message' => isset($item['message']) ? (string) $item['message'] : null,
+                'ingestionTime' => isset($item['ingestionTime']) ? (string) $item['ingestionTime'] : null,
+                'eventId' => isset($item['eventId']) ? (string) $item['eventId'] : null,
+            ]);
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return SearchedLogStream[]
+     */
+    private function populateResultSearchedLogStreams(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = new SearchedLogStream([
+                'logStreamName' => isset($item['logStreamName']) ? (string) $item['logStreamName'] : null,
+                'searchedCompletely' => isset($item['searchedCompletely']) ? filter_var($item['searchedCompletely'], \FILTER_VALIDATE_BOOLEAN) : null,
+            ]);
+        }
+
+        return $items;
+    }
+}

--- a/src/Service/CloudWatchLogs/src/ValueObject/FilteredLogEvent.php
+++ b/src/Service/CloudWatchLogs/src/ValueObject/FilteredLogEvent.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace AsyncAws\CloudWatchLogs\ValueObject;
+
+/**
+ * Represents a matched event.
+ */
+final class FilteredLogEvent
+{
+    /**
+     * The name of the log stream to which this event belongs.
+     */
+    private $logStreamName;
+
+    /**
+     * The time the event occurred, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.
+     */
+    private $timestamp;
+
+    /**
+     * The data contained in the log event.
+     */
+    private $message;
+
+    /**
+     * The time the event was ingested, expressed as the number of milliseconds after Jan 1, 1970 00:00:00 UTC.
+     */
+    private $ingestionTime;
+
+    /**
+     * The ID of the event.
+     */
+    private $eventId;
+
+    /**
+     * @param array{
+     *   logStreamName?: null|string,
+     *   timestamp?: null|string,
+     *   message?: null|string,
+     *   ingestionTime?: null|string,
+     *   eventId?: null|string,
+     * } $input
+     */
+    public function __construct(array $input)
+    {
+        $this->logStreamName = $input['logStreamName'] ?? null;
+        $this->timestamp = $input['timestamp'] ?? null;
+        $this->message = $input['message'] ?? null;
+        $this->ingestionTime = $input['ingestionTime'] ?? null;
+        $this->eventId = $input['eventId'] ?? null;
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getEventId(): ?string
+    {
+        return $this->eventId;
+    }
+
+    public function getIngestionTime(): ?string
+    {
+        return $this->ingestionTime;
+    }
+
+    public function getLogStreamName(): ?string
+    {
+        return $this->logStreamName;
+    }
+
+    public function getMessage(): ?string
+    {
+        return $this->message;
+    }
+
+    public function getTimestamp(): ?string
+    {
+        return $this->timestamp;
+    }
+}

--- a/src/Service/CloudWatchLogs/src/ValueObject/SearchedLogStream.php
+++ b/src/Service/CloudWatchLogs/src/ValueObject/SearchedLogStream.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace AsyncAws\CloudWatchLogs\ValueObject;
+
+/**
+ * Represents the search status of a log stream.
+ */
+final class SearchedLogStream
+{
+    /**
+     * The name of the log stream.
+     */
+    private $logStreamName;
+
+    /**
+     * Indicates whether all the events in this log stream were searched.
+     */
+    private $searchedCompletely;
+
+    /**
+     * @param array{
+     *   logStreamName?: null|string,
+     *   searchedCompletely?: null|bool,
+     * } $input
+     */
+    public function __construct(array $input)
+    {
+        $this->logStreamName = $input['logStreamName'] ?? null;
+        $this->searchedCompletely = $input['searchedCompletely'] ?? null;
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getLogStreamName(): ?string
+    {
+        return $this->logStreamName;
+    }
+
+    public function getSearchedCompletely(): ?bool
+    {
+        return $this->searchedCompletely;
+    }
+}

--- a/src/Service/CloudWatchLogs/tests/Integration/CloudWatchLogsClientTest.php
+++ b/src/Service/CloudWatchLogs/tests/Integration/CloudWatchLogsClientTest.php
@@ -6,6 +6,7 @@ use AsyncAws\CloudWatchLogs\CloudWatchLogsClient;
 use AsyncAws\CloudWatchLogs\Enum\OrderBy;
 use AsyncAws\CloudWatchLogs\Input\CreateLogGroupRequest;
 use AsyncAws\CloudWatchLogs\Input\DescribeLogStreamsRequest;
+use AsyncAws\CloudWatchLogs\Input\FilterLogEventsRequest;
 use AsyncAws\CloudWatchLogs\Input\PutLogEventsRequest;
 use AsyncAws\CloudWatchLogs\ValueObject\InputLogEvent;
 use AsyncAws\Core\Credentials\Credentials;
@@ -39,6 +40,25 @@ class CloudWatchLogsClientTest extends TestCase
             'limit' => 10,
         ]);
         $result = $client->DescribeLogStreams($input);
+
+        self::expectException(ClientException::class);
+        self::expectExceptionMessageMatches('/The specified log group does not exist/');
+
+        $result->resolve();
+    }
+
+    public function testFilterLogEvents(): void
+    {
+        $client = $this->getClient();
+
+        $input = new FilterLogEventsRequest([
+            'logGroupName' => 'app-logs',
+            'startTime' => 1337,
+            'endTime' => 1338,
+            'filterPattern' => 'ERROR',
+            'limit' => 10,
+        ]);
+        $result = $client->filterLogEvents($input);
 
         self::expectException(ClientException::class);
         self::expectExceptionMessageMatches('/The specified log group does not exist/');

--- a/src/Service/CloudWatchLogs/tests/Unit/CloudWatchLogsClientTest.php
+++ b/src/Service/CloudWatchLogs/tests/Unit/CloudWatchLogsClientTest.php
@@ -5,8 +5,10 @@ namespace AsyncAws\CloudWatchLogs\Tests\Unit;
 use AsyncAws\CloudWatchLogs\CloudWatchLogsClient;
 use AsyncAws\CloudWatchLogs\Input\CreateLogGroupRequest;
 use AsyncAws\CloudWatchLogs\Input\DescribeLogStreamsRequest;
+use AsyncAws\CloudWatchLogs\Input\FilterLogEventsRequest;
 use AsyncAws\CloudWatchLogs\Input\PutLogEventsRequest;
 use AsyncAws\CloudWatchLogs\Result\DescribeLogStreamsResponse;
+use AsyncAws\CloudWatchLogs\Result\FilterLogEventsResponse;
 use AsyncAws\CloudWatchLogs\Result\PutLogEventsResponse;
 use AsyncAws\CloudWatchLogs\ValueObject\InputLogEvent;
 use AsyncAws\Core\Credentials\NullProvider;
@@ -40,6 +42,19 @@ class CloudWatchLogsClientTest extends TestCase
         $result = $client->DescribeLogStreams($input);
 
         self::assertInstanceOf(DescribeLogStreamsResponse::class, $result);
+        self::assertFalse($result->info()['resolved']);
+    }
+
+    public function testFilterLogEvents(): void
+    {
+        $client = new CloudWatchLogsClient([], new NullProvider(), new MockHttpClient());
+
+        $input = new FilterLogEventsRequest([
+            'logGroupName' => 'test_logGroupName',
+        ]);
+        $result = $client->filterLogEvents($input);
+
+        self::assertInstanceOf(FilterLogEventsResponse::class, $result);
         self::assertFalse($result->info()['resolved']);
     }
 

--- a/src/Service/CloudWatchLogs/tests/Unit/Input/FilterLogEventsRequestTest.php
+++ b/src/Service/CloudWatchLogs/tests/Unit/Input/FilterLogEventsRequestTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace AsyncAws\CloudWatchLogs\Tests\Unit\Input;
+
+use AsyncAws\CloudWatchLogs\Input\FilterLogEventsRequest;
+use AsyncAws\Core\Test\TestCase;
+
+class FilterLogEventsRequestTest extends TestCase
+{
+    public function testRequest(): void
+    {
+        $input = new FilterLogEventsRequest([
+            'logGroupName' => 'foo',
+            'logStreamNamePrefix' => 'bar',
+            'startTime' => 1337,
+            'endTime' => 1338,
+            'filterPattern' => 'ERROR',
+            'nextToken' => 'foobar',
+            'limit' => 10,
+        ]);
+
+        // see https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_FilterLogEvents.html
+        $expected = '
+            POST / HTTP/1.0
+            Content-Type: application/x-amz-json-1.1
+            x-amz-target: Logs_20140328.FilterLogEvents
+
+            {
+               "logGroupName": "foo",
+               "logStreamNamePrefix": "bar",
+               "startTime": 1337,
+               "endTime": 1338,
+               "filterPattern": "ERROR",
+               "limit": 10,
+               "nextToken": "foobar"
+            }
+            ';
+
+        self::assertRequestEqualsHttpRequest($expected, $input->request());
+    }
+}

--- a/src/Service/CloudWatchLogs/tests/Unit/Result/FilterLogEventsResponseTest.php
+++ b/src/Service/CloudWatchLogs/tests/Unit/Result/FilterLogEventsResponseTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace AsyncAws\CloudWatchLogs\Tests\Unit\Result;
+
+use AsyncAws\CloudWatchLogs\CloudWatchLogsClient;
+use AsyncAws\CloudWatchLogs\Input\FilterLogEventsRequest;
+use AsyncAws\CloudWatchLogs\Result\FilterLogEventsResponse;
+use AsyncAws\CloudWatchLogs\ValueObject\FilteredLogEvent;
+use AsyncAws\CloudWatchLogs\ValueObject\SearchedLogStream;
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Test\Http\SimpleMockedResponse;
+use AsyncAws\Core\Test\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+
+class FilterLogEventsResponseTest extends TestCase
+{
+    public function testFilterLogEventsResponse(): void
+    {
+        // see https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_FilterLogEvents.html
+        $response = new SimpleMockedResponse('{
+           "events": [
+              {
+                 "eventId": "36642742439302039892221577788596614866277653557049884672",
+                 "ingestionTime": 1643117400988,
+                 "logStreamName": "my-log-stream-1",
+                 "message": "production.ERROR something",
+                 "timestamp": 1643117398683
+              },
+              {
+                 "eventId": "36642742439302039892221577788596614866277653557049884673",
+                 "ingestionTime": 1643117400988,
+                 "logStreamName": "my-log-stream-1",
+                 "message": "production.ERROR something else",
+                 "timestamp": 1643117398684
+              }
+           ],
+           "nextToken": "foobar",
+           "searchedLogStreams": [
+              {
+                 "logStreamName": "my-log-stream-1",
+                 "searchedCompletely": false
+              }
+           ]
+        }');
+
+        $client = new MockHttpClient($response);
+        $request = new FilterLogEventsRequest(['logGroupName' => 'app-log']);
+        $result = new FilterLogEventsResponse(new Response($client->request('POST', 'http://localhost'), $client, new NullLogger()), new CloudWatchLogsClient(), $request);
+
+        /** @var FilteredLogEvent[] $events */
+        $events = iterator_to_array($result->getEvents(true));
+        self::assertCount(2, $events);
+        self::assertEquals('production.ERROR something', $events[0]->getMessage());
+        self::assertEquals('36642742439302039892221577788596614866277653557049884672', $events[0]->getEventId());
+        self::assertEquals('1643117398683', $events[0]->getTimestamp());
+        self::assertEquals('my-log-stream-1', $events[0]->getLogStreamName());
+
+        /** @var SearchedLogStream[] $searchedLogStreams */
+        $searchedLogStreams = iterator_to_array($result->getSearchedLogStreams(true));
+        self::assertCount(1, $searchedLogStreams);
+        self::assertEquals('my-log-stream-1', $searchedLogStreams[0]->getLogStreamName());
+        self::assertFalse($searchedLogStreams[0]->getSearchedCompletely());
+
+        self::assertSame('foobar', $result->getnextToken());
+    }
+}


### PR DESCRIPTION
Generated a new operation `FilterLogEvents` for the `CloudWatchLogs` Client.

See https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_FilterLogEvents.html

`ext-filter` was added to `composer.json` by the generate command, don't know why/if that is needed.

Saw also that the [interleaved property is deprecated](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_FilterLogEvents.html#API_FilterLogEvents_RequestSyntax) any special way that should be handled? Its always handled as `true` by the API