### PR TITLE
Do not send request with null body

### DIFF
--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Make the injected HttpClient decorated by our  `RetryableHttpClient`
 - Support for KMS
 
+### Fixed
+
+- Issue with symfony http-client when posting empty payload
+
 ## 1.13.0
 
 ### Added

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -154,8 +154,7 @@ abstract class AbstractApi
             $request->getEndpoint(),
             [
                 'headers' => $request->getHeaders(),
-                'body' => 0 === $length ? null : $requestBody,
-            ]
+            ] + (0 === $length ? [] : ['body' => $requestBody])
         );
 
         if ($debug = filter_var($this->configuration->get('debug'), \FILTER_VALIDATE_BOOLEAN)) {


### PR DESCRIPTION
The `body` option should not be null. In the next version of Symfony, it will throw an exception (see symfony/symfony#45566).