### PR TITLE
add `PutRepositoryTriggers` to `CodeCommit` client

### DIFF
--- a/docs/clients/code-commit.md
+++ b/docs/clients/code-commit.md
@@ -59,3 +59,27 @@ $blob = $codeCommit->getBlob(new GetBlobInput([
 
 echo $blob->getContent(); // Lorem ipsum dolor sit amet...
 ```
+
+
+### Update repository triggers
+
+```php
+use AsyncAws\CodeCommit\CodeCommitClient;
+use AsyncAws\CodeCommit\Input\PutRepositoryTriggersInput;
+
+$codeCommit = new CodeCommitClient();
+
+$blob = $codeCommit->getBlob(new PutRepositoryTriggersInput([
+            'repositoryName' => 'async-aws-monorepo',
+            'triggers' => [new RepositoryTrigger([
+                'name' => 'NotifyOfCodeChanges',
+                # ARN of your Lambda function which is going to get executed when something happens
+                'destinationArn' => 'arn:aws:lambda:eu-west-1:123456789012:function:my-function',
+                'customData' => 'any additional data you want for the execution context - maybe an id of some sort?',
+                'branches' => ['main', 'development'], # send a blank array to be triggered on *all* branches
+                'events' => ['createReference', 'deleteReference', 'updateReference'], # 'all' is also a valid input
+            ])],
+        ]));
+
+echo $blob->getContent(); // Lorem ipsum dolor sit amet...
+```

--- a/docs/clients/code-commit.md
+++ b/docs/clients/code-commit.md
@@ -69,7 +69,7 @@ use AsyncAws\CodeCommit\Input\PutRepositoryTriggersInput;
 
 $codeCommit = new CodeCommitClient();
 
-$blob = $codeCommit->getBlob(new PutRepositoryTriggersInput([
+$result = $codeCommit->putRepositoryTriggers(new PutRepositoryTriggersInput([
             'repositoryName' => 'async-aws-monorepo',
             'triggers' => [new RepositoryTrigger([
                 'name' => 'NotifyOfCodeChanges',
@@ -81,5 +81,5 @@ $blob = $codeCommit->getBlob(new PutRepositoryTriggersInput([
             ])],
         ]));
 
-echo $blob->getContent(); // Lorem ipsum dolor sit amet...
+echo $result->getConfigurationId(); // '6fa51cd8-35c1-EXAMPLE'
 ```

--- a/manifest.json
+++ b/manifest.json
@@ -94,7 +94,8 @@
             "methods": [
                 "GetBlob",
                 "GetBranch",
-                "GetDifferences"
+                "GetDifferences",
+                "PutRepositoryTriggers"
             ]
         },
         "CodeDeploy": {

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -30,6 +30,7 @@ parameters:
               - src/Core/src/Sts/ValueObject
               - src/Service/AppSync/src/ValueObject
               - src/Service/CodeBuild/src/ValueObject
+              - src/Service/CodeCommit/src/ValueObject
               - src/Service/CloudFormation/src/ValueObject
               - src/Service/CloudFront/src/ValueObject
               - src/Service/CloudWatch/src/ValueObject

--- a/src/Service/CodeCommit/src/CodeCommitClient.php
+++ b/src/Service/CodeCommit/src/CodeCommitClient.php
@@ -22,15 +22,31 @@ use AsyncAws\CodeCommit\Exception\InvalidContinuationTokenException;
 use AsyncAws\CodeCommit\Exception\InvalidMaxResultsException;
 use AsyncAws\CodeCommit\Exception\InvalidPathException;
 use AsyncAws\CodeCommit\Exception\InvalidRepositoryNameException;
+use AsyncAws\CodeCommit\Exception\InvalidRepositoryTriggerBranchNameException;
+use AsyncAws\CodeCommit\Exception\InvalidRepositoryTriggerCustomDataException;
+use AsyncAws\CodeCommit\Exception\InvalidRepositoryTriggerDestinationArnException;
+use AsyncAws\CodeCommit\Exception\InvalidRepositoryTriggerEventsException;
+use AsyncAws\CodeCommit\Exception\InvalidRepositoryTriggerNameException;
+use AsyncAws\CodeCommit\Exception\InvalidRepositoryTriggerRegionException;
+use AsyncAws\CodeCommit\Exception\MaximumBranchesExceededException;
+use AsyncAws\CodeCommit\Exception\MaximumRepositoryTriggersExceededException;
 use AsyncAws\CodeCommit\Exception\PathDoesNotExistException;
 use AsyncAws\CodeCommit\Exception\RepositoryDoesNotExistException;
 use AsyncAws\CodeCommit\Exception\RepositoryNameRequiredException;
+use AsyncAws\CodeCommit\Exception\RepositoryTriggerBranchNameListRequiredException;
+use AsyncAws\CodeCommit\Exception\RepositoryTriggerDestinationArnRequiredException;
+use AsyncAws\CodeCommit\Exception\RepositoryTriggerEventsListRequiredException;
+use AsyncAws\CodeCommit\Exception\RepositoryTriggerNameRequiredException;
+use AsyncAws\CodeCommit\Exception\RepositoryTriggersListRequiredException;
 use AsyncAws\CodeCommit\Input\GetBlobInput;
 use AsyncAws\CodeCommit\Input\GetBranchInput;
 use AsyncAws\CodeCommit\Input\GetDifferencesInput;
+use AsyncAws\CodeCommit\Input\PutRepositoryTriggersInput;
 use AsyncAws\CodeCommit\Result\GetBlobOutput;
 use AsyncAws\CodeCommit\Result\GetBranchOutput;
 use AsyncAws\CodeCommit\Result\GetDifferencesOutput;
+use AsyncAws\CodeCommit\Result\PutRepositoryTriggersOutput;
+use AsyncAws\CodeCommit\ValueObject\RepositoryTrigger;
 use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\AwsError\AwsErrorFactoryInterface;
 use AsyncAws\Core\AwsError\JsonRpcAwsErrorFactory;
@@ -187,6 +203,70 @@ class CodeCommitClient extends AbstractApi
         ]]));
 
         return new GetDifferencesOutput($response, $this, $input);
