### PR TITLE
feat(dynamodb): add execute statement operation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -154,6 +154,7 @@
                 "DeleteItem",
                 "DeleteTable",
                 "DescribeTable",
+                "ExecuteStatement",
                 "GetItem",
                 "ListTables",
                 "PutItem",

--- a/src/Service/DynamoDb/src/DynamoDbClient.php
+++ b/src/Service/DynamoDb/src/DynamoDbClient.php
@@ -15,6 +15,7 @@ use AsyncAws\DynamoDb\Enum\ReturnValue;
 use AsyncAws\DynamoDb\Enum\Select;
 use AsyncAws\DynamoDb\Enum\TableClass;
 use AsyncAws\DynamoDb\Exception\ConditionalCheckFailedException;
+use AsyncAws\DynamoDb\Exception\DuplicateItemException;
 use AsyncAws\DynamoDb\Exception\InternalServerErrorException;
 use AsyncAws\DynamoDb\Exception\ItemCollectionSizeLimitExceededException;
 use AsyncAws\DynamoDb\Exception\LimitExceededException;
@@ -29,6 +30,7 @@ use AsyncAws\DynamoDb\Input\CreateTableInput;
 use AsyncAws\DynamoDb\Input\DeleteItemInput;
 use AsyncAws\DynamoDb\Input\DeleteTableInput;
 use AsyncAws\DynamoDb\Input\DescribeTableInput;
+use AsyncAws\DynamoDb\Input\ExecuteStatementInput;
 use AsyncAws\DynamoDb\Input\GetItemInput;
 use AsyncAws\DynamoDb\Input\ListTablesInput;
 use AsyncAws\DynamoDb\Input\PutItemInput;
@@ -43,6 +45,7 @@ use AsyncAws\DynamoDb\Result\CreateTableOutput;
 use AsyncAws\DynamoDb\Result\DeleteItemOutput;
 use AsyncAws\DynamoDb\Result\DeleteTableOutput;
 use AsyncAws\DynamoDb\Result\DescribeTableOutput;
+use AsyncAws\DynamoDb\Result\ExecuteStatementOutput;
 use AsyncAws\DynamoDb\Result\GetItemOutput;
 use AsyncAws\DynamoDb\Result\ListTablesOutput;
 use AsyncAws\DynamoDb\Result\PutItemOutput;
@@ -282,6 +285,48 @@ class DynamoDbClient extends AbstractApi
         ]]));
 
         return new DescribeTableOutput($response);
+    }
+
+    /**
+     * This operation allows you to perform reads and singleton writes on data stored in DynamoDB, using PartiQL.
+     *
+     * @see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteStatement.html
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-dynamodb-2012-08-10.html#executestatement
+     *
+     * @param array{
+     *   Statement: string,
+     *   Parameters?: AttributeValue[],
+     *   ConsistentRead?: bool,
+     *   NextToken?: string,
+     *   ReturnConsumedCapacity?: ReturnConsumedCapacity::*,
+     *   Limit?: int,
+     *   @region?: string,
+     * }|ExecuteStatementInput $input
+     *
+     * @throws ConditionalCheckFailedException
+     * @throws ProvisionedThroughputExceededException
+     * @throws ResourceNotFoundException
+     * @throws ItemCollectionSizeLimitExceededException
+     * @throws TransactionConflictException
+     * @throws RequestLimitExceededException
+     * @throws InternalServerErrorException
+     * @throws DuplicateItemException
+     */
+    public function executeStatement($input): ExecuteStatementOutput
+    {
+        $input = ExecuteStatementInput::create($input);
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'ExecuteStatement', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'ConditionalCheckFailedException' => ConditionalCheckFailedException::class,
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+            'ResourceNotFoundException' => ResourceNotFoundException::class,
+            'ItemCollectionSizeLimitExceededException' => ItemCollectionSizeLimitExceededException::class,
+            'TransactionConflictException' => TransactionConflictException::class,
+            'RequestLimitExceeded' => RequestLimitExceededException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+            'DuplicateItemException' => DuplicateItemException::class,
+        ]]));
+
+        return new ExecuteStatementOutput($response);
     }
 
     /**

--- a/src/Service/DynamoDb/src/Exception/DuplicateItemException.php
+++ b/src/Service/DynamoDb/src/Exception/DuplicateItemException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+/**
+ * There was an attempt to insert an item with the same primary key as an item that already exists in the DynamoDB
+ * table.
+ */
+final class DuplicateItemException extends ClientException
+{
+    protected function populateResult(ResponseInterface $response): void
+    {
+        $data = $response->toArray(false);
+
+        if (null !== $v = (isset($data['message']) ? (string) $data['message'] : null)) {
+            $this->message = $v;
+        }
+    }
+}

