### PR TITLE
Add support for endpoint discovery in core

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -102,6 +102,13 @@ An identifier for the assumed role session
 The relative path that is used to fetch credentials inside and ECS instance.
 See [IAM Roles for Tasks](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) for more information.
 
+### endpointDiscoveryEnabled
+
+**Default:** 'false'
+
+Enable the endpoint discovery when the operation support it
+See [Endpoint discovery](https://docs.aws.amazon.com/sdkref/latest/guide/feature-endpoint-discovery.html) for more information.
+
 ## S3 specific Configuration reference
 
 ### pathStyleEndpoint

--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Added
+
+- Added support for endpoint discovery
+
 ## 1.15.0
 
 ### Added

--- a/src/Core/src/Configuration.php
+++ b/src/Core/src/Configuration.php
@@ -30,6 +30,7 @@ final class Configuration
     public const OPTION_WEB_IDENTITY_TOKEN_FILE = 'webIdentityTokenFile';
     public const OPTION_ROLE_SESSION_NAME = 'roleSessionName';
     public const OPTION_CONTAINER_CREDENTIALS_RELATIVE_URI = 'containerCredentialsRelativeUri';
+    public const OPTION_ENDPOINT_DISCOVERY_ENABLED = 'endpointDiscoveryEnabled';
 
     // S3 specific option
     public const OPTION_PATH_STYLE_ENDPOINT = 'pathStyleEndpoint';
@@ -49,6 +50,7 @@ final class Configuration
         self::OPTION_WEB_IDENTITY_TOKEN_FILE => true,
         self::OPTION_ROLE_SESSION_NAME => true,
         self::OPTION_CONTAINER_CREDENTIALS_RELATIVE_URI => true,
+        self::OPTION_ENDPOINT_DISCOVERY_ENABLED => true,
         self::OPTION_PATH_STYLE_ENDPOINT => true,
         self::OPTION_SEND_CHUNKED_BODY => true,
     ];
@@ -70,6 +72,7 @@ final class Configuration
             self::OPTION_ROLE_SESSION_NAME => 'AWS_ROLE_SESSION_NAME',
         ],
         [self::OPTION_CONTAINER_CREDENTIALS_RELATIVE_URI => 'AWS_CONTAINER_CREDENTIALS_RELATIVE_URI'],
+        [self::OPTION_ENDPOINT_DISCOVERY_ENABLED => ['AWS_ENDPOINT_DISCOVERY_ENABLED', 'AWS_ENABLE_ENDPOINT_DISCOVERY']],
     ];
 
     private const DEFAULT_OPTIONS = [
@@ -82,6 +85,7 @@ final class Configuration
         self::OPTION_ENDPOINT => 'https://%service%.%region%.amazonaws.com',
         self::OPTION_PATH_STYLE_ENDPOINT => 'false',
         self::OPTION_SEND_CHUNKED_BODY => 'false',
+        self::OPTION_ENDPOINT_DISCOVERY_ENABLED => 'false',
     ];
 
     private $data = [];

