### PR TITLE
Update Cloudfront example

### DIFF
--- a/docs/clients/cloud-front.md
+++ b/docs/clients/cloud-front.md
@@ -24,7 +24,7 @@ $cloudFront->createInvalidation([
             'Quantity' => count($paths),
             'Items' => $paths,
         ]),
-        'CallerReference' => time(),
+        'CallerReference' => (string) time(),
     ]),
 ]);
 ```


### PR DESCRIPTION
`CallerReference` is defined as a string in `AsyncAws\CloudFront\ValueObject\InvalidationBatch` but `time()` return an integer.