+    }
+
+    /**
+     * Replaces all triggers for a repository. Used to create or delete triggers.
+     *
+     * @see https://docs.aws.amazon.com/codecommit/latest/APIReference/API_PutRepositoryTriggers.html
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-codecommit-2015-04-13.html#putrepositorytriggers
+     *
+     * @param array{
+     *   repositoryName: string,
+     *   triggers: RepositoryTrigger[],
+     *   @region?: string,
+     * }|PutRepositoryTriggersInput $input
+     *
+     * @throws RepositoryDoesNotExistException
+     * @throws RepositoryNameRequiredException
+     * @throws InvalidRepositoryNameException
+     * @throws RepositoryTriggersListRequiredException
+     * @throws MaximumRepositoryTriggersExceededException
+     * @throws InvalidRepositoryTriggerNameException
+     * @throws InvalidRepositoryTriggerDestinationArnException
+     * @throws InvalidRepositoryTriggerRegionException
+     * @throws InvalidRepositoryTriggerCustomDataException
+     * @throws MaximumBranchesExceededException
+     * @throws InvalidRepositoryTriggerBranchNameException
+     * @throws InvalidRepositoryTriggerEventsException
+     * @throws RepositoryTriggerNameRequiredException
+     * @throws RepositoryTriggerDestinationArnRequiredException
+     * @throws RepositoryTriggerBranchNameListRequiredException
+     * @throws RepositoryTriggerEventsListRequiredException
+     * @throws EncryptionIntegrityChecksFailedException
+     * @throws EncryptionKeyAccessDeniedException
+     * @throws EncryptionKeyDisabledException
+     * @throws EncryptionKeyNotFoundException
+     * @throws EncryptionKeyUnavailableException
+     */
+    public function putRepositoryTriggers($input): PutRepositoryTriggersOutput
+    {
+        $input = PutRepositoryTriggersInput::create($input);
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'PutRepositoryTriggers', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'RepositoryDoesNotExistException' => RepositoryDoesNotExistException::class,
+            'RepositoryNameRequiredException' => RepositoryNameRequiredException::class,
+            'InvalidRepositoryNameException' => InvalidRepositoryNameException::class,
+            'RepositoryTriggersListRequiredException' => RepositoryTriggersListRequiredException::class,
+            'MaximumRepositoryTriggersExceededException' => MaximumRepositoryTriggersExceededException::class,
+            'InvalidRepositoryTriggerNameException' => InvalidRepositoryTriggerNameException::class,
+            'InvalidRepositoryTriggerDestinationArnException' => InvalidRepositoryTriggerDestinationArnException::class,
+            'InvalidRepositoryTriggerRegionException' => InvalidRepositoryTriggerRegionException::class,
+            'InvalidRepositoryTriggerCustomDataException' => InvalidRepositoryTriggerCustomDataException::class,
+            'MaximumBranchesExceededException' => MaximumBranchesExceededException::class,
+            'InvalidRepositoryTriggerBranchNameException' => InvalidRepositoryTriggerBranchNameException::class,
+            'InvalidRepositoryTriggerEventsException' => InvalidRepositoryTriggerEventsException::class,
+            'RepositoryTriggerNameRequiredException' => RepositoryTriggerNameRequiredException::class,
+            'RepositoryTriggerDestinationArnRequiredException' => RepositoryTriggerDestinationArnRequiredException::class,
+            'RepositoryTriggerBranchNameListRequiredException' => RepositoryTriggerBranchNameListRequiredException::class,
+            'RepositoryTriggerEventsListRequiredException' => RepositoryTriggerEventsListRequiredException::class,
+            'EncryptionIntegrityChecksFailedException' => EncryptionIntegrityChecksFailedException::class,
+            'EncryptionKeyAccessDeniedException' => EncryptionKeyAccessDeniedException::class,
+            'EncryptionKeyDisabledException' => EncryptionKeyDisabledException::class,
+            'EncryptionKeyNotFoundException' => EncryptionKeyNotFoundException::class,
+            'EncryptionKeyUnavailableException' => EncryptionKeyUnavailableException::class,
+        ]]));
+
+        return new PutRepositoryTriggersOutput($response);
     }
 
     protected function getAwsErrorFactory(): AwsErrorFactoryInterface