--- a/src/Core/src/EndpointDiscovery/EndpointCache.php
+++ b/src/Core/src/EndpointDiscovery/EndpointCache.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace AsyncAws\Core\EndpointDiscovery;
+
+use AsyncAws\Core\Exception\LogicException;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal
+ */
+class EndpointCache
+{
+    private $endpoints = [];
+
+    private $expired = [];
+
+    public function addEndpoints(?string $region, array $endpoints): void
+    {
+        $now = time();
+
+        if (null === $region) {
+            $region = '';
+        }
+        if (!isset($this->endpoints[$region])) {
+            $this->endpoints[$region] = [];
+        }
+
+        /** @var EndpointInterface $endpoint */
+        foreach ($endpoints as $endpoint) {
+            $this->endpoints[$region][$this->sanitizeEndpoint($endpoint->getAddress())] = $now + ($endpoint->getCachePeriodInMinutes() * 60);
+        }
+        arsort($this->endpoints[$region]);
+    }
+
+    public function removeEndpoint(string $endpoint): void
+    {
+        $endpoint = $this->sanitizeEndpoint($endpoint);
+        foreach ($this->endpoints as &$endpoints) {
+            unset($endpoints[$endpoint]);
+        }
+        unset($endpoints);
+        foreach ($this->expired as &$endpoints) {
+            unset($endpoints[$endpoint]);
+        }
+
+        unset($endpoints);
+    }
+
+    public function getActiveEndpoint(?string $region): ?string
+    {
+        if (null === $region) {
+            $region = '';
+        }
+        $now = time();
+
+        foreach ($this->endpoints[$region] ?? [] as $endpoint => $expiresAt) {
+            if ($expiresAt < $now) {
+                $this->expired[$region] = \array_slice($this->expired[$region] ?? [], -100); // keep only the last 100 items
+                unset($this->endpoints[$region][$endpoint]);
+                $this->expired[$region][$endpoint] = $expiresAt;
+
+                continue;
+            }
+
+            return $endpoint;
+        }
+
+        return null;
+    }
+
+    public function getExpiredEndpoint(?string $region): ?string
+    {
+        if (null === $region) {
+            $region = '';
+        }
+        if (empty($this->expired[$region])) {
+            return null;
+        }
+
+        return array_key_last($this->expired[$region]);
+    }
+
+    private function sanitizeEndpoint(string $address): string
+    {
+        $parsed = parse_url($address);
+
+        // parse_url() will correctly parse full URIs with schemes
+        if (isset($parsed['host'])) {
+            return rtrim(sprintf(
+                '%s://%s/%s',
+                $parsed['scheme'] ?? 'https',
+                $parsed['host'],
+                ltrim($parsed['path'] ?? '/', '/')
+            ), '/');
+        }
+
+        // parse_url() will put host & path in 'path' if scheme is not provided
+        if (isset($parsed['path'])) {
+            $split = explode('/', $parsed['path'], 2);
+            $parsed['host'] = $split[0];
+            if (isset($split[1])) {
+                $parsed['path'] = $split[1];
+            } else {
+                $parsed['path'] = '';
+            }
+
+            return rtrim(sprintf(
+                '%s://%s/%s',
+                $parsed['scheme'] ?? 'https',
+                $parsed['host'],
+                ltrim($parsed['path'], '/')
+            ), '/');
+        }
+
+        throw new LogicException(sprintf('The supplied endpoint "%s" is invalid.', $address));
+    }
+}

--- a/src/Core/src/EndpointDiscovery/EndpointInterface.php
+++ b/src/Core/src/EndpointDiscovery/EndpointInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace AsyncAws\Core\EndpointDiscovery;
+
+interface EndpointInterface
+{
+    public function getAddress(): string;
+
+    public function getCachePeriodInMinutes(): int;
+}

--- a/src/Core/src/RequestContext.php
+++ b/src/Core/src/RequestContext.php
@@ -19,12 +19,24 @@ class RequestContext
         'expirationDate' => true,
         'currentDate' => true,
         'exceptionMapping' => true,
+        'usesEndpointDiscovery' => true,
+        'requiresEndpointDiscovery' => true,
     ];
 
     /**
      * @var string|null
      */
     private $operation;
+
+    /**
+     * @var bool
+     */
+    private $usesEndpointDiscovery = false;
+
+    /**
+     * @var bool
+     */
+    private $requiresEndpointDiscovery = false;
 
     /**
      * @var string|null
@@ -53,6 +65,8 @@ class RequestContext
      *  expirationDate?: null|\DateTimeImmutable
      *  currentDate?: null|\DateTimeImmutable
      *  exceptionMapping?: string[]
+     *  usesEndpointDiscovery?: bool
+     *  requiresEndpointDiscovery?: bool
      * }
      */
     public function __construct(array $options = [])
@@ -89,5 +103,15 @@ class RequestContext
     public function getExceptionMapping(): array
     {
         return $this->exceptionMapping;
+    }
+
+    public function usesEndpointDiscovery(): bool
+    {
+        return $this->usesEndpointDiscovery;
+    }
+
+    public function requiresEndpointDiscovery(): bool
+    {
+        return $this->requiresEndpointDiscovery;
     }
 }

--- a/src/Core/tests/Unit/AbstractApiTest.php
+++ b/src/Core/tests/Unit/AbstractApiTest.php
@@ -6,7 +6,14 @@ namespace AsyncAws\Core\Tests\Unit;
 
 use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\Configuration;
+use AsyncAws\Core\EndpointDiscovery\EndpointInterface;
+use AsyncAws\Core\Request;
+use AsyncAws\Core\RequestContext;
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Stream\StringStream;
 use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class AbstractApiTest extends TestCase
 {
@@ -29,6 +36,27 @@ class AbstractApiTest extends TestCase
         $endpoint = $api->getEndpoint('/some/path', [], 'eu-central-1');
         self::assertEquals('https://foobar.eu-central-1.amazonaws.com/some/path', $endpoint);
     }
