### PR TITLE
Add support for endpoint discovery

### DIFF
--- a/docs/clients/timestream-query.md
+++ b/docs/clients/timestream-query.md
@@ -10,12 +10,12 @@ package: async-aws/timestream-query
 ### Execute a query
 
 ```php
-use AsyncAws\TimestreamQuery\Input\QueryInput;
+use AsyncAws\TimestreamQuery\Input\QueryRequest;
 use AsyncAws\TimestreamQuery\TimestreamQueryClient;
 
 $timestreamQuery = new TimestreamQueryClient();
 
-$result = $timestreamQuery->query(new QueryInput([
+$result = $timestreamQuery->query(new QueryRequest[
     'ClientToken' => 'qwertyuiop',
     'QueryString' => 'SELECT * FROM db.tbl ORDER BY time DESC LIMIT 10',
 ]));

--- a/src/CodeGenerator/src/Definition/Member.php
+++ b/src/CodeGenerator/src/Definition/Member.php
@@ -18,6 +18,10 @@ class Member
 
     public function __construct(array $data, \Closure $shapeLocator)
     {
+        if (isset($data['endpointdiscoveryid'])) {
+            throw new \LogicException('EndpointOperation with identifier parameters is not implemented yet');
+        }
+
         $this->data = $data;
         $this->shapeLocator = $shapeLocator;
     }

--- a/src/CodeGenerator/src/Definition/Operation.php
+++ b/src/CodeGenerator/src/Definition/Operation.php
@@ -173,6 +173,21 @@ class Operation
         return $this->data['deprecated'] ?? false;
     }
 
+    public function requiresEndpointDiscovery(): bool
+    {
+        return $this->data['endpointdiscovery']['required'] ?? false;
+    }
+
+    public function usesEndpointDiscovery(): bool
+    {
+        return isset($this->data['endpointdiscovery']);
+    }
+
+    public function isEndpointOperation(): bool
+    {
+        return $this->data['endpointoperation'] ?? false;
+    }
+
     private function getInputShape(): Shape
     {
         if (isset($this->data['input']['shape'])) {

--- a/src/CodeGenerator/src/Definition/ServiceDefinition.php
+++ b/src/CodeGenerator/src/Definition/ServiceDefinition.php
@@ -76,6 +76,17 @@ class ServiceDefinition
         return null;
     }
 
+    public function findEndpointOperationName(): ?Operation
+    {
+        foreach ($this->definition['operations'] as $name => $data) {
+            if (isset($data['endpointoperation'])) {
+                return $this->getOperation($name);
+            }
+        }
+
+        return null;
+    }
+
     public function getWaiter(string $name): ?Waiter
     {
         if (isset($this->waiter['waiters'][$name])) {
@@ -147,7 +158,6 @@ class ServiceDefinition
     private function getShape(string $name, ?Member $member, array $extra): ?Shape
     {
         if (isset($this->definition['shapes'][$name])) {
-            $documentation = null;
             if ($member instanceof StructureMember) {
                 $documentation = $this->documentation['shapes'][$name]['refs'][$member->getOwnerShape()->getName() . '$' . $member->getName()] ?? null;
             } else {

--- a/src/CodeGenerator/src/File/ComposerWriter.php
+++ b/src/CodeGenerator/src/File/ComposerWriter.php
@@ -30,7 +30,7 @@ class ComposerWriter
                 $content['require']['ext-filter'],
             );
         }
-        $content['require'] += $requirements;
+        $content['require'] = $requirements + $content['require'];
         uksort($content['require'], function ($a, $b) {
             $la = 'php' === $a ? 0 : ('ext-' === substr($a, 0, 4) ? 1 : 2);
             $lb = 'php' === $b ? 0 : ('ext-' === substr($b, 0, 4) ? 1 : 2);

--- a/src/CodeGenerator/src/Generator/ResultGenerator.php
+++ b/src/CodeGenerator/src/Generator/ResultGenerator.php
@@ -85,7 +85,7 @@ class ResultGenerator
         $classBuilder->addUse(ResponseInterface::class);
         $classBuilder->addUse(HttpClientInterface::class);
 
-        $this->populatorGenerator->generate($operation, $shape, $classBuilder);
+        $this->populatorGenerator->generate($operation, $shape, $classBuilder, false, $operation->isEndpointOperation());
         $this->addUse($shape, $classBuilder);
 
         return $className;

--- a/src/CodeGenerator/src/Generator/ServiceGenerator.php
+++ b/src/CodeGenerator/src/Generator/ServiceGenerator.php
@@ -124,7 +124,7 @@ class ServiceGenerator
 
     public function operation(): OperationGenerator
     {
-        return $this->operation ?? $this->operation = new OperationGenerator($this->classRegistry, $this->namespaceRegistry, $this->input(), $this->result(), $this->pagination(), $this->test(), $this->exception(), $this->type());
+        return $this->operation ?? $this->operation = new OperationGenerator($this->classRegistry, $this->namespaceRegistry, $this->requirementsRegistry, $this->input(), $this->result(), $this->pagination(), $this->test(), $this->exception(), $this->type());
     }
 
     public function waiter(): WaiterGenerator

--- a/src/CodeGenerator/src/Generator/TestGenerator.php
+++ b/src/CodeGenerator/src/Generator/TestGenerator.php
@@ -170,7 +170,7 @@ class TestGenerator
         $classBuilder->addUse(MockHttpClient::class);
 
         $exampleOutput = $operation->getExample()->getOutput();
-        $comment = $exampleOutput ? '// see example-1.json from SDK' : '// see https://docs.aws.amazon.com/SERVICE/latest/APIReference/API_OPERATION.html';
+        $comment = $exampleOutput ? '// see example-1.json from SDK' : '// see ' . $operation->getApiReferenceDocumentationUrl();
         switch ($operation->getService()->getProtocol()) {
             case 'rest-xml':
             case 'query':

--- a/src/Service/DynamoDb/CHANGELOG.md
+++ b/src/Service/DynamoDb/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Added
 
+- Added support for endpoint discovery
 - AWS enhancement: Documentation updates.
 
 ## 1.2.0

--- a/src/Service/DynamoDb/composer.json
+++ b/src/Service/DynamoDb/composer.json
@@ -14,7 +14,7 @@
         "php": "^7.2.5 || ^8.0",
         "ext-filter": "*",
         "ext-json": "*",
-        "async-aws/core": "^1.9",
+        "async-aws/core": "^1.16",
         "symfony/polyfill-uuid": "^1.0"
     },
     "conflict": {

--- a/src/Service/DynamoDb/src/DynamoDbClient.php
+++ b/src/Service/DynamoDb/src/DynamoDbClient.php
@@ -32,6 +32,7 @@ use AsyncAws\DynamoDb\Input\BatchWriteItemInput;
 use AsyncAws\DynamoDb\Input\CreateTableInput;
 use AsyncAws\DynamoDb\Input\DeleteItemInput;
 use AsyncAws\DynamoDb\Input\DeleteTableInput;
+use AsyncAws\DynamoDb\Input\DescribeEndpointsRequest;
 use AsyncAws\DynamoDb\Input\DescribeTableInput;
 use AsyncAws\DynamoDb\Input\ExecuteStatementInput;
 use AsyncAws\DynamoDb\Input\GetItemInput;
@@ -48,6 +49,7 @@ use AsyncAws\DynamoDb\Result\BatchWriteItemOutput;
 use AsyncAws\DynamoDb\Result\CreateTableOutput;
 use AsyncAws\DynamoDb\Result\DeleteItemOutput;
 use AsyncAws\DynamoDb\Result\DeleteTableOutput;
+use AsyncAws\DynamoDb\Result\DescribeEndpointsResponse;
 use AsyncAws\DynamoDb\Result\DescribeTableOutput;
 use AsyncAws\DynamoDb\Result\ExecuteStatementOutput;
 use AsyncAws\DynamoDb\Result\GetItemOutput;
@@ -107,7 +109,7 @@ class DynamoDbClient extends AbstractApi
             'ResourceNotFoundException' => ResourceNotFoundException::class,
             'RequestLimitExceeded' => RequestLimitExceededException::class,
             'InternalServerError' => InternalServerErrorException::class,
-        ]]));
+        ], 'usesEndpointDiscovery' => true]));
 
         return new BatchGetItemOutput($response, $this, $input);
     }
@@ -145,7 +147,7 @@ class DynamoDbClient extends AbstractApi
             'ItemCollectionSizeLimitExceededException' => ItemCollectionSizeLimitExceededException::class,
             'RequestLimitExceeded' => RequestLimitExceededException::class,
             'InternalServerError' => InternalServerErrorException::class,
-        ]]));
+        ], 'usesEndpointDiscovery' => true]));
 
         return new BatchWriteItemOutput($response);
     }
@@ -184,7 +186,7 @@ class DynamoDbClient extends AbstractApi
             'ResourceInUseException' => ResourceInUseException::class,
             'LimitExceededException' => LimitExceededException::class,
             'InternalServerError' => InternalServerErrorException::class,
-        ]]));
+        ], 'usesEndpointDiscovery' => true]));
 
         return new CreateTableOutput($response);
     }
@@ -229,7 +231,7 @@ class DynamoDbClient extends AbstractApi
             'TransactionConflictException' => TransactionConflictException::class,
             'RequestLimitExceeded' => RequestLimitExceededException::class,
             'InternalServerError' => InternalServerErrorException::class,
-        ]]));
+        ], 'usesEndpointDiscovery' => true]));
 
         return new DeleteItemOutput($response);
     }
@@ -262,9 +264,27 @@ class DynamoDbClient extends AbstractApi
             'ResourceNotFoundException' => ResourceNotFoundException::class,
             'LimitExceededException' => LimitExceededException::class,
             'InternalServerError' => InternalServerErrorException::class,
-        ]]));
+        ], 'usesEndpointDiscovery' => true]));
 
         return new DeleteTableOutput($response);
+    }
+
+    /**
+     * Returns the regional endpoint information.
+     *
+     * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeEndpoints.html
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-dynamodb-2012-08-10.html#describeendpoints
+     *
+     * @param array{
+     *   @region?: string,
+     * }|DescribeEndpointsRequest $input
+     */
+    public function describeEndpoints($input = []): DescribeEndpointsResponse
+    {
+        $input = DescribeEndpointsRequest::create($input);
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DescribeEndpoints', 'region' => $input->getRegion()]));
+
+        return new DescribeEndpointsResponse($response);
     }
 
     /**
@@ -288,7 +308,7 @@ class DynamoDbClient extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DescribeTable', 'region' => $input->getRegion(), 'exceptionMapping' => [
             'ResourceNotFoundException' => ResourceNotFoundException::class,
             'InternalServerError' => InternalServerErrorException::class,
-        ]]));
+        ], 'usesEndpointDiscovery' => true]));
 
         return new DescribeTableOutput($response);
     }
@@ -366,7 +386,7 @@ class DynamoDbClient extends AbstractApi
             'ResourceNotFoundException' => ResourceNotFoundException::class,
             'RequestLimitExceeded' => RequestLimitExceededException::class,
             'InternalServerError' => InternalServerErrorException::class,
-        ]]));
+        ], 'usesEndpointDiscovery' => true]));
 
         return new GetItemOutput($response);
     }
@@ -391,7 +411,7 @@ class DynamoDbClient extends AbstractApi
         $input = ListTablesInput::create($input);
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ListTables', 'region' => $input->getRegion(), 'exceptionMapping' => [
             'InternalServerError' => InternalServerErrorException::class,
-        ]]));
+        ], 'usesEndpointDiscovery' => true]));
 
         return new ListTablesOutput($response, $this, $input);
     }
@@ -439,7 +459,7 @@ class DynamoDbClient extends AbstractApi
             'TransactionConflictException' => TransactionConflictException::class,
             'RequestLimitExceeded' => RequestLimitExceededException::class,
             'InternalServerError' => InternalServerErrorException::class,
-        ]]));
+        ], 'usesEndpointDiscovery' => true]));
 
         return new PutItemOutput($response);
     }
@@ -486,7 +506,7 @@ class DynamoDbClient extends AbstractApi
             'ResourceNotFoundException' => ResourceNotFoundException::class,
             'RequestLimitExceeded' => RequestLimitExceededException::class,
             'InternalServerError' => InternalServerErrorException::class,
-        ]]));
+        ], 'usesEndpointDiscovery' => true]));
 
         return new QueryOutput($response, $this, $input);
     }
@@ -531,7 +551,7 @@ class DynamoDbClient extends AbstractApi
             'ResourceNotFoundException' => ResourceNotFoundException::class,
             'RequestLimitExceeded' => RequestLimitExceededException::class,
             'InternalServerError' => InternalServerErrorException::class,
-        ]]));
+        ], 'usesEndpointDiscovery' => true]));
 
         return new ScanOutput($response, $this, $input);
     }
@@ -610,7 +630,7 @@ class DynamoDbClient extends AbstractApi
             'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
             'RequestLimitExceeded' => RequestLimitExceededException::class,
             'InternalServerError' => InternalServerErrorException::class,
-        ]]));
+        ], 'usesEndpointDiscovery' => true]));
 
         return new TransactWriteItemsOutput($response);
     }
@@ -659,7 +679,7 @@ class DynamoDbClient extends AbstractApi
             'TransactionConflictException' => TransactionConflictException::class,
             'RequestLimitExceeded' => RequestLimitExceededException::class,
             'InternalServerError' => InternalServerErrorException::class,
-        ]]));
+        ], 'usesEndpointDiscovery' => true]));
 
         return new UpdateItemOutput($response);
     }
@@ -697,7 +717,7 @@ class DynamoDbClient extends AbstractApi
             'ResourceNotFoundException' => ResourceNotFoundException::class,
             'LimitExceededException' => LimitExceededException::class,
             'InternalServerError' => InternalServerErrorException::class,
-        ]]));
+        ], 'usesEndpointDiscovery' => true]));
 
         return new UpdateTableOutput($response);
     }
@@ -730,9 +750,14 @@ class DynamoDbClient extends AbstractApi
             'ResourceNotFoundException' => ResourceNotFoundException::class,
             'LimitExceededException' => LimitExceededException::class,
             'InternalServerError' => InternalServerErrorException::class,
-        ]]));
+        ], 'usesEndpointDiscovery' => true]));
 
         return new UpdateTimeToLiveOutput($response);
+    }
+
+    protected function discoverEndpoints(?string $region): array
+    {
+        return $this->describeEndpoints($region ? ['@region' => $region] : [])->getEndpoints();
     }
 
     protected function getAwsErrorFactory(): AwsErrorFactoryInterface

--- a/src/Service/DynamoDb/src/Input/DescribeEndpointsRequest.php
+++ b/src/Service/DynamoDb/src/Input/DescribeEndpointsRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Input;
+
+use AsyncAws\Core\Input;
+use AsyncAws\Core\Request;
+use AsyncAws\Core\Stream\StreamFactory;
+
+final class DescribeEndpointsRequest extends Input
+{
+    /**
+     * @param array{
+     *   @region?: string,
+     * } $input
+     */
+    public function __construct(array $input = [])
+    {
+        parent::__construct($input);
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    /**
+     * @internal
+     */
+    public function request(): Request
+    {
+        // Prepare headers
+        $headers = [
+            'Content-Type' => 'application/x-amz-json-1.0',
+            'X-Amz-Target' => 'DynamoDB_20120810.DescribeEndpoints',
+        ];
+
+        // Prepare query
+        $query = [];
+
+        // Prepare URI
+        $uriString = '/';
+
+        // Prepare Body
+        $bodyPayload = $this->requestBody();
+        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload, 4194304);
+
+        // Return the Request
+        return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));
+    }
+
+    private function requestBody(): array
+    {
+        $payload = [];
+
+        return $payload;
+    }
+}

--- a/src/Service/DynamoDb/src/Result/DescribeEndpointsResponse.php
+++ b/src/Service/DynamoDb/src/Result/DescribeEndpointsResponse.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Result;
+
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Result;
+use AsyncAws\DynamoDb\ValueObject\Endpoint;
+
+class DescribeEndpointsResponse extends Result
+{
+    /**
+     * List of endpoints.
+     */
+    private $endpoints;
+
+    /**
+     * @return Endpoint[]
+     */
+    public function getEndpoints(): array
+    {
+        $this->initialize();
+
+        return $this->endpoints;
+    }
+
+    protected function populateResult(Response $response): void
+    {
+        $data = $response->toArray();
+
+        $this->endpoints = $this->populateResultEndpoints($data['Endpoints']);
+    }
+
+    private function populateResultEndpoint(array $json): Endpoint
+    {
+        return new Endpoint([
+            'Address' => (string) $json['Address'],
+            'CachePeriodInMinutes' => (string) $json['CachePeriodInMinutes'],
+        ]);
+    }
+
+    /**
+     * @return Endpoint[]
+     */
+    private function populateResultEndpoints(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = $this->populateResultEndpoint($item);
+        }
+
+        return $items;
+    }
+}

--- a/src/Service/DynamoDb/src/ValueObject/Endpoint.php
+++ b/src/Service/DynamoDb/src/ValueObject/Endpoint.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace AsyncAws\DynamoDb\ValueObject;
+
+use AsyncAws\Core\EndpointDiscovery\EndpointInterface;
+
+/**
+ * An endpoint information details.
+ */
+final class Endpoint implements EndpointInterface
+{
+    /**
+     * IP address of the endpoint.
+     */
+    private $address;
+
+    /**
+     * Endpoint cache time to live (TTL) value.
+     */
+    private $cachePeriodInMinutes;
+
+    /**
+     * @param array{
+     *   Address: string,
+     *   CachePeriodInMinutes: string,
+     * } $input
+     */
+    public function __construct(array $input)
+    {
+        $this->address = $input['Address'] ?? null;
+        $this->cachePeriodInMinutes = $input['CachePeriodInMinutes'] ?? null;
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getAddress(): string
+    {
+        return $this->address;
+    }
+
+    public function getCachePeriodInMinutes(): int
+    {
+        return $this->cachePeriodInMinutes;
+    }
+}

--- a/src/Service/DynamoDb/tests/Integration/DynamoDbClientTest.php
+++ b/src/Service/DynamoDb/tests/Integration/DynamoDbClientTest.php
@@ -519,6 +519,23 @@ class DynamoDbClientTest extends TestCase
         self::assertSame('attribute', $result->getTimeToLiveSpecification()->getAttributeName());
     }
 
+    public function testDiscoveredEndpoint(): void
+    {
+        $client = new DynamoDbClient([
+            'endpoint' => 'http://localhost:4575',
+            'endpointDiscoveryEnabled' => true,
+        ], new Credentials('aws_id', 'aws_secret'));
+
+        $input = new ListTablesInput([
+            'ExclusiveStartTableName' => 'Thr',
+            'Limit' => 5,
+        ]);
+        $result = $client->ListTables($input);
+
+        $names = iterator_to_array($result->getTableNames(true));
+        self::assertTrue(\count($names) >= 0);
+    }
+
     private function getClient(): DynamoDbClient
     {
         if ($this->client instanceof DynamoDbClient) {

--- a/src/Service/DynamoDb/tests/Unit/Input/DescribeEndpointsRequestTest.php
+++ b/src/Service/DynamoDb/tests/Unit/Input/DescribeEndpointsRequestTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Tests\Unit\Input;
+
+use AsyncAws\Core\Test\TestCase;
+use AsyncAws\DynamoDb\Input\DescribeEndpointsRequest;
+
+class DescribeEndpointsRequestTest extends TestCase
+{
+    public function testRequest(): void
+    {
+        $input = new DescribeEndpointsRequest([
+
+        ]);
+
+        // see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeEndpoints.html
+        $expected = '
+            POST / HTTP/1.0
+            Content-Type: application/x-amz-json-1.0
+            x-amz-target: DynamoDB_20120810.DescribeEndpoints
+
+            {
+            }
+        ';
+
+        self::assertRequestEqualsHttpRequest($expected, $input->request());
+    }
+}

--- a/src/Service/DynamoDb/tests/Unit/Result/DescribeEndpointsResponseTest.php
+++ b/src/Service/DynamoDb/tests/Unit/Result/DescribeEndpointsResponseTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Tests\Unit\Result;
+
+use AsyncAws\Core\EndpointDiscovery\EndpointInterface;
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Test\Http\SimpleMockedResponse;
+use AsyncAws\Core\Test\TestCase;
+use AsyncAws\DynamoDb\Result\DescribeEndpointsResponse;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+
+class DescribeEndpointsResponseTest extends TestCase
+{
+    public function testDescribeEndpointsResponse(): void
+    {
+        // see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeEndpoints.html
+        $response = new SimpleMockedResponse('{
+           "Endpoints": [
+              {
+                 "Address": "www.aws.com",
+                 "CachePeriodInMinutes": 1234
+              }
+           ]
+        }');
+
+        $client = new MockHttpClient($response);
+        $result = new DescribeEndpointsResponse(new Response($client->request('POST', 'http://localhost'), $client, new NullLogger()));
+
+        self::assertCount(1, $result->getEndpoints());
+        self::assertInstanceOf(EndpointInterface::class, $result->getEndpoints()[0]);
+        self::assertSame('www.aws.com', $result->getEndpoints()[0]->getAddress());
+        self::assertSame(1234, $result->getEndpoints()[0]->getCachePeriodInMinutes());
+    }
+}

--- a/src/Service/TimestreamQuery/CHANGELOG.md
+++ b/src/Service/TimestreamQuery/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Added
+
+- Added support for endpoint discovery
+
 ## 0.1.0
 
 First version

--- a/src/Service/TimestreamQuery/composer.json
+++ b/src/Service/TimestreamQuery/composer.json
@@ -14,7 +14,7 @@
         "php": "^7.2.5 || ^8.0",
         "ext-filter": "*",
         "ext-json": "*",
-        "async-aws/core": "^1.9",
+        "async-aws/core": "^1.16",
         "symfony/polyfill-uuid": "^1.0"
     },
     "autoload": {

--- a/src/Service/TimestreamQuery/src/Input/DescribeEndpointsRequest.php
+++ b/src/Service/TimestreamQuery/src/Input/DescribeEndpointsRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace AsyncAws\TimestreamQuery\Input;
+
+use AsyncAws\Core\Input;
+use AsyncAws\Core\Request;
+use AsyncAws\Core\Stream\StreamFactory;
+
+final class DescribeEndpointsRequest extends Input
+{
+    /**
+     * @param array{
+     *   @region?: string,
+     * } $input
+     */
+    public function __construct(array $input = [])
+    {
+        parent::__construct($input);
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    /**
+     * @internal
+     */
+    public function request(): Request
+    {
+        // Prepare headers
+        $headers = [
+            'Content-Type' => 'application/x-amz-json-1.0',
+            'X-Amz-Target' => 'Timestream_20181101.DescribeEndpoints',
+        ];
+
+        // Prepare query
+        $query = [];
+
+        // Prepare URI
+        $uriString = '/';
+
+        // Prepare Body
+        $bodyPayload = $this->requestBody();
+        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload, 4194304);
+
+        // Return the Request
+        return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));
+    }
+
+    private function requestBody(): array
+    {
+        $payload = [];
+
+        return $payload;
+    }
+}

--- a/src/Service/TimestreamQuery/src/Result/DescribeEndpointsResponse.php
+++ b/src/Service/TimestreamQuery/src/Result/DescribeEndpointsResponse.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace AsyncAws\TimestreamQuery\Result;
+
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Result;
+use AsyncAws\TimestreamQuery\ValueObject\Endpoint;
+
+class DescribeEndpointsResponse extends Result
+{
+    /**
+     * An `Endpoints` object is returned when a `DescribeEndpoints` request is made.
+     */
+    private $endpoints;
+
+    /**
+     * @return Endpoint[]
+     */
+    public function getEndpoints(): array
+    {
+        $this->initialize();
+
+        return $this->endpoints;
+    }
+
+    protected function populateResult(Response $response): void
+    {
+        $data = $response->toArray();
+
+        $this->endpoints = $this->populateResultEndpoints($data['Endpoints']);
+    }
+
+    private function populateResultEndpoint(array $json): Endpoint
+    {
+        return new Endpoint([
+            'Address' => (string) $json['Address'],
+            'CachePeriodInMinutes' => (string) $json['CachePeriodInMinutes'],
+        ]);
+    }
+
+    /**
+     * @return Endpoint[]
+     */
+    private function populateResultEndpoints(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = $this->populateResultEndpoint($item);
+        }
+
+        return $items;
+    }
+}

--- a/src/Service/TimestreamQuery/src/TimestreamQueryClient.php
+++ b/src/Service/TimestreamQuery/src/TimestreamQueryClient.php
@@ -15,9 +15,11 @@ use AsyncAws\TimestreamQuery\Exception\QueryExecutionException;
 use AsyncAws\TimestreamQuery\Exception\ThrottlingException;
 use AsyncAws\TimestreamQuery\Exception\ValidationException;
 use AsyncAws\TimestreamQuery\Input\CancelQueryRequest;
+use AsyncAws\TimestreamQuery\Input\DescribeEndpointsRequest;
 use AsyncAws\TimestreamQuery\Input\PrepareQueryRequest;
 use AsyncAws\TimestreamQuery\Input\QueryRequest;
 use AsyncAws\TimestreamQuery\Result\CancelQueryResponse;
+use AsyncAws\TimestreamQuery\Result\DescribeEndpointsResponse;
 use AsyncAws\TimestreamQuery\Result\PrepareQueryResponse;
 use AsyncAws\TimestreamQuery\Result\QueryResponse;
 
@@ -53,9 +55,36 @@ class TimestreamQueryClient extends AbstractApi
             'ThrottlingException' => ThrottlingException::class,
             'ValidationException' => ValidationException::class,
             'InvalidEndpointException' => InvalidEndpointException::class,
-        ]]));
+        ], 'requiresEndpointDiscovery' => true, 'usesEndpointDiscovery' => true]));
 
         return new CancelQueryResponse($response);
+    }
+
+    /**
+     * DescribeEndpoints returns a list of available endpoints to make Timestream API calls against. This API is available
+     * through both Write and Query.
+     *
+     * @see https://docs.aws.amazon.com/timestream/latest/developerguide/API_DescribeEndpoints.html
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-query.timestream-2018-11-01.html#describeendpoints
+     *
+     * @param array{
+     *   @region?: string,
+     * }|DescribeEndpointsRequest $input
+     *
+     * @throws InternalServerException
+     * @throws ValidationException
+     * @throws ThrottlingException
+     */
+    public function describeEndpoints($input = []): DescribeEndpointsResponse
+    {
+        $input = DescribeEndpointsRequest::create($input);
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'DescribeEndpoints', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'InternalServerException' => InternalServerException::class,
+            'ValidationException' => ValidationException::class,
+            'ThrottlingException' => ThrottlingException::class,
+        ]]));
+
+        return new DescribeEndpointsResponse($response);
     }
 
     /**
@@ -86,7 +115,7 @@ class TimestreamQueryClient extends AbstractApi
             'ThrottlingException' => ThrottlingException::class,
             'ValidationException' => ValidationException::class,
             'InvalidEndpointException' => InvalidEndpointException::class,
-        ]]));
+        ], 'requiresEndpointDiscovery' => true, 'usesEndpointDiscovery' => true]));
 
         return new PrepareQueryResponse($response);
     }
@@ -127,9 +156,14 @@ class TimestreamQueryClient extends AbstractApi
             'ThrottlingException' => ThrottlingException::class,
             'ValidationException' => ValidationException::class,
             'InvalidEndpointException' => InvalidEndpointException::class,
-        ]]));
+        ], 'requiresEndpointDiscovery' => true, 'usesEndpointDiscovery' => true]));
 
         return new QueryResponse($response, $this, $input);
+    }
+
+    protected function discoverEndpoints(?string $region): array
+    {
+        return $this->describeEndpoints($region ? ['@region' => $region] : [])->getEndpoints();
     }
 
     protected function getAwsErrorFactory(): AwsErrorFactoryInterface

--- a/src/Service/TimestreamQuery/src/ValueObject/Endpoint.php
+++ b/src/Service/TimestreamQuery/src/ValueObject/Endpoint.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace AsyncAws\TimestreamQuery\ValueObject;
+
+use AsyncAws\Core\EndpointDiscovery\EndpointInterface;
+
+/**
+ * Represents an available endpoint against which to make API calls against, as well as the TTL for that endpoint.
+ */
+final class Endpoint implements EndpointInterface
+{
+    /**
+     * An endpoint address.
+     */
+    private $address;
+
+    /**
+     * The TTL for the endpoint, in minutes.
+     */
+    private $cachePeriodInMinutes;
+
+    /**
+     * @param array{
+     *   Address: string,
+     *   CachePeriodInMinutes: string,
+     * } $input
+     */
+    public function __construct(array $input)
+    {
+        $this->address = $input['Address'] ?? null;
+        $this->cachePeriodInMinutes = $input['CachePeriodInMinutes'] ?? null;
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getAddress(): string
+    {
+        return $this->address;
+    }
+
+    public function getCachePeriodInMinutes(): int
+    {
+        return $this->cachePeriodInMinutes;
+    }
+}

--- a/src/Service/TimestreamQuery/tests/Unit/Input/DescribeEndpointsRequestTest.php
+++ b/src/Service/TimestreamQuery/tests/Unit/Input/DescribeEndpointsRequestTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AsyncAws\TimestreamQuery\Tests\Unit\Input;
+
+use AsyncAws\Core\Test\TestCase;
+use AsyncAws\TimestreamQuery\Input\DescribeEndpointsRequest;
+
+class DescribeEndpointsRequestTest extends TestCase
+{
+    public function testRequest(): void
+    {
+        $input = new DescribeEndpointsRequest([
+
+        ]);
+
+        // see https://docs.aws.amazon.com/timestream/latest/developerguide/API_Operations_Amazon_Timestream_Query.html/API_DescribeEndpoints.html
+        $expected = '
+            POST / HTTP/1.0
+            Content-Type: application/x-amz-json-1.0
+            x-amz-target: Timestream_20181101.DescribeEndpoints
+
+            {
+            }
+        ';
+
+        self::assertRequestEqualsHttpRequest($expected, $input->request());
+    }
+}

--- a/src/Service/TimestreamQuery/tests/Unit/Result/DescribeEndpointsResponseTest.php
+++ b/src/Service/TimestreamQuery/tests/Unit/Result/DescribeEndpointsResponseTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace AsyncAws\TimestreamQuery\Tests\Unit\Result;
+
+use AsyncAws\Core\EndpointDiscovery\EndpointInterface;
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Test\Http\SimpleMockedResponse;
+use AsyncAws\Core\Test\TestCase;
+use AsyncAws\TimestreamQuery\Result\DescribeEndpointsResponse;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+
+class DescribeEndpointsResponseTest extends TestCase
+{
+    public function testDescribeEndpointsResponse(): void
+    {
+        // see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeEndpoints.html
+        $response = new SimpleMockedResponse('{
+           "Endpoints": [
+              {
+                 "Address": "www.aws.com",
+                 "CachePeriodInMinutes": 1234
+              }
+           ]
+        }');
+
+        $client = new MockHttpClient($response);
+        $result = new DescribeEndpointsResponse(new Response($client->request('POST', 'http://localhost'), $client, new NullLogger()));
+
+        self::assertCount(1, $result->getEndpoints());
+        self::assertInstanceOf(EndpointInterface::class, $result->getEndpoints()[0]);
+        self::assertSame('www.aws.com', $result->getEndpoints()[0]->getAddress());
+        self::assertSame(1234, $result->getEndpoints()[0]->getCachePeriodInMinutes());
+    }
+}

--- a/src/Service/TimestreamQuery/tests/Unit/TimestreamQueryClientTest.php
+++ b/src/Service/TimestreamQuery/tests/Unit/TimestreamQueryClientTest.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\TimestreamQuery\Tests\Unit;
 
 use AsyncAws\Core\Credentials\NullProvider;
+use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\TimestreamQuery\Input\CancelQueryRequest;
 use AsyncAws\TimestreamQuery\Input\PrepareQueryRequest;
@@ -17,7 +18,12 @@ class TimestreamQueryClientTest extends TestCase
 {
     public function testCancelQuery(): void
     {
-        $client = new TimestreamQueryClient([], new NullProvider(), new MockHttpClient());
+        $client = new TimestreamQueryClient([], new NullProvider(), new MockHttpClient([new SimpleMockedResponse('{
+          "Endpoints": [{
+            "Address": "www.aws.com",
+            "CachePeriodInMinutes": 1234
+          }]
+        }'), new SimpleMockedResponse('{}')]));
 
         $input = new CancelQueryRequest([
             'QueryId' => 'qwertyuiop',
@@ -30,7 +36,12 @@ class TimestreamQueryClientTest extends TestCase
 
     public function testPrepareQuery(): void
     {
-        $client = new TimestreamQueryClient([], new NullProvider(), new MockHttpClient());
+        $client = new TimestreamQueryClient([], new NullProvider(), new MockHttpClient([new SimpleMockedResponse('{
+          "Endpoints": [{
+            "Address": "www.aws.com",
+            "CachePeriodInMinutes": 1234
+          }]
+        }'), new SimpleMockedResponse('{}')]));
 
         $input = new PrepareQueryRequest([
             'QueryString' => 'SELECT * FROM db.tbl ORDER BY time DESC LIMIT 10',
@@ -45,7 +56,12 @@ class TimestreamQueryClientTest extends TestCase
 
     public function testQuery(): void
     {
-        $client = new TimestreamQueryClient([], new NullProvider(), new MockHttpClient());
+        $client = new TimestreamQueryClient([], new NullProvider(), new MockHttpClient([new SimpleMockedResponse('{
+          "Endpoints": [{
+            "Address": "www.aws.com",
+            "CachePeriodInMinutes": 1234
+          }]
+        }'), new SimpleMockedResponse('{}')]));
 
         $input = new QueryRequest([
             'ClientToken' => 'qwertyuiop',

--- a/src/Service/TimestreamWrite/CHANGELOG.md
+++ b/src/Service/TimestreamWrite/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Added
+
+- Added support for endpoint discovery
+
 ## 0.1.0
 
 First version

--- a/src/Service/TimestreamWrite/composer.json
+++ b/src/Service/TimestreamWrite/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.16"
     },
     "autoload": {
         "psr-4": {

--- a/src/Service/TimestreamWrite/src/Input/DescribeEndpointsRequest.php
+++ b/src/Service/TimestreamWrite/src/Input/DescribeEndpointsRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace AsyncAws\TimestreamWrite\Input;
+
+use AsyncAws\Core\Input;
+use AsyncAws\Core\Request;
+use AsyncAws\Core\Stream\StreamFactory;
+
+final class DescribeEndpointsRequest extends Input
+{
+    /**
+     * @param array{
+     *   @region?: string,
+     * } $input
+     */
+    public function __construct(array $input = [])
+    {
+        parent::__construct($input);
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    /**
+     * @internal
+     */
+    public function request(): Request
+    {
+        // Prepare headers
+        $headers = [
+            'Content-Type' => 'application/x-amz-json-1.0',
+            'X-Amz-Target' => 'Timestream_20181101.DescribeEndpoints',
+        ];
+
+        // Prepare query
+        $query = [];
+
+        // Prepare URI
+        $uriString = '/';
+
+        // Prepare Body
+        $bodyPayload = $this->requestBody();
+        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload, 4194304);
+
+        // Return the Request
+        return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));
+    }
+
+    private function requestBody(): array
+    {
+        $payload = [];
+
+        return $payload;
+    }
+}

--- a/src/Service/TimestreamWrite/src/Result/DescribeEndpointsResponse.php
+++ b/src/Service/TimestreamWrite/src/Result/DescribeEndpointsResponse.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace AsyncAws\TimestreamWrite\Result;
+
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Result;
+use AsyncAws\TimestreamWrite\ValueObject\Endpoint;
+
+class DescribeEndpointsResponse extends Result
+{
+    /**
+     * An `Endpoints` object is returned when a `DescribeEndpoints` request is made.
+     */
+    private $endpoints;
+
+    /**
+     * @return Endpoint[]
+     */
+    public function getEndpoints(): array
+    {
+        $this->initialize();
+
+        return $this->endpoints;
+    }
+
+    protected function populateResult(Response $response): void
+    {
+        $data = $response->toArray();
+
+        $this->endpoints = $this->populateResultEndpoints($data['Endpoints']);
+    }
+
+    private function populateResultEndpoint(array $json): Endpoint
+    {
+        return new Endpoint([
+            'Address' => (string) $json['Address'],
+            'CachePeriodInMinutes' => (string) $json['CachePeriodInMinutes'],
+        ]);
+    }
+
+    /**
+     * @return Endpoint[]
+     */
+    private function populateResultEndpoints(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = $this->populateResultEndpoint($item);
+        }
+
+        return $items;
+    }
+}

--- a/src/Service/TimestreamWrite/src/ValueObject/Endpoint.php
+++ b/src/Service/TimestreamWrite/src/ValueObject/Endpoint.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace AsyncAws\TimestreamWrite\ValueObject;
+
+use AsyncAws\Core\EndpointDiscovery\EndpointInterface;
+
+/**
+ * Represents an available endpoint against which to make API calls agaisnt, as well as the TTL for that endpoint.
+ */
+final class Endpoint implements EndpointInterface
+{
+    /**
+     * An endpoint address.
+     */
+    private $address;
+
+    /**
+     * The TTL for the endpoint, in minutes.
+     */
+    private $cachePeriodInMinutes;
+
+    /**
+     * @param array{
+     *   Address: string,
+     *   CachePeriodInMinutes: string,
+     * } $input
+     */
+    public function __construct(array $input)
+    {
+        $this->address = $input['Address'] ?? null;
+        $this->cachePeriodInMinutes = $input['CachePeriodInMinutes'] ?? null;
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getAddress(): string
+    {
+        return $this->address;
+    }
+
+    public function getCachePeriodInMinutes(): int
+    {
+        return $this->cachePeriodInMinutes;
+    }
+}

--- a/src/Service/TimestreamWrite/tests/Unit/Input/DescribeEndpointsRequestTest.php
+++ b/src/Service/TimestreamWrite/tests/Unit/Input/DescribeEndpointsRequestTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace AsyncAws\TimestreamWrite\Tests\Unit\Input;
+
+use AsyncAws\Core\Test\TestCase;
+use AsyncAws\TimestreamWrite\Input\DescribeEndpointsRequest;
+
+class DescribeEndpointsRequestTest extends TestCase
+{
+    public function testRequest(): void
+    {
+        $input = new DescribeEndpointsRequest([
+
+        ]);
+
+        // see https://docs.aws.amazon.com/timestream/latest/developerguide/API_Operations_Amazon_Timestream_Write.html/API_DescribeEndpoints.html
+        $expected = '
+            POST / HTTP/1.0
+            Content-Type: application/x-amz-json-1.0
+            x-amz-target: Timestream_20181101.DescribeEndpoints
+
+            {
+            }
+        ';
+
+        self::assertRequestEqualsHttpRequest($expected, $input->request());
+    }
+}

--- a/src/Service/TimestreamWrite/tests/Unit/Result/DescribeEndpointsResponseTest.php
+++ b/src/Service/TimestreamWrite/tests/Unit/Result/DescribeEndpointsResponseTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace AsyncAws\TimestreamWrite\Tests\Unit\Result;
+
+use AsyncAws\Core\EndpointDiscovery\EndpointInterface;
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Test\Http\SimpleMockedResponse;
+use AsyncAws\Core\Test\TestCase;
+use AsyncAws\TimestreamWrite\Result\DescribeEndpointsResponse;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+
+class DescribeEndpointsResponseTest extends TestCase
+{
+    public function testDescribeEndpointsResponse(): void
+    {
+        // see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_DescribeEndpoints.html
+        $response = new SimpleMockedResponse('{
+           "Endpoints": [
+              {
+                 "Address": "www.aws.com",
+                 "CachePeriodInMinutes": 1234
+              }
+           ]
+        }');
+
+        $client = new MockHttpClient($response);
+        $result = new DescribeEndpointsResponse(new Response($client->request('POST', 'http://localhost'), $client, new NullLogger()));
+
+        self::assertCount(1, $result->getEndpoints());
+        self::assertInstanceOf(EndpointInterface::class, $result->getEndpoints()[0]);
+        self::assertSame('www.aws.com', $result->getEndpoints()[0]->getAddress());
+        self::assertSame(1234, $result->getEndpoints()[0]->getCachePeriodInMinutes());
+    }
+}

--- a/src/Service/TimestreamWrite/tests/Unit/TimestreamWriteClientTest.php
+++ b/src/Service/TimestreamWrite/tests/Unit/TimestreamWriteClientTest.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\TimestreamWrite\Tests\Unit;
 
 use AsyncAws\Core\Credentials\NullProvider;
+use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\TimestreamWrite\Enum\MeasureValueType;
 use AsyncAws\TimestreamWrite\Input\WriteRecordsRequest;
@@ -16,7 +17,12 @@ class TimestreamWriteClientTest extends TestCase
 {
     public function testWriteRecords(): void
     {
-        $client = new TimestreamWriteClient([], new NullProvider(), new MockHttpClient());
+        $client = new TimestreamWriteClient([], new NullProvider(), new MockHttpClient([new SimpleMockedResponse('{
+          "Endpoints": [{
+            "Address": "www.aws.com",
+            "CachePeriodInMinutes": 1234
+          }]
+        }'), new SimpleMockedResponse('{}')]));
 
         $input = new WriteRecordsRequest([
             'DatabaseName' => 'db',


### PR DESCRIPTION
Alternative to https://github.com/async-aws/aws/pull/1235 to automatically discover endpoints.

AWS data.json files provides required information to automatically fetch endpoint.

This PR:
 - adds a new `endpointCache` that take care of caching and reusing previously fetched endpoints with TTL
 - adds a new `client::discoverEndpoints` protected method to fetch the list of endpoints from the client
 - add glue in Request's Context to ask the AbstractApi to fetch endpoints using the AWS API

this PR is in draft and requires to be split inu multiple PR to fix version constraints
- [ ] the `Core` that contain new Context properties
- [ ] The generator + services