--- a/src/Service/CodeCommit/src/Enum/RepositoryTriggerEventEnum.php
+++ b/src/Service/CodeCommit/src/Enum/RepositoryTriggerEventEnum.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Enum;
+
+final class RepositoryTriggerEventEnum
+{
+    public const ALL = 'all';
+    public const CREATE_REFERENCE = 'createReference';
+    public const DELETE_REFERENCE = 'deleteReference';
+    public const UPDATE_REFERENCE = 'updateReference';
+
+    public static function exists(string $value): bool
+    {
+        return isset([
+            self::ALL => true,
+            self::CREATE_REFERENCE => true,
+            self::DELETE_REFERENCE => true,
+            self::UPDATE_REFERENCE => true,
+        ][$value]);
+    }
+}

--- a/src/Service/CodeCommit/src/Exception/InvalidRepositoryTriggerBranchNameException.php
+++ b/src/Service/CodeCommit/src/Exception/InvalidRepositoryTriggerBranchNameException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * One or more branch names specified for the trigger is not valid.
+ */
+final class InvalidRepositoryTriggerBranchNameException extends ClientException
+{
+}

--- a/src/Service/CodeCommit/src/Exception/InvalidRepositoryTriggerCustomDataException.php
+++ b/src/Service/CodeCommit/src/Exception/InvalidRepositoryTriggerCustomDataException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The custom data provided for the trigger is not valid.
+ */
+final class InvalidRepositoryTriggerCustomDataException extends ClientException
+{
+}

--- a/src/Service/CodeCommit/src/Exception/InvalidRepositoryTriggerDestinationArnException.php
+++ b/src/Service/CodeCommit/src/Exception/InvalidRepositoryTriggerDestinationArnException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The Amazon Resource Name (ARN) for the trigger is not valid for the specified destination. The most common reason for
+ * this error is that the ARN does not meet the requirements for the service type.
+ */
+final class InvalidRepositoryTriggerDestinationArnException extends ClientException
+{
+}

