### PR TITLE
Simplify generated endpointMetadata

### DIFF
--- a/src/Core/src/Sts/StsClient.php
+++ b/src/Core/src/Sts/StsClient.php
@@ -165,15 +165,8 @@ class StsClient extends AbstractApi
                 ];
             case 'us-isob-east-1':
                 return [
-                    'endpoint' => "https://sts.$region.sc2s.sgov.gov",
-                    'signRegion' => $region,
-                    'signService' => 'sts',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://sts.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
+                    'endpoint' => 'https://sts.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
                     'signService' => 'sts',
                     'signVersions' => ['v4'],
                 ];
@@ -184,24 +177,10 @@ class StsClient extends AbstractApi
                     'signService' => 'sts',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://sts.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
-                    'signService' => 'sts',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-east-2-fips':
                 return [
                     'endpoint' => 'https://sts-fips.us-east-2.amazonaws.com',
                     'signRegion' => 'us-east-2',
-                    'signService' => 'sts',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-east-1':
-                return [
-                    'endpoint' => 'https://sts.us-gov-east-1.amazonaws.com',
-                    'signRegion' => 'us-gov-east-1',
                     'signService' => 'sts',
                     'signVersions' => ['v4'],
                 ];
@@ -212,13 +191,6 @@ class StsClient extends AbstractApi
                     'signService' => 'sts',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://sts.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'sts',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-gov-west-1-fips':
                 return [
                     'endpoint' => 'https://sts.us-gov-west-1.amazonaws.com',
@@ -226,24 +198,10 @@ class StsClient extends AbstractApi
                     'signService' => 'sts',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://sts.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'sts',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-west-1-fips':
                 return [
                     'endpoint' => 'https://sts-fips.us-west-1.amazonaws.com',
                     'signRegion' => 'us-west-1',
-                    'signService' => 'sts',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://sts.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
                     'signService' => 'sts',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/CloudFormation/src/CloudFormationClient.php
+++ b/src/Service/CloudFormation/src/CloudFormationClient.php
@@ -114,15 +114,8 @@ class CloudFormationClient extends AbstractApi
                 ];
             case 'us-isob-east-1':
                 return [
-                    'endpoint' => "https://cloudformation.$region.sc2s.sgov.gov",
-                    'signRegion' => $region,
-                    'signService' => 'cloudformation',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://cloudformation.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
+                    'endpoint' => 'https://cloudformation.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
                     'signService' => 'cloudformation',
                     'signVersions' => ['v4'],
                 ];
@@ -133,13 +126,6 @@ class CloudFormationClient extends AbstractApi
                     'signService' => 'cloudformation',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://cloudformation.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
-                    'signService' => 'cloudformation',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-east-2-fips':
                 return [
                     'endpoint' => 'https://cloudformation-fips.us-east-2.amazonaws.com',
@@ -147,38 +133,10 @@ class CloudFormationClient extends AbstractApi
                     'signService' => 'cloudformation',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-gov-east-1':
-                return [
-                    'endpoint' => 'https://cloudformation.us-gov-east-1.amazonaws.com',
-                    'signRegion' => 'us-gov-east-1',
-                    'signService' => 'cloudformation',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://cloudformation.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'cloudformation',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://cloudformation.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'cloudformation',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-west-1-fips':
                 return [
                     'endpoint' => 'https://cloudformation-fips.us-west-1.amazonaws.com',
                     'signRegion' => 'us-west-1',
-                    'signService' => 'cloudformation',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://cloudformation.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
                     'signService' => 'cloudformation',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/CloudWatch/src/CloudWatchClient.php
+++ b/src/Service/CloudWatch/src/CloudWatchClient.php
@@ -198,8 +198,8 @@ class CloudWatchClient extends AbstractApi
                 ];
             case 'us-isob-east-1':
                 return [
-                    'endpoint' => "https://monitoring.$region.sc2s.sgov.gov",
-                    'signRegion' => $region,
+                    'endpoint' => 'https://monitoring.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
                     'signService' => 'monitoring',
                     'signVersions' => ['v4'],
                 ];
@@ -241,48 +241,6 @@ class CloudWatchClient extends AbstractApi
             case 'fips-us-west-2':
                 return [
                     'endpoint' => 'https://monitoring-fips.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
-                    'signService' => 'monitoring',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://monitoring.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'monitoring',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://monitoring.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
-                    'signService' => 'monitoring',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-east-1':
-                return [
-                    'endpoint' => 'https://monitoring.us-gov-east-1.amazonaws.com',
-                    'signRegion' => 'us-gov-east-1',
-                    'signService' => 'monitoring',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://monitoring.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'monitoring',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://monitoring.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'monitoring',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://monitoring.us-west-2.amazonaws.com',
                     'signRegion' => 'us-west-2',
                     'signService' => 'monitoring',
                     'signVersions' => ['v4'],

--- a/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
+++ b/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
@@ -197,8 +197,8 @@ class CloudWatchLogsClient extends AbstractApi
                 ];
             case 'us-isob-east-1':
                 return [
-                    'endpoint' => "https://logs.$region.sc2s.sgov.gov",
-                    'signRegion' => $region,
+                    'endpoint' => 'https://logs.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
                     'signService' => 'logs',
                     'signVersions' => ['v4'],
                 ];
@@ -226,48 +226,6 @@ class CloudWatchLogsClient extends AbstractApi
             case 'fips-us-west-2':
                 return [
                     'endpoint' => 'https://logs-fips.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
-                    'signService' => 'logs',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://logs.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'logs',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://logs.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
-                    'signService' => 'logs',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-east-1':
-                return [
-                    'endpoint' => 'https://logs.us-gov-east-1.amazonaws.com',
-                    'signRegion' => 'us-gov-east-1',
-                    'signService' => 'logs',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://logs.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'logs',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://logs.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'logs',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://logs.us-west-2.amazonaws.com',
                     'signRegion' => 'us-west-2',
                     'signService' => 'logs',
                     'signVersions' => ['v4'],

--- a/src/Service/CodeDeploy/src/CodeDeployClient.php
+++ b/src/Service/CodeDeploy/src/CodeDeployClient.php
@@ -231,15 +231,8 @@ class CodeDeployClient extends AbstractApi
                 ];
             case 'us-isob-east-1':
                 return [
-                    'endpoint' => "https://codedeploy.$region.sc2s.sgov.gov",
-                    'signRegion' => $region,
-                    'signService' => 'codedeploy',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://codedeploy.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
+                    'endpoint' => 'https://codedeploy.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
                     'signService' => 'codedeploy',
                     'signVersions' => ['v4'],
                 ];
@@ -250,24 +243,10 @@ class CodeDeployClient extends AbstractApi
                     'signService' => 'codedeploy',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://codedeploy.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
-                    'signService' => 'codedeploy',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-east-2-fips':
                 return [
                     'endpoint' => 'https://codedeploy-fips.us-east-2.amazonaws.com',
                     'signRegion' => 'us-east-2',
-                    'signService' => 'codedeploy',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-east-1':
-                return [
-                    'endpoint' => 'https://codedeploy.us-gov-east-1.amazonaws.com',
-                    'signRegion' => 'us-gov-east-1',
                     'signService' => 'codedeploy',
                     'signVersions' => ['v4'],
                 ];
@@ -278,13 +257,6 @@ class CodeDeployClient extends AbstractApi
                     'signService' => 'codedeploy',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://codedeploy.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'codedeploy',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-gov-west-1-fips':
                 return [
                     'endpoint' => 'https://codedeploy-fips.us-gov-west-1.amazonaws.com',
@@ -292,24 +264,10 @@ class CodeDeployClient extends AbstractApi
                     'signService' => 'codedeploy',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://codedeploy.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'codedeploy',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-west-1-fips':
                 return [
                     'endpoint' => 'https://codedeploy-fips.us-west-1.amazonaws.com',
                     'signRegion' => 'us-west-1',
-                    'signService' => 'codedeploy',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://codedeploy.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
                     'signService' => 'codedeploy',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
+++ b/src/Service/CognitoIdentityProvider/src/CognitoIdentityProviderClient.php
@@ -1099,41 +1099,6 @@ class CognitoIdentityProviderClient extends AbstractApi
                     'signService' => 'cognito-idp',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://cognito-idp.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'cognito-idp',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://cognito-idp.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
-                    'signService' => 'cognito-idp',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://cognito-idp.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'cognito-idp',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://cognito-idp.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'cognito-idp',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://cognito-idp.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
-                    'signService' => 'cognito-idp',
-                    'signVersions' => ['v4'],
-                ];
         }
 
         return [

--- a/src/Service/DynamoDb/src/DynamoDbClient.php
+++ b/src/Service/DynamoDb/src/DynamoDbClient.php
@@ -662,22 +662,15 @@ class DynamoDbClient extends AbstractApi
                 ];
             case 'us-iso-west-1':
                 return [
-                    'endpoint' => "https://dynamodb.$region.c2s.ic.gov",
-                    'signRegion' => $region,
+                    'endpoint' => 'https://dynamodb.us-iso-west-1.c2s.ic.gov',
+                    'signRegion' => 'us-iso-west-1',
                     'signService' => 'dynamodb',
                     'signVersions' => ['v4'],
                 ];
             case 'us-isob-east-1':
                 return [
-                    'endpoint' => "https://dynamodb.$region.sc2s.sgov.gov",
-                    'signRegion' => $region,
-                    'signService' => 'dynamodb',
-                    'signVersions' => ['v4'],
-                ];
-            case 'ca-central-1':
-                return [
-                    'endpoint' => 'https://dynamodb.ca-central-1.amazonaws.com',
-                    'signRegion' => 'ca-central-1',
+                    'endpoint' => 'https://dynamodb.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
                     'signService' => 'dynamodb',
                     'signVersions' => ['v4'],
                 ];
@@ -695,24 +688,10 @@ class DynamoDbClient extends AbstractApi
                     'signService' => 'dynamodb',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://dynamodb.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'dynamodb',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-east-1-fips':
                 return [
                     'endpoint' => 'https://dynamodb-fips.us-east-1.amazonaws.com',
                     'signRegion' => 'us-east-1',
-                    'signService' => 'dynamodb',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://dynamodb.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
                     'signService' => 'dynamodb',
                     'signVersions' => ['v4'],
                 ];
@@ -723,24 +702,10 @@ class DynamoDbClient extends AbstractApi
                     'signService' => 'dynamodb',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-gov-east-1':
-                return [
-                    'endpoint' => 'https://dynamodb.us-gov-east-1.amazonaws.com',
-                    'signRegion' => 'us-gov-east-1',
-                    'signService' => 'dynamodb',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-gov-east-1-fips':
                 return [
                     'endpoint' => 'https://dynamodb.us-gov-east-1.amazonaws.com',
                     'signRegion' => 'us-gov-east-1',
-                    'signService' => 'dynamodb',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://dynamodb.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
                     'signService' => 'dynamodb',
                     'signVersions' => ['v4'],
                 ];
@@ -758,24 +723,10 @@ class DynamoDbClient extends AbstractApi
                     'signService' => 'dynamodb',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://dynamodb.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'dynamodb',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-west-1-fips':
                 return [
                     'endpoint' => 'https://dynamodb-fips.us-west-1.amazonaws.com',
                     'signRegion' => 'us-west-1',
-                    'signService' => 'dynamodb',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://dynamodb.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
                     'signService' => 'dynamodb',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/ElastiCache/src/ElastiCacheClient.php
+++ b/src/Service/ElastiCache/src/ElastiCacheClient.php
@@ -67,13 +67,6 @@ class ElastiCacheClient extends AbstractApi
                     'signService' => 'elasticache',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-gov-east-1':
-                return [
-                    'endpoint' => "https://elasticache.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'elasticache',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -84,8 +77,8 @@ class ElastiCacheClient extends AbstractApi
                 ];
             case 'us-isob-east-1':
                 return [
-                    'endpoint' => "https://elasticache.$region.sc2s.sgov.gov",
-                    'signRegion' => $region,
+                    'endpoint' => 'https://elasticache.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
                     'signService' => 'elasticache',
                     'signVersions' => ['v4'],
                 ];
@@ -96,24 +89,10 @@ class ElastiCacheClient extends AbstractApi
                     'signService' => 'elasticache',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://elasticache.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'elasticache',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-east-1-fips':
                 return [
                     'endpoint' => 'https://elasticache-fips.us-east-1.amazonaws.com',
                     'signRegion' => 'us-east-1',
-                    'signService' => 'elasticache',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://elasticache.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
                     'signService' => 'elasticache',
                     'signVersions' => ['v4'],
                 ];
@@ -124,13 +103,6 @@ class ElastiCacheClient extends AbstractApi
                     'signService' => 'elasticache',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://elasticache.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'elasticache',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-gov-west-1-fips':
                 return [
                     'endpoint' => 'https://elasticache.us-gov-west-1.amazonaws.com',
@@ -138,24 +110,10 @@ class ElastiCacheClient extends AbstractApi
                     'signService' => 'elasticache',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://elasticache.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'elasticache',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-west-1-fips':
                 return [
                     'endpoint' => 'https://elasticache-fips.us-west-1.amazonaws.com',
                     'signRegion' => 'us-west-1',
-                    'signService' => 'elasticache',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://elasticache.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
                     'signService' => 'elasticache',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/EventBridge/src/EventBridgeClient.php
+++ b/src/Service/EventBridge/src/EventBridgeClient.php
@@ -67,8 +67,8 @@ class EventBridgeClient extends AbstractApi
                 ];
             case 'us-isob-east-1':
                 return [
-                    'endpoint' => "https://events.$region.sc2s.sgov.gov",
-                    'signRegion' => $region,
+                    'endpoint' => 'https://events.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
                     'signService' => 'events',
                     'signVersions' => ['v4'],
                 ];
@@ -96,48 +96,6 @@ class EventBridgeClient extends AbstractApi
             case 'fips-us-west-2':
                 return [
                     'endpoint' => 'https://events-fips.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
-                    'signService' => 'events',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://events.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'events',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://events.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
-                    'signService' => 'events',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-east-1':
-                return [
-                    'endpoint' => 'https://events.us-gov-east-1.amazonaws.com',
-                    'signRegion' => 'us-gov-east-1',
-                    'signService' => 'events',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://events.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'events',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://events.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'events',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://events.us-west-2.amazonaws.com',
                     'signRegion' => 'us-west-2',
                     'signService' => 'events',
                     'signVersions' => ['v4'],

--- a/src/Service/Firehose/src/FirehoseClient.php
+++ b/src/Service/Firehose/src/FirehoseClient.php
@@ -104,8 +104,8 @@ class FirehoseClient extends AbstractApi
                 ];
             case 'us-iso-east-1':
                 return [
-                    'endpoint' => "https://firehose.$region.c2s.ic.gov",
-                    'signRegion' => $region,
+                    'endpoint' => 'https://firehose.us-iso-east-1.c2s.ic.gov',
+                    'signRegion' => 'us-iso-east-1',
                     'signService' => 'firehose',
                     'signVersions' => ['v4'],
                 ];
@@ -147,48 +147,6 @@ class FirehoseClient extends AbstractApi
             case 'fips-us-west-2':
                 return [
                     'endpoint' => 'https://firehose-fips.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
-                    'signService' => 'firehose',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://firehose.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'firehose',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://firehose.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
-                    'signService' => 'firehose',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-east-1':
-                return [
-                    'endpoint' => 'https://firehose.us-gov-east-1.amazonaws.com',
-                    'signRegion' => 'us-gov-east-1',
-                    'signService' => 'firehose',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://firehose.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'firehose',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://firehose.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'firehose',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://firehose.us-west-2.amazonaws.com',
                     'signRegion' => 'us-west-2',
                     'signService' => 'firehose',
                     'signVersions' => ['v4'],

--- a/src/Service/Kinesis/src/KinesisClient.php
+++ b/src/Service/Kinesis/src/KinesisClient.php
@@ -1030,8 +1030,8 @@ class KinesisClient extends AbstractApi
                 ];
             case 'us-isob-east-1':
                 return [
-                    'endpoint' => "https://kinesis.$region.sc2s.sgov.gov",
-                    'signRegion' => $region,
+                    'endpoint' => 'https://kinesis.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
                     'signService' => 'kinesis',
                     'signVersions' => ['v4'],
                 ];
@@ -1059,48 +1059,6 @@ class KinesisClient extends AbstractApi
             case 'fips-us-west-2':
                 return [
                     'endpoint' => 'https://kinesis-fips.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
-                    'signService' => 'kinesis',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://kinesis.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'kinesis',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://kinesis.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
-                    'signService' => 'kinesis',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-east-1':
-                return [
-                    'endpoint' => 'https://kinesis.us-gov-east-1.amazonaws.com',
-                    'signRegion' => 'us-gov-east-1',
-                    'signService' => 'kinesis',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://kinesis.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'kinesis',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://kinesis.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'kinesis',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://kinesis.us-west-2.amazonaws.com',
                     'signRegion' => 'us-west-2',
                     'signService' => 'kinesis',
                     'signVersions' => ['v4'],

--- a/src/Service/Lambda/src/LambdaClient.php
+++ b/src/Service/Lambda/src/LambdaClient.php
@@ -377,8 +377,8 @@ class LambdaClient extends AbstractApi
                 ];
             case 'us-isob-east-1':
                 return [
-                    'endpoint' => "https://lambda.$region.sc2s.sgov.gov",
-                    'signRegion' => $region,
+                    'endpoint' => 'https://lambda.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
                     'signService' => 'lambda',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/RdsDataService/src/RdsDataServiceClient.php
+++ b/src/Service/RdsDataService/src/RdsDataServiceClient.php
@@ -221,37 +221,6 @@ class RdsDataServiceClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'cn-north-1':
-            case 'cn-northwest-1':
-                return [
-                    'endpoint' => "https://rds-data.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'rds-data',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-east-1':
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => "https://rds-data.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'rds-data',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-iso-east-1':
-            case 'us-iso-west-1':
-                return [
-                    'endpoint' => "https://rds-data.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'rds-data',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-isob-east-1':
-                return [
-                    'endpoint' => "https://rds-data.$region.amazonaws.com",
-                    'signRegion' => $region,
-                    'signService' => 'rds-data',
-                    'signVersions' => ['v4'],
-                ];
         }
 
         return [

--- a/src/Service/Rekognition/src/RekognitionClient.php
+++ b/src/Service/Rekognition/src/RekognitionClient.php
@@ -439,13 +439,6 @@ class RekognitionClient extends AbstractApi
         }
 
         switch ($region) {
-            case 'ca-central-1':
-                return [
-                    'endpoint' => 'https://rekognition.ca-central-1.amazonaws.com',
-                    'signRegion' => 'ca-central-1',
-                    'signService' => 'rekognition',
-                    'signVersions' => ['v4'],
-                ];
             case 'ca-central-1-fips':
                 return [
                     'endpoint' => 'https://rekognition-fips.ca-central-1.amazonaws.com',
@@ -537,24 +530,10 @@ class RekognitionClient extends AbstractApi
                     'signService' => 'rekognition',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://rekognition.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'rekognition',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-east-1-fips':
                 return [
                     'endpoint' => 'https://rekognition-fips.us-east-1.amazonaws.com',
                     'signRegion' => 'us-east-1',
-                    'signService' => 'rekognition',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://rekognition.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
                     'signService' => 'rekognition',
                     'signVersions' => ['v4'],
                 ];
@@ -565,13 +544,6 @@ class RekognitionClient extends AbstractApi
                     'signService' => 'rekognition',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://rekognition.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'rekognition',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-gov-west-1-fips':
                 return [
                     'endpoint' => 'https://rekognition-fips.us-gov-west-1.amazonaws.com',
@@ -579,24 +551,10 @@ class RekognitionClient extends AbstractApi
                     'signService' => 'rekognition',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://rekognition.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'rekognition',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-west-1-fips':
                 return [
                     'endpoint' => 'https://rekognition-fips.us-west-1.amazonaws.com',
                     'signRegion' => 'us-west-1',
-                    'signService' => 'rekognition',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://rekognition.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
                     'signService' => 'rekognition',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -926,15 +926,15 @@ class S3Client extends AbstractApi
         switch ($region) {
             case 'us-iso-west-1':
                 return [
-                    'endpoint' => "https://s3.$region.c2s.ic.gov",
-                    'signRegion' => $region,
+                    'endpoint' => 'https://s3.us-iso-west-1.c2s.ic.gov',
+                    'signRegion' => 'us-iso-west-1',
                     'signService' => 's3',
                     'signVersions' => ['s3v4'],
                 ];
             case 'us-isob-east-1':
                 return [
-                    'endpoint' => "https://s3.$region.sc2s.sgov.gov",
-                    'signRegion' => $region,
+                    'endpoint' => 'https://s3.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
                     'signService' => 's3',
                     'signVersions' => ['s3v4'],
                 ];

--- a/src/Service/SecretsManager/src/SecretsManagerClient.php
+++ b/src/Service/SecretsManager/src/SecretsManagerClient.php
@@ -298,15 +298,8 @@ class SecretsManagerClient extends AbstractApi
                 ];
             case 'us-iso-east-1':
                 return [
-                    'endpoint' => "https://secretsmanager.$region.c2s.ic.gov",
-                    'signRegion' => $region,
-                    'signService' => 'secretsmanager',
-                    'signVersions' => ['v4'],
-                ];
-            case 'ca-central-1':
-                return [
-                    'endpoint' => 'https://secretsmanager.ca-central-1.amazonaws.com',
-                    'signRegion' => 'ca-central-1',
+                    'endpoint' => 'https://secretsmanager.us-iso-east-1.c2s.ic.gov',
+                    'signRegion' => 'us-iso-east-1',
                     'signService' => 'secretsmanager',
                     'signVersions' => ['v4'],
                 ];
@@ -317,24 +310,10 @@ class SecretsManagerClient extends AbstractApi
                     'signService' => 'secretsmanager',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://secretsmanager.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'secretsmanager',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-east-1-fips':
                 return [
                     'endpoint' => 'https://secretsmanager-fips.us-east-1.amazonaws.com',
                     'signRegion' => 'us-east-1',
-                    'signService' => 'secretsmanager',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://secretsmanager.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
                     'signService' => 'secretsmanager',
                     'signVersions' => ['v4'],
                 ];
@@ -345,24 +324,10 @@ class SecretsManagerClient extends AbstractApi
                     'signService' => 'secretsmanager',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-gov-east-1':
-                return [
-                    'endpoint' => 'https://secretsmanager.us-gov-east-1.amazonaws.com',
-                    'signRegion' => 'us-gov-east-1',
-                    'signService' => 'secretsmanager',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-gov-east-1-fips':
                 return [
                     'endpoint' => 'https://secretsmanager-fips.us-gov-east-1.amazonaws.com',
                     'signRegion' => 'us-gov-east-1',
-                    'signService' => 'secretsmanager',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://secretsmanager.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
                     'signService' => 'secretsmanager',
                     'signVersions' => ['v4'],
                 ];
@@ -373,24 +338,10 @@ class SecretsManagerClient extends AbstractApi
                     'signService' => 'secretsmanager',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://secretsmanager.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'secretsmanager',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-west-1-fips':
                 return [
                     'endpoint' => 'https://secretsmanager-fips.us-west-1.amazonaws.com',
                     'signRegion' => 'us-west-1',
-                    'signService' => 'secretsmanager',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://secretsmanager.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
                     'signService' => 'secretsmanager',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/Ses/src/SesClient.php
+++ b/src/Service/Ses/src/SesClient.php
@@ -89,13 +89,6 @@ class SesClient extends AbstractApi
                     'signService' => 'ses',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://email.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'ses',
-                    'signVersions' => ['v4'],
-                ];
         }
 
         return [

--- a/src/Service/Sns/src/SnsClient.php
+++ b/src/Service/Sns/src/SnsClient.php
@@ -455,15 +455,15 @@ class SnsClient extends AbstractApi
                 ];
             case 'us-iso-west-1':
                 return [
-                    'endpoint' => "https://sns.$region.c2s.ic.gov",
-                    'signRegion' => $region,
+                    'endpoint' => 'https://sns.us-iso-west-1.c2s.ic.gov',
+                    'signRegion' => 'us-iso-west-1',
                     'signService' => 'sns',
                     'signVersions' => ['v4'],
                 ];
             case 'us-isob-east-1':
                 return [
-                    'endpoint' => "https://sns.$region.sc2s.sgov.gov",
-                    'signRegion' => $region,
+                    'endpoint' => 'https://sns.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
                     'signService' => 'sns',
                     'signVersions' => ['v4'],
                 ];
@@ -495,52 +495,10 @@ class SnsClient extends AbstractApi
                     'signService' => 'sns',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://sns.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'sns',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://sns.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
-                    'signService' => 'sns',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-east-1':
-                return [
-                    'endpoint' => 'https://sns.us-gov-east-1.amazonaws.com',
-                    'signRegion' => 'us-gov-east-1',
-                    'signService' => 'sns',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://sns.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'sns',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-iso-east-1':
                 return [
                     'endpoint' => 'https://sns.us-iso-east-1.c2s.ic.gov',
                     'signRegion' => 'us-iso-east-1',
-                    'signService' => 'sns',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://sns.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'sns',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://sns.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
                     'signService' => 'sns',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/Sqs/src/SqsClient.php
+++ b/src/Service/Sqs/src/SqsClient.php
@@ -460,15 +460,15 @@ class SqsClient extends AbstractApi
                 ];
             case 'us-iso-west-1':
                 return [
-                    'endpoint' => "https://sqs.$region.c2s.ic.gov",
-                    'signRegion' => $region,
+                    'endpoint' => 'https://sqs.us-iso-west-1.c2s.ic.gov',
+                    'signRegion' => 'us-iso-west-1',
                     'signService' => 'sqs',
                     'signVersions' => ['v4'],
                 ];
             case 'us-isob-east-1':
                 return [
-                    'endpoint' => "https://sqs.$region.sc2s.sgov.gov",
-                    'signRegion' => $region,
+                    'endpoint' => 'https://sqs.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
                     'signService' => 'sqs',
                     'signVersions' => ['v4'],
                 ];
@@ -500,52 +500,10 @@ class SqsClient extends AbstractApi
                     'signService' => 'sqs',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://sqs.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'sqs',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://sqs.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
-                    'signService' => 'sqs',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-east-1':
-                return [
-                    'endpoint' => 'https://sqs.us-gov-east-1.amazonaws.com',
-                    'signRegion' => 'us-gov-east-1',
-                    'signService' => 'sqs',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://sqs.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'sqs',
-                    'signVersions' => ['v4'],
-                ];
             case 'us-iso-east-1':
                 return [
                     'endpoint' => 'https://sqs.us-iso-east-1.c2s.ic.gov',
                     'signRegion' => 'us-iso-east-1',
-                    'signService' => 'sqs',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://sqs.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'sqs',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://sqs.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
                     'signService' => 'sqs',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/Ssm/src/SsmClient.php
+++ b/src/Service/Ssm/src/SsmClient.php
@@ -275,22 +275,15 @@ class SsmClient extends AbstractApi
                 ];
             case 'us-iso-east-1':
                 return [
-                    'endpoint' => "https://ssm.$region.c2s.ic.gov",
-                    'signRegion' => $region,
+                    'endpoint' => 'https://ssm.us-iso-east-1.c2s.ic.gov',
+                    'signRegion' => 'us-iso-east-1',
                     'signService' => 'ssm',
                     'signVersions' => ['v4'],
                 ];
             case 'us-isob-east-1':
                 return [
-                    'endpoint' => "https://ssm.$region.sc2s.sgov.gov",
-                    'signRegion' => $region,
-                    'signService' => 'ssm',
-                    'signVersions' => ['v4'],
-                ];
-            case 'ca-central-1':
-                return [
-                    'endpoint' => 'https://ssm.ca-central-1.amazonaws.com',
-                    'signRegion' => 'ca-central-1',
+                    'endpoint' => 'https://ssm.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
                     'signService' => 'ssm',
                     'signVersions' => ['v4'],
                 ];
@@ -339,48 +332,6 @@ class SsmClient extends AbstractApi
             case 'fips-us-west-2':
                 return [
                     'endpoint' => 'https://ssm-fips.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
-                    'signService' => 'ssm',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://ssm.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'ssm',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://ssm.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
-                    'signService' => 'ssm',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-east-1':
-                return [
-                    'endpoint' => 'https://ssm.us-gov-east-1.amazonaws.com',
-                    'signRegion' => 'us-gov-east-1',
-                    'signService' => 'ssm',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://ssm.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'ssm',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://ssm.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'ssm',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://ssm.us-west-2.amazonaws.com',
                     'signRegion' => 'us-west-2',
                     'signService' => 'ssm',
                     'signVersions' => ['v4'],

--- a/src/Service/StepFunctions/src/StepFunctionsClient.php
+++ b/src/Service/StepFunctions/src/StepFunctionsClient.php
@@ -195,8 +195,8 @@ class StepFunctionsClient extends AbstractApi
                 ];
             case 'us-isob-east-1':
                 return [
-                    'endpoint' => "https://states.$region.sc2s.sgov.gov",
-                    'signRegion' => $region,
+                    'endpoint' => 'https://states.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
                     'signService' => 'states',
                     'signVersions' => ['v4'],
                 ];
@@ -238,48 +238,6 @@ class StepFunctionsClient extends AbstractApi
             case 'fips-us-west-2':
                 return [
                     'endpoint' => 'https://states-fips.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
-                    'signService' => 'states',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://states.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'states',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://states.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
-                    'signService' => 'states',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-east-1':
-                return [
-                    'endpoint' => 'https://states.us-gov-east-1.amazonaws.com',
-                    'signRegion' => 'us-gov-east-1',
-                    'signService' => 'states',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://states.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'states',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://states.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'states',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://states.us-west-2.amazonaws.com',
                     'signRegion' => 'us-west-2',
                     'signService' => 'states',
                     'signVersions' => ['v4'],

--- a/src/Service/XRay/src/XRayClient.php
+++ b/src/Service/XRay/src/XRayClient.php
@@ -104,48 +104,6 @@ class XRayClient extends AbstractApi
                     'signService' => 'xray',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-east-1':
-                return [
-                    'endpoint' => 'https://xray.us-east-1.amazonaws.com',
-                    'signRegion' => 'us-east-1',
-                    'signService' => 'xray',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-east-2':
-                return [
-                    'endpoint' => 'https://xray.us-east-2.amazonaws.com',
-                    'signRegion' => 'us-east-2',
-                    'signService' => 'xray',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-east-1':
-                return [
-                    'endpoint' => 'https://xray.us-gov-east-1.amazonaws.com',
-                    'signRegion' => 'us-gov-east-1',
-                    'signService' => 'xray',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-gov-west-1':
-                return [
-                    'endpoint' => 'https://xray.us-gov-west-1.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'xray',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-1':
-                return [
-                    'endpoint' => 'https://xray.us-west-1.amazonaws.com',
-                    'signRegion' => 'us-west-1',
-                    'signService' => 'xray',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-west-2':
-                return [
-                    'endpoint' => 'https://xray.us-west-2.amazonaws.com',
-                    'signRegion' => 'us-west-2',
-                    'signService' => 'xray',
-                    'signVersions' => ['v4'],
-                ];
         }
 
         return [


### PR DESCRIPTION
This PR remove duplicate data in the generated `getEndpointMetadata` and reduce false-positive changes generated by the bot.

ie. in the below example, the case can be removed.
```
switch ($region) {
  case 'us-west-1':
    return [
      'endpoint' => 'https://sqs.us-west-1.amazonaws.com',
      'signRegion' => 'us-west-1',
      'signService' => 'sqs',
      'signVersions' => ['v4'],
    ];
}

return [
  'endpoint' => "https://sqs.$region.amazonaws.com",
  'signRegion' => $region,
  'signService' => 'sqs',
  'signVersions' => ['v4'],
];
```