### PR TITLE
Do not override HttpClient DI

### DIFF
--- a/docs/clients/index.md
+++ b/docs/clients/index.md
@@ -21,13 +21,16 @@ All arguments are optional and sensible defaults are used.
 ```php
 use AsyncAws\Core\Configuration;
 use AsyncAws\Core\Credentials\ConfigurationProvider;
+use AsyncAws\Core\HttpClient\AwsHttpClientFactory;
 use AsyncAws\DynamoDb\DynamoDbClient;
 
 $config = Configuration::create([
     'region' => 'eu-central-1',
 ]);
 $credentialProvider = new ConfigurationProvider();
-$httpClient = // ... Instance of Symfony's HttpClientInterface
+$httpClient = HttpClient::create(); // ... Instance of Symfony's HttpClientInterface
+// Or, to enable automatic retries on top of your own HttpClient
+// $httpClient = AwsHttpClientFactory::createRetryableClient($httpClient); T
 $logger = // ... A PSR-3 logger
 
 $dynamoDb = new DynamoDbClient($config, $credentialProvider, $httpClient, $logger);

--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Support for TimestreamQuery
 - Support for TimestreamWrite
 - AWS enhancement: Documentation updates.
+- Reverted the automated decoration of the injected HttpClient
+- Added an AwsHttpClientFactory to help people creating retryable clients
 
 ### Changed
 

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -74,15 +74,15 @@ abstract class AbstractApi
         $this->awsErrorFactory = $this->getAwsErrorFactory();
         if (!isset($httpClient)) {
             $httpClient = HttpClient::create();
-        }
-        if (class_exists(RetryableHttpClient::class) && !$httpClient instanceof RetryableHttpClient) {
-            /** @psalm-suppress MissingDependency */
-            $httpClient = new RetryableHttpClient(
-                $httpClient,
-                new AwsRetryStrategy(AwsRetryStrategy::DEFAULT_RETRY_STATUS_CODES, 1000, 2.0, 0, 0.1, $this->awsErrorFactory),
-                3,
-                $this->logger
-            );
+            if (class_exists(RetryableHttpClient::class)) {
+                /** @psalm-suppress MissingDependency */
+                $httpClient = new RetryableHttpClient(
+                    $httpClient,
+                    new AwsRetryStrategy(AwsRetryStrategy::DEFAULT_RETRY_STATUS_CODES, 1000, 2.0, 0, 0.1, $this->awsErrorFactory),
+                    3,
+                    $this->logger
+                );
+            }
         }
         $this->httpClient = $httpClient;
         $this->configuration = $configuration;

--- a/src/Core/src/HttpClient/AwsHttpClientFactory.php
+++ b/src/Core/src/HttpClient/AwsHttpClientFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace AsyncAws\Core\HttpClient;
+
+use Psr\Log\LoggerInterface;
+use Symfony\Component\HttpClient\HttpClient;
+use Symfony\Component\HttpClient\RetryableHttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+class AwsHttpClientFactory
+{
+    public static function createRetryableClient(HttpClientInterface $httpClient = null, LoggerInterface $logger = null): HttpClientInterface
+    {
+        if (null === $httpClient) {
+            $httpClient = HttpClient::create();
+        }
+        if (class_exists(RetryableHttpClient::class)) {
+            /** @psalm-suppress MissingDependency */
+            $httpClient = new RetryableHttpClient(
+                $httpClient,
+                new AwsRetryStrategy(),
+                3,
+                $logger
+            );
+        }
+
+        return $httpClient;
+    }
+}


### PR DESCRIPTION
fix #1234 by reverting #1162

The current implementation decorates the injected HttpClient with the RetriableClient.
I think that's a mistake (the clients should not change the injected dependencies).

This PR reverts that behavior, and lets people inject a non-retryable client if they want.

I'm not sure if this is a BC-break or not :thinking: Code wont break sure... but a behavior (auto-setup retry on top of the injected client) could be disabled for some people.