--- a/src/Service/CodeCommit/src/Exception/InvalidRepositoryTriggerEventsException.php
+++ b/src/Service/CodeCommit/src/Exception/InvalidRepositoryTriggerEventsException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * One or more events specified for the trigger is not valid. Check to make sure that all events specified match the
+ * requirements for allowed events.
+ */
+final class InvalidRepositoryTriggerEventsException extends ClientException
+{
+}

--- a/src/Service/CodeCommit/src/Exception/InvalidRepositoryTriggerNameException.php
+++ b/src/Service/CodeCommit/src/Exception/InvalidRepositoryTriggerNameException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The name of the trigger is not valid.
+ */
+final class InvalidRepositoryTriggerNameException extends ClientException
+{
+}

--- a/src/Service/CodeCommit/src/Exception/InvalidRepositoryTriggerRegionException.php
+++ b/src/Service/CodeCommit/src/Exception/InvalidRepositoryTriggerRegionException.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The AWS Region for the trigger target does not match the AWS Region for the repository. Triggers must be created in
+ * the same Region as the target for the trigger.
+ */
+final class InvalidRepositoryTriggerRegionException extends ClientException
+{
+}

--- a/src/Service/CodeCommit/src/Exception/MaximumBranchesExceededException.php
+++ b/src/Service/CodeCommit/src/Exception/MaximumBranchesExceededException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The number of branches for the trigger was exceeded.
+ */
+final class MaximumBranchesExceededException extends ClientException
+{
+}

--- a/src/Service/CodeCommit/src/Exception/MaximumRepositoryTriggersExceededException.php
+++ b/src/Service/CodeCommit/src/Exception/MaximumRepositoryTriggersExceededException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The number of triggers allowed for the repository was exceeded.
+ */
+final class MaximumRepositoryTriggersExceededException extends ClientException
+{
+}

--- a/src/Service/CodeCommit/src/Exception/RepositoryTriggerBranchNameListRequiredException.php
+++ b/src/Service/CodeCommit/src/Exception/RepositoryTriggerBranchNameListRequiredException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * At least one branch name is required, but was not specified in the trigger configuration.
+ */
+final class RepositoryTriggerBranchNameListRequiredException extends ClientException
+{
+}

--- a/src/Service/CodeCommit/src/Exception/RepositoryTriggerDestinationArnRequiredException.php
+++ b/src/Service/CodeCommit/src/Exception/RepositoryTriggerDestinationArnRequiredException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * A destination ARN for the target service for the trigger is required, but was not specified.
+ */
+final class RepositoryTriggerDestinationArnRequiredException extends ClientException
+{
+}

--- a/src/Service/CodeCommit/src/Exception/RepositoryTriggerEventsListRequiredException.php
+++ b/src/Service/CodeCommit/src/Exception/RepositoryTriggerEventsListRequiredException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * At least one event for the trigger is required, but was not specified.
+ */
+final class RepositoryTriggerEventsListRequiredException extends ClientException
+{
+}

--- a/src/Service/CodeCommit/src/Exception/RepositoryTriggerNameRequiredException.php
+++ b/src/Service/CodeCommit/src/Exception/RepositoryTriggerNameRequiredException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * A name for the trigger is required, but was not specified.
+ */
+final class RepositoryTriggerNameRequiredException extends ClientException
+{
+}

--- a/src/Service/CodeCommit/src/Exception/RepositoryTriggersListRequiredException.php
+++ b/src/Service/CodeCommit/src/Exception/RepositoryTriggersListRequiredException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Exception;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+
+/**
+ * The list of triggers for the repository is required, but was not specified.
+ */
+final class RepositoryTriggersListRequiredException extends ClientException
+{
+}