--- a/src/Service/DynamoDb/src/Input/ExecuteStatementInput.php
+++ b/src/Service/DynamoDb/src/Input/ExecuteStatementInput.php
@@ -1,0 +1,231 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Input;
+
+use AsyncAws\Core\Exception\InvalidArgument;
+use AsyncAws\Core\Input;
+use AsyncAws\Core\Request;
+use AsyncAws\Core\Stream\StreamFactory;
+use AsyncAws\DynamoDb\Enum\ReturnConsumedCapacity;
+use AsyncAws\DynamoDb\ValueObject\AttributeValue;
+
+final class ExecuteStatementInput extends Input
+{
+    /**
+     * The PartiQL statement representing the operation to run.
+     *
+     * @required
+     *
+     * @var string|null
+     */
+    private $statement;
+
+    /**
+     * The parameters for the PartiQL statement, if any.
+     *
+     * @var AttributeValue[]|null
+     */
+    private $parameters;
+
+    /**
+     * The consistency of a read operation. If set to `true`, then a strongly consistent read is used; otherwise, an
+     * eventually consistent read is used.
+     *
+     * @var bool|null
+     */
+    private $consistentRead;
+
+    /**
+     * Set this value to get remaining results, if `NextToken` was returned in the statement response.
+     *
+     * @var string|null
+     */
+    private $nextToken;
+
+    /**
+     * @var ReturnConsumedCapacity::*|null
+     */
+    private $returnConsumedCapacity;
+
+    /**
+     * The maximum number of items to evaluate (not necessarily the number of matching items). If DynamoDB processes the
+     * number of items up to the limit while processing the results, it stops the operation and returns the matching values
+     * up to that point, along with a key in `LastEvaluatedKey` to apply in a subsequent operation so you can pick up where
+     * you left off. Also, if the processed dataset size exceeds 1 MB before DynamoDB reaches this limit, it stops the
+     * operation and returns the matching values up to the limit, and a key in `LastEvaluatedKey` to apply in a subsequent
+     * operation to continue the operation.
+     *
+     * @var int|null
+     */
+    private $limit;
+
+    /**
+     * @param array{
+     *   Statement?: string,
+     *   Parameters?: AttributeValue[],
+     *   ConsistentRead?: bool,
+     *   NextToken?: string,
+     *   ReturnConsumedCapacity?: ReturnConsumedCapacity::*,
+     *   Limit?: int,
+     *   @region?: string,
+     * } $input
+     */
+    public function __construct(array $input = [])
+    {
+        $this->statement = $input['Statement'] ?? null;
+        $this->parameters = isset($input['Parameters']) ? array_map([AttributeValue::class, 'create'], $input['Parameters']) : null;
+        $this->consistentRead = $input['ConsistentRead'] ?? null;
+        $this->nextToken = $input['NextToken'] ?? null;
+        $this->returnConsumedCapacity = $input['ReturnConsumedCapacity'] ?? null;
+        $this->limit = $input['Limit'] ?? null;
+        parent::__construct($input);
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getConsistentRead(): ?bool
+    {
+        return $this->consistentRead;
+    }
+
+    public function getLimit(): ?int
+    {
+        return $this->limit;
+    }
+
+    public function getNextToken(): ?string
+    {
+        return $this->nextToken;
+    }
+
+    /**
+     * @return AttributeValue[]
+     */
+    public function getParameters(): array
+    {
+        return $this->parameters ?? [];
+    }
+
+    /**
+     * @return ReturnConsumedCapacity::*|null
+     */
+    public function getReturnConsumedCapacity(): ?string
+    {
+        return $this->returnConsumedCapacity;
+    }
+
+    public function getStatement(): ?string
+    {
+        return $this->statement;
+    }
+
+    /**
+     * @internal
+     */
+    public function request(): Request
+    {
+        // Prepare headers
+        $headers = [
+            'Content-Type' => 'application/x-amz-json-1.0',
+            'X-Amz-Target' => 'DynamoDB_20120810.ExecuteStatement',
+        ];
+
+        // Prepare query
+        $query = [];
+
+        // Prepare URI
+        $uriString = '/';
+
+        // Prepare Body
+        $bodyPayload = $this->requestBody();
+        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload, 4194304);
+
+        // Return the Request
+        return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));
+    }
+
+    public function setConsistentRead(?bool $value): self
+    {
+        $this->consistentRead = $value;
+
+        return $this;
+    }
+
+    public function setLimit(?int $value): self
+    {
+        $this->limit = $value;
+
+        return $this;
+    }
+
+    public function setNextToken(?string $value): self
+    {
+        $this->nextToken = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param AttributeValue[] $value
+     */
+    public function setParameters(array $value): self
+    {
+        $this->parameters = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param ReturnConsumedCapacity::*|null $value
+     */
+    public function setReturnConsumedCapacity(?string $value): self
+    {
+        $this->returnConsumedCapacity = $value;
+
+        return $this;
+    }
+
+    public function setStatement(?string $value): self
+    {
+        $this->statement = $value;
+
+        return $this;
+    }
+
+    private function requestBody(): array
+    {
+        $payload = [];
+        if (null === $v = $this->statement) {
+            throw new InvalidArgument(sprintf('Missing parameter "Statement" for "%s". The value cannot be null.', __CLASS__));
+        }
+        $payload['Statement'] = $v;
+        if (null !== $v = $this->parameters) {
+            $index = -1;
+            $payload['Parameters'] = [];
+            foreach ($v as $listValue) {
+                ++$index;
+                $payload['Parameters'][$index] = $listValue->requestBody();
+            }
+        }
+        if (null !== $v = $this->consistentRead) {
+            $payload['ConsistentRead'] = (bool) $v;
+        }
+        if (null !== $v = $this->nextToken) {
+            $payload['NextToken'] = $v;
+        }
+        if (null !== $v = $this->returnConsumedCapacity) {
+            if (!ReturnConsumedCapacity::exists($v)) {
+                throw new InvalidArgument(sprintf('Invalid parameter "ReturnConsumedCapacity" for "%s". The value "%s" is not a valid "ReturnConsumedCapacity".', __CLASS__, $v));
+            }
+            $payload['ReturnConsumedCapacity'] = $v;
+        }
+        if (null !== $v = $this->limit) {
+            $payload['Limit'] = $v;
+        }
+
+        return $payload;
+    }
+}

--- a/src/Service/DynamoDb/src/Result/ExecuteStatementOutput.php
+++ b/src/Service/DynamoDb/src/Result/ExecuteStatementOutput.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Result;
+
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Result;
+use AsyncAws\DynamoDb\ValueObject\AttributeValue;
+use AsyncAws\DynamoDb\ValueObject\Capacity;
+use AsyncAws\DynamoDb\ValueObject\ConsumedCapacity;
+
+class ExecuteStatementOutput extends Result
+{
+    /**
+     * If a read operation was used, this property will contain the result of the read operation; a map of attribute names
+     * and their values. For the write operations this value will be empty.
+     */
+    private $items;
+
+    /**
+     * If the response of a read request exceeds the response payload limit DynamoDB will set this value in the response. If
+     * set, you can use that this value in the subsequent request to get the remaining results.
+     */
+    private $nextToken;
+
+    private $consumedCapacity;
+
+    /**
+     * The primary key of the item where the operation stopped, inclusive of the previous result set. Use this value to
+     * start a new operation, excluding this value in the new request. If `LastEvaluatedKey` is empty, then the "last page"
+     * of results has been processed and there is no more data to be retrieved. If `LastEvaluatedKey` is not empty, it does
+     * not necessarily mean that there is more data in the result set. The only way to know when you have reached the end of
+     * the result set is when `LastEvaluatedKey` is empty.
+     */
+    private $lastEvaluatedKey;
+
+    public function getConsumedCapacity(): ?ConsumedCapacity
+    {
+        $this->initialize();
+
+        return $this->consumedCapacity;
+    }
+
+    /**
+     * @return array<string, AttributeValue>[]
+     */
+    public function getItems(): array
+    {
+        $this->initialize();
+
+        return $this->items;
+    }
+
+    /**
+     * @return array<string, AttributeValue>
+     */
+    public function getLastEvaluatedKey(): array
+    {
+        $this->initialize();
+
+        return $this->lastEvaluatedKey;
+    }
+
+    public function getNextToken(): ?string
+    {
+        $this->initialize();
+
+        return $this->nextToken;
+    }
+
+    protected function populateResult(Response $response): void
+    {
+        $data = $response->toArray();
+
+        $this->items = empty($data['Items']) ? [] : $this->populateResultItemList($data['Items']);
+        $this->nextToken = isset($data['NextToken']) ? (string) $data['NextToken'] : null;
+        $this->consumedCapacity = empty($data['ConsumedCapacity']) ? null : $this->populateResultConsumedCapacity($data['ConsumedCapacity']);
+        $this->lastEvaluatedKey = empty($data['LastEvaluatedKey']) ? [] : $this->populateResultKey($data['LastEvaluatedKey']);
+    }
+
+    /**
+     * @return array<string, AttributeValue>
+     */
+    private function populateResultAttributeMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = AttributeValue::create($value);
+        }
+
+        return $items;
+    }
+
+    private function populateResultCapacity(array $json): Capacity
+    {
+        return new Capacity([
+            'ReadCapacityUnits' => isset($json['ReadCapacityUnits']) ? (float) $json['ReadCapacityUnits'] : null,
+            'WriteCapacityUnits' => isset($json['WriteCapacityUnits']) ? (float) $json['WriteCapacityUnits'] : null,
+            'CapacityUnits' => isset($json['CapacityUnits']) ? (float) $json['CapacityUnits'] : null,
+        ]);
+    }
+
+    private function populateResultConsumedCapacity(array $json): ConsumedCapacity
+    {
+        return new ConsumedCapacity([
+            'TableName' => isset($json['TableName']) ? (string) $json['TableName'] : null,
+            'CapacityUnits' => isset($json['CapacityUnits']) ? (float) $json['CapacityUnits'] : null,
+            'ReadCapacityUnits' => isset($json['ReadCapacityUnits']) ? (float) $json['ReadCapacityUnits'] : null,
+            'WriteCapacityUnits' => isset($json['WriteCapacityUnits']) ? (float) $json['WriteCapacityUnits'] : null,
+            'Table' => empty($json['Table']) ? null : $this->populateResultCapacity($json['Table']),
+            'LocalSecondaryIndexes' => !isset($json['LocalSecondaryIndexes']) ? null : $this->populateResultSecondaryIndexesCapacityMap($json['LocalSecondaryIndexes']),
+            'GlobalSecondaryIndexes' => !isset($json['GlobalSecondaryIndexes']) ? null : $this->populateResultSecondaryIndexesCapacityMap($json['GlobalSecondaryIndexes']),
+        ]);
+    }
+
+    /**
+     * @return array<string, AttributeValue>[]
+     */
+    private function populateResultItemList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = $this->populateResultAttributeMap($item);
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return array<string, AttributeValue>
+     */
+    private function populateResultKey(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = AttributeValue::create($value);
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return array<string, Capacity>
+     */
+    private function populateResultSecondaryIndexesCapacityMap(array $json): array
+    {
+        $items = [];
+        foreach ($json as $name => $value) {
+            $items[(string) $name] = Capacity::create($value);
+        }
+
+        return $items;
+    }
+}

