### PR TITLE
doc: fix typo

### DIFF
--- a/docs/compare.md
+++ b/docs/compare.md
@@ -183,7 +183,7 @@ $command = $s3->getCommand('GetObject', [
     'Bucket' => 'my-bucket',
     'Key' => 'test',
 ]);
-$psr7 = $s3->createPresignedRequest($cmd, '+60 min');
+$psr7 = $s3->createPresignedRequest($command, '+60 min');
 echo (string) $psr7->getUri();
 
 ```


### PR DESCRIPTION
The variables name are not the same: 
<img width="870" alt="image" src="https://user-images.githubusercontent.com/2103975/204408302-521232d2-558d-4992-a6c8-51ed38bb23df.png">