--- a/src/Service/CodeCommit/src/Input/PutRepositoryTriggersInput.php
+++ b/src/Service/CodeCommit/src/Input/PutRepositoryTriggersInput.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Input;
+
+use AsyncAws\CodeCommit\ValueObject\RepositoryTrigger;
+use AsyncAws\Core\Exception\InvalidArgument;
+use AsyncAws\Core\Input;
+use AsyncAws\Core\Request;
+use AsyncAws\Core\Stream\StreamFactory;
+
+/**
+ * Represents the input of a put repository triggers operation.
+ */
+final class PutRepositoryTriggersInput extends Input
+{
+    /**
+     * The name of the repository where you want to create or update the trigger.
+     *
+     * @required
+     *
+     * @var string|null
+     */
+    private $repositoryName;
+
+    /**
+     * The JSON block of configuration information for each trigger.
+     *
+     * @required
+     *
+     * @var RepositoryTrigger[]|null
+     */
+    private $triggers;
+
+    /**
+     * @param array{
+     *   repositoryName?: string,
+     *   triggers?: RepositoryTrigger[],
+     *   @region?: string,
+     * } $input
+     */
+    public function __construct(array $input = [])
+    {
+        $this->repositoryName = $input['repositoryName'] ?? null;
+        $this->triggers = isset($input['triggers']) ? array_map([RepositoryTrigger::class, 'create'], $input['triggers']) : null;
+        parent::__construct($input);
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getRepositoryName(): ?string
+    {
+        return $this->repositoryName;
+    }
+
+    /**
+     * @return RepositoryTrigger[]
+     */
+    public function getTriggers(): array
+    {
+        return $this->triggers ?? [];
+    }
+
+    /**
+     * @internal
+     */
+    public function request(): Request
+    {
+        // Prepare headers
+        $headers = [
+            'Content-Type' => 'application/x-amz-json-1.1',
+            'X-Amz-Target' => 'CodeCommit_20150413.PutRepositoryTriggers',
+        ];
+
+        // Prepare query
+        $query = [];
+
+        // Prepare URI
+        $uriString = '/';
+
+        // Prepare Body
+        $bodyPayload = $this->requestBody();
+        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload, 4194304);
+
+        // Return the Request
+        return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));
+    }
+
+    public function setRepositoryName(?string $value): self
+    {
+        $this->repositoryName = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param RepositoryTrigger[] $value
+     */
+    public function setTriggers(array $value): self
+    {
+        $this->triggers = $value;
+
+        return $this;
+    }
+
+    private function requestBody(): array
+    {
+        $payload = [];
+        if (null === $v = $this->repositoryName) {
+            throw new InvalidArgument(sprintf('Missing parameter "repositoryName" for "%s". The value cannot be null.', __CLASS__));
+        }
+        $payload['repositoryName'] = $v;
+        if (null === $v = $this->triggers) {
+            throw new InvalidArgument(sprintf('Missing parameter "triggers" for "%s". The value cannot be null.', __CLASS__));
+        }
+
+        $index = -1;
+        $payload['triggers'] = [];
+        foreach ($v as $listValue) {
+            ++$index;
+            $payload['triggers'][$index] = $listValue->requestBody();
+        }
+
+        return $payload;
+    }
+}

--- a/src/Service/CodeCommit/src/Result/PutRepositoryTriggersOutput.php
+++ b/src/Service/CodeCommit/src/Result/PutRepositoryTriggersOutput.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Result;
+
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Result;
+
+/**
+ * Represents the output of a put repository triggers operation.
+ */
+class PutRepositoryTriggersOutput extends Result
+{
+    /**
+     * The system-generated unique ID for the create or update operation.
+     */
+    private $configurationId;
+
+    public function getConfigurationId(): ?string
+    {
+        $this->initialize();
+
+        return $this->configurationId;
+    }
+
+    protected function populateResult(Response $response): void
+    {
+        $data = $response->toArray();
+
+        $this->configurationId = isset($data['configurationId']) ? (string) $data['configurationId'] : null;
+    }
+}

--- a/src/Service/CodeCommit/src/ValueObject/RepositoryTrigger.php
+++ b/src/Service/CodeCommit/src/ValueObject/RepositoryTrigger.php
@@ -48,11 +48,11 @@ final class RepositoryTrigger
      */
     public function __construct(array $input)
     {
-        $this->name = $input['name'];
-        $this->destinationArn = $input['destinationArn'];
+        $this->name = $input['name'] ?? null;
+        $this->destinationArn = $input['destinationArn'] ?? null;
         $this->customData = $input['customData'] ?? null;
         $this->branches = $input['branches'] ?? null;
-        $this->events = $input['events'];
+        $this->events = $input['events'] ?? null;
     }
 
     public static function create($input): self