--- a/src/Service/DynamoDb/src/ValueObject/ConsumedCapacity.php
+++ b/src/Service/DynamoDb/src/ValueObject/ConsumedCapacity.php
@@ -2,13 +2,6 @@
 
 namespace AsyncAws\DynamoDb\ValueObject;
 
-/**
- * The capacity units consumed by an operation. The data returned includes the total provisioned throughput consumed,
- * along with statistics for the table and any indexes involved in the operation. `ConsumedCapacity` is only returned if
- * the request asked for it. For more information, see Provisioned Throughput in the *Amazon DynamoDB Developer Guide*.
- *
- * @see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ProvisionedThroughputIntro.html
- */
 final class ConsumedCapacity
 {
     /**

--- a/src/Service/DynamoDb/tests/Unit/DynamoDbClientTest.php
+++ b/src/Service/DynamoDb/tests/Unit/DynamoDbClientTest.php
@@ -12,6 +12,7 @@ use AsyncAws\DynamoDb\Input\CreateTableInput;
 use AsyncAws\DynamoDb\Input\DeleteItemInput;
 use AsyncAws\DynamoDb\Input\DeleteTableInput;
 use AsyncAws\DynamoDb\Input\DescribeTableInput;
+use AsyncAws\DynamoDb\Input\ExecuteStatementInput;
 use AsyncAws\DynamoDb\Input\GetItemInput;
 use AsyncAws\DynamoDb\Input\ListTablesInput;
 use AsyncAws\DynamoDb\Input\PutItemInput;
@@ -26,6 +27,7 @@ use AsyncAws\DynamoDb\Result\CreateTableOutput;
 use AsyncAws\DynamoDb\Result\DeleteItemOutput;
 use AsyncAws\DynamoDb\Result\DeleteTableOutput;
 use AsyncAws\DynamoDb\Result\DescribeTableOutput;
+use AsyncAws\DynamoDb\Result\ExecuteStatementOutput;
 use AsyncAws\DynamoDb\Result\GetItemOutput;
 use AsyncAws\DynamoDb\Result\ListTablesOutput;
 use AsyncAws\DynamoDb\Result\PutItemOutput;
@@ -135,6 +137,20 @@ class DynamoDbClientTest extends TestCase
         $result = $client->DescribeTable($input);
 
         self::assertInstanceOf(DescribeTableOutput::class, $result);
+        self::assertFalse($result->info()['resolved']);
+    }
+
+    public function testExecuteStatement(): void
+    {
+        $client = new DynamoDbClient([], new NullProvider(), new MockHttpClient());
+
+        $input = new ExecuteStatementInput([
+            'Statement' => 'change me',
+
+        ]);
+        $result = $client->executeStatement($input);
+
+        self::assertInstanceOf(ExecuteStatementOutput::class, $result);
         self::assertFalse($result->info()['resolved']);
     }
 

--- a/src/Service/DynamoDb/tests/Unit/Input/ExecuteStatementInputTest.php
+++ b/src/Service/DynamoDb/tests/Unit/Input/ExecuteStatementInputTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Tests\Unit\Input;
+
+use AsyncAws\Core\Test\TestCase;
+use AsyncAws\DynamoDb\Input\ExecuteStatementInput;
+use AsyncAws\DynamoDb\ValueObject\AttributeValue;
+
+class ExecuteStatementInputTest extends TestCase
+{
+    public function testRequest(): void
+    {
+        self::fail('Not implemented');
+
+        $input = new ExecuteStatementInput([
+            'Statement' => 'change me',
+            'Parameters' => [new AttributeValue([
+                'S' => 'change me',
+                'N' => 'change me',
+                'B' => 'change me',
+                'SS' => ['change me'],
+                'NS' => ['change me'],
+                'BS' => ['change me'],
+                'M' => ['change me' => ''],
+                'L' => [''],
+                'NULL' => false,
+                'BOOL' => false,
+            ])],
+            'ConsistentRead' => false,
+            'NextToken' => 'change me',
+        ]);
+
+        // see https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteStatement.html
+        $expected = '
+            POST / HTTP/1.0
+            Content-Type: application/x-amz-json-1.0
+
+            {
+            "change": "it"
+        }
+                ';
+
+        self::assertRequestEqualsHttpRequest($expected, $input->request());
+    }
+}

--- a/src/Service/DynamoDb/tests/Unit/Result/ExecuteStatementOutputTest.php
+++ b/src/Service/DynamoDb/tests/Unit/Result/ExecuteStatementOutputTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace AsyncAws\DynamoDb\Tests\Unit\Result;
+
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Test\Http\SimpleMockedResponse;
+use AsyncAws\Core\Test\TestCase;
+use AsyncAws\DynamoDb\Result\ExecuteStatementOutput;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+
+class ExecuteStatementOutputTest extends TestCase
+{
+    public function testExecuteStatementOutput(): void
+    {
+        self::fail('Not implemented');
+
+        // see https://docs.aws.amazon.com/dynamodb/latest/APIReference/API_ExecuteStatement.html
+        $response = new SimpleMockedResponse('{
+            "change": "it"
+        }');
+
+        $client = new MockHttpClient($response);
+        $result = new ExecuteStatementOutput(new Response($client->request('POST', 'http://localhost'), $client, new NullLogger()));
+
+        // self::assertTODO(expected, $result->getItems());
+        self::assertSame('changeIt', $result->getNextToken());
+    }
+}


### PR DESCRIPTION
See https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ExecuteStatement.html

I've followed https://async-aws.com/contribute/generate.html#creating-a-new-client-operation guide