+
+    public function testDiscoveredEndpoint()
+    {
+        $httpClient = $this->createMock(HttpClientInterface::class);
+        $api = new DummyApi([
+            'region' => 'eu-west-1',
+            'accessKeyId' => 'key',
+            'accessKeySecret' => 'secret',
+        ], null, $httpClient);
+
+        $response = $this->createMock(ResponseInterface::class);
+
+        $httpClient->expects(self::once())
+            ->method('request')
+            ->with('GET', 'https://foobar.discovered.amazonaws.com/')
+            ->willReturn($response)
+        ;
+
+        $response = $api->getResponseExposed(new Request('GET', '/foo', [], [], StringStream::create('')), new RequestContext(['requiresEndpointDiscovery' => true]));
+        $response->cancel();
+    }
 }
 
 class DummyApi extends AbstractApi
@@ -36,6 +64,11 @@ class DummyApi extends AbstractApi
     public function getEndpoint(string $uri, array $query, ?string $region): string
     {
         return parent::getEndpoint($uri, $query, $region);
+    }
+
+    public function getResponseExposed(Request $request, ?RequestContext $context = null): Response
+    {
+        return parent::getResponse($request, $context);
     }
 
     protected function getEndpointMetadata(?string $region): array
@@ -50,5 +83,20 @@ class DummyApi extends AbstractApi
             'signService' => 'foobar',
             'signVersions' => ['v4'],
         ];
+    }
+
+    protected function discoverEndpoints(?string $region): array
+    {
+        return [new class() implements EndpointInterface {
+            public function getAddress(): string
+            {
+                return 'https://foobar.discovered.amazonaws.com';
+            }
+
+            public function getCachePeriodInMinutes(): int
+            {
+                return 3600;
+            }
+        }];
     }
 }

--- a/src/Core/tests/Unit/EndpointDiscovery/EndpointCacheTest.php
+++ b/src/Core/tests/Unit/EndpointDiscovery/EndpointCacheTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core\Tests\Unit\EndpointDiscovery;
+
+use AsyncAws\Core\EndpointDiscovery\EndpointCache;
+use AsyncAws\Core\EndpointDiscovery\EndpointInterface;
+use PHPUnit\Framework\TestCase;
+
+class EndpointCacheTest extends TestCase
+{
+    public function testAddEndpoints()
+    {
+        $cache = new EndpointCache();
+
+        $cache->addEndpoints('r1', [$this->getEndpoint('foo.com', -10)]);
+        self::assertNull($cache->getActiveEndpoint('r1'));
+        self::assertSame('https://foo.com', $cache->getExpiredEndpoint('r1'));
+
+        $cache->addEndpoints('r1', [$this->getEndpoint('bar.com', -1), $this->getEndpoint('bar.com', -2)]);
+        self::assertNull($cache->getActiveEndpoint('r1'));
+        self::assertSame('https://bar.com', $cache->getExpiredEndpoint('r1'));
+
+        $cache->addEndpoints('r2', [$this->getEndpoint('qux.com', 10)]);
+        self::assertNull($cache->getActiveEndpoint('r1'));
+        self::assertSame('https://qux.com', $cache->getActiveEndpoint('r2'));
+
+        $cache->addEndpoints('r2', [$this->getEndpoint('foofoo.com', 20), $this->getEndpoint('barfoo.com', 15)]);
+        self::assertSame('https://foofoo.com', $cache->getActiveEndpoint('r2'));
+
+        $cache->removeEndpoint('https://foofoo.com');
+        self::assertSame('https://barfoo.com', $cache->getActiveEndpoint('r2'));
+    }
+
+    private function getEndpoint(string $address, int $ttl): EndpointInterface
+    {
+        return new class($address, $ttl) implements EndpointInterface {
+            private $address;
+
+            private $ttl;
+
+            public function __construct(string $address, int $ttl)
+            {
+                $this->address = $address;
+                $this->ttl = $ttl;
+            }
+
+            public function getAddress(): string
+            {
+                return $this->address;
+            }
+
+            public function getCachePeriodInMinutes(): int
+            {
+                return $this->ttl;
+            }
+        };
+    }
+}


### PR DESCRIPTION
Followup #1239

This PR add support of endpoint discovery in core.
It could be leverage by client, thank to new parameter in RequestContext and implementing the underlying protected method