--- a/src/Service/CodeCommit/src/ValueObject/RepositoryTrigger.php
+++ b/src/Service/CodeCommit/src/ValueObject/RepositoryTrigger.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace AsyncAws\CodeCommit\ValueObject;
+
+use AsyncAws\CodeCommit\Enum\RepositoryTriggerEventEnum;
+use AsyncAws\Core\Exception\InvalidArgument;
+
+/**
+ * Information about a trigger for a repository.
+ */
+final class RepositoryTrigger
+{
+    /**
+     * The name of the trigger.
+     */
+    private $name;
+
+    /**
+     * The ARN of the resource that is the target for a trigger (for example, the ARN of a topic in Amazon SNS).
+     */
+    private $destinationArn;
+
+    /**
+     * Any custom data associated with the trigger to be included in the information sent to the target of the trigger.
+     */
+    private $customData;
+
+    /**
+     * The branches to be included in the trigger configuration. If you specify an empty array, the trigger applies to all
+     * branches.
+     */
+    private $branches;
+
+    /**
+     * The repository events that cause the trigger to run actions in another service, such as sending a notification
+     * through Amazon SNS.
+     */
+    private $events;
+
+    /**
+     * @param array{
+     *   name: string,
+     *   destinationArn: string,
+     *   customData?: null|string,
+     *   branches?: null|string[],
+     *   events: list<RepositoryTriggerEventEnum::*>,
+     * } $input
+     */
+    public function __construct(array $input)
+    {
+        $this->name = $input['name'] ?? null;
+        $this->destinationArn = $input['destinationArn'] ?? null;
+        $this->customData = $input['customData'] ?? null;
+        $this->branches = $input['branches'] ?? null;
+        $this->events = $input['events'] ?? null;
+    }
+
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getBranches(): array
+    {
+        return $this->branches ?? [];
+    }
+
+    public function getCustomData(): ?string
+    {
+        return $this->customData;
+    }
+
+    public function getDestinationArn(): string
+    {
+        return $this->destinationArn;
+    }
+
+    /**
+     * @return list<RepositoryTriggerEventEnum::*>
+     */
+    public function getEvents(): array
+    {
+        return $this->events ?? [];
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    /**
+     * @internal
+     */
+    public function requestBody(): array
+    {
+        $payload = [];
+        if (null === $v = $this->name) {
+            throw new InvalidArgument(sprintf('Missing parameter "name" for "%s". The value cannot be null.', __CLASS__));
+        }
+        $payload['name'] = $v;
+        if (null === $v = $this->destinationArn) {
+            throw new InvalidArgument(sprintf('Missing parameter "destinationArn" for "%s". The value cannot be null.', __CLASS__));
+        }
+        $payload['destinationArn'] = $v;
+        if (null !== $v = $this->customData) {
+            $payload['customData'] = $v;
+        }
+        if (null !== $v = $this->branches) {
+            $index = -1;
+            $payload['branches'] = [];
+            foreach ($v as $listValue) {
+                ++$index;
+                $payload['branches'][$index] = $listValue;
+            }
+        }
+        if (null === $v = $this->events) {
+            throw new InvalidArgument(sprintf('Missing parameter "events" for "%s". The value cannot be null.', __CLASS__));
+        }
+
+        $index = -1;
+        $payload['events'] = [];
+        foreach ($v as $listValue) {
+            ++$index;
+            if (!RepositoryTriggerEventEnum::exists($listValue)) {
+                throw new InvalidArgument(sprintf('Invalid parameter "events" for "%s". The value "%s" is not a valid "RepositoryTriggerEventEnum".', __CLASS__, $listValue));
+            }
+            $payload['events'][$index] = $listValue;
+        }
+
+        return $payload;
+    }
+}

--- a/src/Service/CodeCommit/src/ValueObject/RepositoryTrigger.php
+++ b/src/Service/CodeCommit/src/ValueObject/RepositoryTrigger.php
@@ -48,11 +48,11 @@ final class RepositoryTrigger
      */
     public function __construct(array $input)
     {
-        $this->name = $input['name'] ?? null;
-        $this->destinationArn = $input['destinationArn'] ?? null;
+        $this->name = $input['name'];
+        $this->destinationArn = $input['destinationArn'];
         $this->customData = $input['customData'] ?? null;
         $this->branches = $input['branches'] ?? null;
-        $this->events = $input['events'] ?? null;
+        $this->events = $input['events'];
     }
 
     public static function create($input): self

--- a/src/Service/CodeCommit/tests/Integration/CodeCommitClientTest.php
+++ b/src/Service/CodeCommit/tests/Integration/CodeCommitClientTest.php
@@ -6,6 +6,8 @@ use AsyncAws\CodeCommit\CodeCommitClient;
 use AsyncAws\CodeCommit\Input\GetBlobInput;
 use AsyncAws\CodeCommit\Input\GetBranchInput;
 use AsyncAws\CodeCommit\Input\GetDifferencesInput;
+use AsyncAws\CodeCommit\Input\PutRepositoryTriggersInput;
+use AsyncAws\CodeCommit\ValueObject\RepositoryTrigger;
 use AsyncAws\Core\Credentials\NullProvider;
 use AsyncAws\Core\Test\TestCase;
 
@@ -60,6 +62,27 @@ class CodeCommitClientTest extends TestCase
 
         // self::assertTODO(expected, $result->getdifferences());
         self::assertSame('changeIt', $result->getNextToken());
+    }
+
+    public function testPutRepositoryTriggers(): void
+    {
+        $client = $this->getClient();
+
+        $input = new PutRepositoryTriggersInput([
+            'repositoryName' => 'async-aws-monorepo',
+            'triggers' => [new RepositoryTrigger([
+                'name' => 'NotifyOfCodeChangesInMainBranch',
+                'destinationArn' => 'arn:aws:lambda:eu-west-1:123456789012:function:my-function',
+                'customData' => 'any additional data you want for the context',
+                'branches' => ['main'],
+                'events' => ['createReference', 'deleteReference', 'updateReference'],
+            ])],
+        ]);
+        $result = $client->putRepositoryTriggers($input);
+
+        $result->resolve();
+
+        self::assertSame('changeIt', $result->getconfigurationId());
     }
 
     private function getClient(): CodeCommitClient

