### PR TITLE
Do not enable chunked-body by default

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,7 +113,7 @@ See [Virtual Hosting of Buckets](https://docs.aws.amazon.com/AmazonS3/latest/dev
 
 ### sendChunkedBody
 
-**Default:** 'true'
+**Default:** 'false'
 
 Set to true to send requests in multiple chunks. This prevents reading the file
 twice to calculate the signature, but is not always allowed by Non-AWS S3

--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -5,10 +5,11 @@
 ### Added
 
 - Support for CodeBuild
-
-### Added
-
 - AWS enhancement: Documentation updates.
+
+### Changed
+
+- Set default value to `false` for the `sendChunkedBody` option.
 
 ## 1.14.0
 

--- a/src/Core/src/Configuration.php
+++ b/src/Core/src/Configuration.php
@@ -81,7 +81,7 @@ final class Configuration
         // https://docs.aws.amazon.com/general/latest/gr/rande.html
         self::OPTION_ENDPOINT => 'https://%service%.%region%.amazonaws.com',
         self::OPTION_PATH_STYLE_ENDPOINT => 'false',
-        self::OPTION_SEND_CHUNKED_BODY => 'true',
+        self::OPTION_SEND_CHUNKED_BODY => 'false',
     ];
 
     private $data = [];

--- a/src/Service/S3/CHANGELOG.md
+++ b/src/Service/S3/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Changed
+
+- Set default value to `false` for the `sendChunkedBody` option.
+
 ## 1.11.0
 
 ### Added

--- a/src/Service/S3/src/Signer/SignerV4ForS3.php
+++ b/src/Service/S3/src/Signer/SignerV4ForS3.php
@@ -49,7 +49,7 @@ class SignerV4ForS3 extends SignerV4
     {
         parent::__construct($scopeName, $region);
 
-        $this->sendChunkedBody = $s3SignerOptions[Configuration::OPTION_SEND_CHUNKED_BODY] ?? true;
+        $this->sendChunkedBody = $s3SignerOptions[Configuration::OPTION_SEND_CHUNKED_BODY] ?? false;
         unset($s3SignerOptions[Configuration::OPTION_SEND_CHUNKED_BODY]);
 
         if (!empty($s3SignerOptions)) {


### PR DESCRIPTION
Because AWS has a bug and lets an empty `ContentEncoding` header (which break browser that serve such file).
see https://github.com/aws-amplify/aws-sdk-ios/issues/443, https://github.com/aws/aws-sdk-net/issues/559 

I think we should not enable this behavior by default (like what other SDKs do)