### PR TITLE
Fix error when config keys arent included

### DIFF
--- a/src/Integration/Laravel/Filesystem/src/AsyncAwsFilesystemManager.php
+++ b/src/Integration/Laravel/Filesystem/src/AsyncAwsFilesystemManager.php
@@ -17,7 +17,7 @@ class AsyncAwsFilesystemManager extends FilesystemManager
     public function createAsyncAwsS3Driver(array $config)
     {
         $s3Config = [];
-        if ($config['key'] && $config['secret']) {
+        if (!empty($config['key']) && !empty($config['secret'])) {
             $s3Config['accessKeyId'] = $config['key'] ?? null;
             $s3Config['accessKeySecret'] = $config['secret'] ?? null;
             $s3Config['sessionToken'] = $config['token'] ?? null;

--- a/src/Integration/Laravel/Filesystem/src/AsyncAwsFilesystemManager.php
+++ b/src/Integration/Laravel/Filesystem/src/AsyncAwsFilesystemManager.php
@@ -18,8 +18,8 @@ class AsyncAwsFilesystemManager extends FilesystemManager
     {
         $s3Config = [];
         if (!empty($config['key']) && !empty($config['secret'])) {
-            $s3Config['accessKeyId'] = $config['key'] ?? null;
-            $s3Config['accessKeySecret'] = $config['secret'] ?? null;
+            $s3Config['accessKeyId'] = $config['key'];
+            $s3Config['accessKeySecret'] = $config['secret'];
             $s3Config['sessionToken'] = $config['token'] ?? null;
         }
 


### PR DESCRIPTION
Code would previously error due to array keys not existing even though it should go ahead and attempt to create the client and search for the AWS keys in the environment variables/other AWS credential stores