### PR TITLE
Fixed broken query string encoding

### DIFF
--- a/src/CodeGenerator/src/Generator/TestGenerator.php
+++ b/src/CodeGenerator/src/Generator/TestGenerator.php
@@ -104,7 +104,7 @@ class TestGenerator
 
                 break;
             case 'query':
-                $stub = substr(var_export($exampleInput ? (\is_array($exampleInput) ? http_build_query($exampleInput, '', '&', \PHP_QUERY_RFC1738) : $exampleInput) : "
+                $stub = substr(var_export($exampleInput ? (\is_array($exampleInput) ? http_build_query($exampleInput, '', '&', \PHP_QUERY_RFC3986) : $exampleInput) : "
     Action={$operation->getName()}
     &Version={$operation->getApiVersion()}
 ", true), 1, -1);

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -260,7 +260,7 @@ abstract class AbstractApi
             return $endpoint;
         }
 
-        return $endpoint . (false === strpos($endpoint, '?') ? '?' : '&') . http_build_query($query, '', '&', \PHP_QUERY_RFC1738);
+        return $endpoint . (false === strpos($endpoint, '?') ? '?' : '&') . http_build_query($query, '', '&', \PHP_QUERY_RFC3986);
     }
 
     protected function discoverEndpoints(?string $region): array

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -256,11 +256,11 @@ abstract class AbstractApi
         }
 
         $endpoint .= $uri;
-        if (empty($query)) {
+        if ([] === $query) {
             return $endpoint;
         }
 
-        return $endpoint . (false === strpos($endpoint, '?') ? '?' : '&') . http_build_query($query);
+        return $endpoint . (false === strpos($endpoint, '?') ? '?' : '&') . http_build_query($query, '', '&', \PHP_QUERY_RFC1738);
     }
 
     protected function discoverEndpoints(?string $region): array

--- a/src/Core/src/Request.php
+++ b/src/Core/src/Request.php
@@ -125,7 +125,7 @@ class Request
     public function getEndpoint(): string
     {
         if (empty($this->endpoint)) {
-            $this->endpoint = $this->parsed['scheme'] . '://' . $this->parsed['host'] . (isset($this->parsed['port']) ? ':' . $this->parsed['port'] : '') . $this->uri . ($this->query ? (false === strpos($this->uri, '?') ? '?' : '&') . http_build_query($this->query, '', '&', \PHP_QUERY_RFC1738) : '');
+            $this->endpoint = $this->parsed['scheme'] . '://' . $this->parsed['host'] . (isset($this->parsed['port']) ? ':' . $this->parsed['port'] : '') . $this->uri . ($this->query ? (false === strpos($this->uri, '?') ? '?' : '&') . http_build_query($this->query, '', '&', \PHP_QUERY_RFC3986) : '');
         }
 
         return $this->endpoint;

--- a/src/Core/src/Request.php
+++ b/src/Core/src/Request.php
@@ -125,7 +125,7 @@ class Request
     public function getEndpoint(): string
     {
         if (empty($this->endpoint)) {
-            $this->endpoint = $this->parsed['scheme'] . '://' . $this->parsed['host'] . (isset($this->parsed['port']) ? ':' . $this->parsed['port'] : '') . $this->uri . ($this->query ? (false === strpos($this->uri, '?') ? '?' : '&') . http_build_query($this->query) : '');
+            $this->endpoint = $this->parsed['scheme'] . '://' . $this->parsed['host'] . (isset($this->parsed['port']) ? ':' . $this->parsed['port'] : '') . $this->uri . ($this->query ? (false === strpos($this->uri, '?') ? '?' : '&') . http_build_query($this->query, '', '&', \PHP_QUERY_RFC1738) : '');
         }
 
         return $this->endpoint;

--- a/src/Core/src/Signer/SignerV4.php
+++ b/src/Core/src/Signer/SignerV4.php
@@ -310,14 +310,14 @@ class SignerV4 implements Signer
         $encodedQuery = [];
         foreach ($query as $key => $values) {
             if (!\is_array($values)) {
-                $encodedQuery[] = urlencode($key) . '=' . urlencode($values);
+                $encodedQuery[] = rawurlencode($key) . '=' . rawurlencode($values);
 
                 continue;
             }
 
             sort($values);
             foreach ($values as $value) {
-                $encodedQuery[] = urlencode($key) . '=' . urlencode($value);
+                $encodedQuery[] = rawurlencode($key) . '=' . rawurlencode($value);
             }
         }
 

--- a/src/Core/src/Signer/SignerV4.php
+++ b/src/Core/src/Signer/SignerV4.php
@@ -310,14 +310,14 @@ class SignerV4 implements Signer
         $encodedQuery = [];
         foreach ($query as $key => $values) {
             if (!\is_array($values)) {
-                $encodedQuery[] = rawurlencode($key) . '=' . rawurlencode($values);
+                $encodedQuery[] = urlencode($key) . '=' . urlencode($values);
 
                 continue;
             }
 
             sort($values);
             foreach ($values as $value) {
-                $encodedQuery[] = rawurlencode($key) . '=' . rawurlencode($value);
+                $encodedQuery[] = urlencode($key) . '=' . urlencode($value);
             }
         }
 

--- a/src/Core/src/Test/TestCase.php
+++ b/src/Core/src/Test/TestCase.php
@@ -59,7 +59,7 @@ class TestCase extends PHPUnitTestCase
         $actualUrl = $actual->getUri();
         if ($actual->getQuery()) {
             $actualUrl .= false !== strpos($actual->getUri(), '?') ? '&' : '?';
-            $actualUrl .= http_build_query($actual->getQuery(), '', '&', \PHP_QUERY_RFC1738);
+            $actualUrl .= http_build_query($actual->getQuery(), '', '&', \PHP_QUERY_RFC3986);
         }
         self::assertUrlEqualsUrl($url, $actualUrl);
 

--- a/src/Core/src/Test/TestCase.php
+++ b/src/Core/src/Test/TestCase.php
@@ -59,7 +59,7 @@ class TestCase extends PHPUnitTestCase
         $actualUrl = $actual->getUri();
         if ($actual->getQuery()) {
             $actualUrl .= false !== strpos($actual->getUri(), '?') ? '&' : '?';
-            $actualUrl .= http_build_query($actual->getQuery());
+            $actualUrl .= http_build_query($actual->getQuery(), '', '&', \PHP_QUERY_RFC1738);
         }
         self::assertUrlEqualsUrl($url, $actualUrl);
 


### PR DESCRIPTION
`http_build_query` defaults to building strings for form request bodies, not URI query strings. We have to put it into that mode using the 4th param.