--- a/src/Service/CodeCommit/tests/Unit/CodeCommitClientTest.php
+++ b/src/Service/CodeCommit/tests/Unit/CodeCommitClientTest.php
@@ -6,9 +6,12 @@ use AsyncAws\CodeCommit\CodeCommitClient;
 use AsyncAws\CodeCommit\Input\GetBlobInput;
 use AsyncAws\CodeCommit\Input\GetBranchInput;
 use AsyncAws\CodeCommit\Input\GetDifferencesInput;
+use AsyncAws\CodeCommit\Input\PutRepositoryTriggersInput;
 use AsyncAws\CodeCommit\Result\GetBlobOutput;
 use AsyncAws\CodeCommit\Result\GetBranchOutput;
 use AsyncAws\CodeCommit\Result\GetDifferencesOutput;
+use AsyncAws\CodeCommit\Result\PutRepositoryTriggersOutput;
+use AsyncAws\CodeCommit\ValueObject\RepositoryTrigger;
 use AsyncAws\Core\Credentials\NullProvider;
 use AsyncAws\Core\Test\TestCase;
 use Symfony\Component\HttpClient\MockHttpClient;
@@ -47,7 +50,7 @@ class CodeCommitClientTest extends TestCase
         $client = new CodeCommitClient([], new NullProvider(), new MockHttpClient());
 
         $input = new GetDifferencesInput([
-            'repositoryName' => 'change me',
+            'repositoryName' => 'my-super-code-repository',
 
             'afterCommitSpecifier' => 'change me',
 
@@ -55,6 +58,25 @@ class CodeCommitClientTest extends TestCase
         $result = $client->getDifferences($input);
 
         self::assertInstanceOf(GetDifferencesOutput::class, $result);
+        self::assertFalse($result->info()['resolved']);
+    }
+
+    public function testPutRepositoryTriggers(): void
+    {
+        $client = new CodeCommitClient([], new NullProvider(), new MockHttpClient());
+
+        $input = new PutRepositoryTriggersInput([
+            'repositoryName' => 'my-super-code-repository',
+            'triggers' => [new RepositoryTrigger([
+                'name' => 'NotifyMeOfCodeChanges',
+                'destinationArn' => 'arn:aws:lambda:eu-west-1:123456789012:function:my-function',
+
+                'events' => ['createReference', 'deleteReference', 'updateReference'],
+            ])],
+        ]);
+        $result = $client->putRepositoryTriggers($input);
+
+        self::assertInstanceOf(PutRepositoryTriggersOutput::class, $result);
         self::assertFalse($result->info()['resolved']);
     }
 }

