### PR TITLE
Update simple_s3 documentation

### DIFF
--- a/docs/integration/simple-s3.md
+++ b/docs/integration/simple-s3.md
@@ -18,16 +18,13 @@ composer require async-aws/simple-s3
 ```php
 use AsyncAws\SimpleS3\SimpleS3Client;
 
-$s3 = new SimpleS3Client([
-    'accessKeyId' => 'your_access_key',
-    'accessKeySecret' => 'your_access_key_secret',
-    'region' => 'eu-central-1',
-]);
+$s3 = new SimpleS3Client();
 
 $s3->createBucket([
     'Bucket' => 'my-image-bucket',
     'CreateBucketConfiguration' => [
-        'LocationConstraint' => $s3->getConfiguration()->get(Configuration::OPTION_REGION)
+        'LocationConstraint' => 'eu-central-1'
+        //  'LocationConstraint' => $s3->getConfiguration()->get(Configuration::OPTION_REGION)
     ],
 ]);
 

--- a/docs/integration/simple-s3.md
+++ b/docs/integration/simple-s3.md
@@ -18,7 +18,19 @@ composer require async-aws/simple-s3
 ```php
 use AsyncAws\SimpleS3\SimpleS3Client;
 
-$s3 = new SimpleS3Client();
+$s3 = new SimpleS3Client([
+    'accessKeyId' => 'your_access_key',
+    'accessKeySecret' => 'your_access_key_secret',
+    'region' => 'eu-central-1',
+]);
+
+$s3->createBucket([
+    'Bucket' => 'my-image-bucket',
+    'CreateBucketConfiguration' => [
+        'LocationConstraint' => $s3->getConfiguration()->get(Configuration::OPTION_REGION)
+    ],
+]);
+
 $resource = \fopen('/path/to/cat/image.jpg', 'r');
 $s3->upload('my-image-bucket', 'photos/cat_2.jpg', $resource);
 $s3->upload('my-image-bucket', 'photos/cat_2.txt', 'I like this cat');


### PR DESCRIPTION
Creating a bucket is not evident because it requires an optional key (this sentence makes no sense, and that's precisely the point) so here is an example clarifying things.

For your information, this is **required** for the bucket creation but in the meantime, the official documentation [does not specify it](https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/s3-examples-creating-buckets.html#create-a-bucket). They are using in their code [a middleware](https://github.com/aws/aws-sdk-php/blob/6e694b9710d625be8facbaa17aca9c5e3295c7be/src/S3/S3Client.php#L535) which is missing in here. The best option (seen with @Nyholm ) seems to be adding documentation.