### PR TITLE
implement IMDSv2

### DIFF
--- a/docs/authentication/ec2-metadata.md
+++ b/docs/authentication/ec2-metadata.md
@@ -10,5 +10,5 @@ When you run code within an EC2 instance (or EKS, Lambda), AsyncAws is able to f
 When running a single application on the Server, this is the simplest way to grant permissions to the application. You
 have nothing to configure on the application, you only grant permissions on the Role attached to the instance.
 
-AsyncAWS uses the IMDSv1 protocol to read instance metadata. So this authentication method won't work if the v1
+AsyncAWS uses the IMDSv2 protocol to read instance metadata. So this authentication method won't work if the v2
 protocol is disabled.

--- a/docs/authentication/ec2-metadata.md
+++ b/docs/authentication/ec2-metadata.md
@@ -10,5 +10,4 @@ When you run code within an EC2 instance (or EKS, Lambda), AsyncAws is able to f
 When running a single application on the Server, this is the simplest way to grant permissions to the application. You
 have nothing to configure on the application, you only grant permissions on the Role attached to the instance.
 
-AsyncAWS uses the IMDSv2 protocol to read instance metadata. So this authentication method won't work if the v2
-protocol is disabled.
+AsyncAWS uses the IMDSv2 protocol to read instance metadata and fallback to the IMDSv1 protocol if it isn't supported.


### PR DESCRIPTION
fix #1163

Here is an implementation for IMDSv2 that we have in use. In the end we adjusted the `InstanceProvider` as described in the documentation:

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-data-retrieval.html

~In this implementation I replace the IMDSv1 variant with IMDSv2. I wonder if we really still need IMDSv1 or if IMDSv2 is available everywhere.~
It will first try to do an IMDSv2 authentication, if it doesn't work, then it will fallback to IMDSv1

I look forward to feedback.