--- a/src/Service/CodeCommit/tests/Unit/Input/PutRepositoryTriggersInputTest.php
+++ b/src/Service/CodeCommit/tests/Unit/Input/PutRepositoryTriggersInputTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Tests\Unit\Input;
+
+use AsyncAws\CodeCommit\Input\PutRepositoryTriggersInput;
+use AsyncAws\CodeCommit\ValueObject\RepositoryTrigger;
+use AsyncAws\Core\Test\TestCase;
+
+class PutRepositoryTriggersInputTest extends TestCase
+{
+    public function testRequest(): void
+    {
+        $input = new PutRepositoryTriggersInput([
+            'repositoryName' => 'my-super-code-repository',
+            'triggers' => [new RepositoryTrigger([
+                'name' => 'NotifyMeOfCodeChanges',
+                'destinationArn' => 'arn:aws:lambda:eu-west-1:123456789012:function:my-function',
+                'customData' => 'Any custom data associated with the trigger to be included in the information sent to the target of the trigger.',
+                'branches' => ['main', 'release', 'development', 'git-flow'],
+                'events' => ['createReference', 'deleteReference', 'updateReference'],
+            ])],
+        ]);
+
+        // see https://docs.aws.amazon.com/codecommit/latest/APIReference/API_PutRepositoryTriggers.html
+        $expected = '
+            POST / HTTP/1.0
+            Content-Type: application/x-amz-json-1.1
+            x-amz-target: CodeCommit_20150413.PutRepositoryTriggers
+
+        {
+            "repositoryName": "my-super-code-repository",
+            "triggers": [
+                {
+                    "branches": [
+                        "main",
+                        "release",
+                        "development",
+                        "git-flow"
+                    ],
+                    "customData": "Any custom data associated with the trigger to be included in the information sent to the target of the trigger.",
+                    "destinationArn": "arn:aws:lambda:eu-west-1:123456789012:function:my-function",
+                    "events": [
+                        "createReference",
+                        "deleteReference",
+                        "updateReference"
+                    ],
+                    "name": "NotifyMeOfCodeChanges"
+                }
+            ]
+        }
+
+                ';
+
+        self::assertRequestEqualsHttpRequest($expected, $input->request());
+    }
+}

--- a/src/Service/CodeCommit/tests/Unit/Result/PutRepositoryTriggersOutputTest.php
+++ b/src/Service/CodeCommit/tests/Unit/Result/PutRepositoryTriggersOutputTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace AsyncAws\CodeCommit\Tests\Unit\Result;
+
+use AsyncAws\CodeCommit\Result\PutRepositoryTriggersOutput;
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Test\Http\SimpleMockedResponse;
+use AsyncAws\Core\Test\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+
+class PutRepositoryTriggersOutputTest extends TestCase
+{
+    public function testPutRepositoryTriggersOutput(): void
+    {
+        // see https://docs.aws.amazon.com/codecommit/latest/APIReference/API_PutRepositoryTriggers.html
+        $response = new SimpleMockedResponse('{
+    "configurationId": "6fa51cd8-35c1-EXAMPLE"
+}');
+
+        $client = new MockHttpClient($response);
+        $result = new PutRepositoryTriggersOutput(new Response($client->request('POST', 'http://localhost'), $client, new NullLogger()));
+
+        self::assertSame('6fa51cd8-35c1-EXAMPLE', $result->getconfigurationId());
+    }
+}


### PR DESCRIPTION
Generated code for `PutRepositoryTriggers` because you wanna know when stuff's happening, right?

Test / Docs examples inspired by:
https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-codecommit-2015-04-13.html#putrepositorytriggers
https://docs.aws.amazon.com/cli/latest/reference/codecommit/put-repository-triggers.html
https://docs.aws.amazon.com/codecommit/latest/APIReference/API_PutRepositoryTriggers.html