### PR TITLE
Enforce HTTPS with TLS 1.2 or higher

### DIFF
--- a/docs/clients/index.md
+++ b/docs/clients/index.md
@@ -28,7 +28,7 @@ $config = Configuration::create([
     'region' => 'eu-central-1',
 ]);
 $credentialProvider = new ConfigurationProvider();
-$httpClient = HttpClient::create(); // ... Instance of Symfony's HttpClientInterface
+$httpClient = AwsHttpClientFactory::createClient(); // ... Instance of Symfony's HttpClientInterface
 // Or, to enable automatic retries on top of your own HttpClient
 // $httpClient = AwsHttpClientFactory::createRetryableClient($httpClient); T
 $logger = // ... A PSR-3 logger

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -13,6 +13,7 @@
     "require": {
         "php": "^7.2.5 || ^8.0",
         "ext-SimpleXML": "*",
+        "ext-curl": "*",
         "ext-hash": "*",
         "ext-json": "*",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -13,6 +13,7 @@ use AsyncAws\Core\EndpointDiscovery\EndpointCache;
 use AsyncAws\Core\Exception\InvalidArgument;
 use AsyncAws\Core\Exception\LogicException;
 use AsyncAws\Core\Exception\RuntimeException;
+use AsyncAws\Core\HttpClient\AwsHttpClientFactory;
 use AsyncAws\Core\HttpClient\AwsRetryStrategy;
 use AsyncAws\Core\Signer\Signer;
 use AsyncAws\Core\Signer\SignerV4;
@@ -81,7 +82,7 @@ abstract class AbstractApi
         $this->awsErrorFactory = $this->getAwsErrorFactory();
         $this->endpointCache = new EndpointCache();
         if (!isset($httpClient)) {
-            $httpClient = HttpClient::create();
+            $httpClient = AwsHttpClientFactory::createClient();
             if (class_exists(RetryableHttpClient::class)) {
                 /** @psalm-suppress MissingDependency */
                 $httpClient = new RetryableHttpClient(

--- a/src/Core/src/AwsClientFactory.php
+++ b/src/Core/src/AwsClientFactory.php
@@ -95,7 +95,7 @@ class AwsClientFactory
             throw new InvalidArgument(sprintf('Second argument to "%s::__construct()" must be an array or an instance of "%s"', __CLASS__, Configuration::class));
         }
 
-        $this->httpClient = $httpClient ?? HttpClient::create();
+        $this->httpClient = $httpClient ?? AwsHttpClientFactory::createClient();
         $this->logger = $logger ?? new NullLogger();
         $this->configuration = $configuration;
         $this->credentialProvider = $credentialProvider ?? new CacheProvider(ChainProvider::createDefaultChain($this->httpClient, $this->logger));

--- a/src/Core/src/Credentials/ChainProvider.php
+++ b/src/Core/src/Credentials/ChainProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AsyncAws\Core\Credentials;
 
 use AsyncAws\Core\Configuration;
+use AsyncAws\Core\HttpClient\AwsHttpClientFactory;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\HttpClient;
@@ -67,7 +68,7 @@ final class ChainProvider implements CredentialProvider, ResetInterface
 
     public static function createDefaultChain(?HttpClientInterface $httpClient = null, ?LoggerInterface $logger = null): CredentialProvider
     {
-        $httpClient = $httpClient ?? HttpClient::create();
+        $httpClient = $httpClient ?? AwsHttpClientFactory::createClient();
         $logger = $logger ?? new NullLogger();
 
         return new ChainProvider([

--- a/src/Core/src/Credentials/ContainerProvider.php
+++ b/src/Core/src/Credentials/ContainerProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AsyncAws\Core\Credentials;
 
 use AsyncAws\Core\Configuration;
+use AsyncAws\Core\HttpClient\AwsHttpClientFactory;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\HttpClient;
@@ -31,7 +32,7 @@ final class ContainerProvider implements CredentialProvider
     public function __construct(?HttpClientInterface $httpClient = null, ?LoggerInterface $logger = null, float $timeout = 1.0)
     {
         $this->logger = $logger ?? new NullLogger();
-        $this->httpClient = $httpClient ?? HttpClient::create();
+        $this->httpClient = $httpClient ?? AwsHttpClientFactory::createClient();
         $this->timeout = $timeout;
     }
 

--- a/src/Core/src/Credentials/InstanceProvider.php
+++ b/src/Core/src/Credentials/InstanceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AsyncAws\Core\Credentials;
 
 use AsyncAws\Core\Configuration;
+use AsyncAws\Core\HttpClient\AwsHttpClientFactory;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\Exception\JsonException;
@@ -39,7 +40,7 @@ final class InstanceProvider implements CredentialProvider
     public function __construct(?HttpClientInterface $httpClient = null, ?LoggerInterface $logger = null, float $timeout = 1.0, int $tokenTtl = 21600)
     {
         $this->logger = $logger ?? new NullLogger();
-        $this->httpClient = $httpClient ?? HttpClient::create();
+        $this->httpClient = $httpClient ?? AwsHttpClientFactory::createClient();
         $this->timeout = $timeout;
         $this->tokenTtl = $tokenTtl;
     }

--- a/src/Core/src/HttpClient/AwsHttpClientFactory.php
+++ b/src/Core/src/HttpClient/AwsHttpClientFactory.php
@@ -12,11 +12,25 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 class AwsHttpClientFactory
 {
+    public static function createClient(): HttpClientInterface
+    {
+        return return new CurlHttpClient([
+            'extra' => [
+                'curl' => [
+                    \CURLOPT_PROTOCOLS => \CURLPROTO_HTTPS,
+                    \CURLOPT_REDIR_PROTOCOLS => \CURLPROTO_HTTPS
+                    \CURLOPT_SSLVERSION => \CURL_SSLVERSION_TLSv1_2,
+                ],
+            ]
+        ]);
+    }
+
     public static function createRetryableClient(HttpClientInterface $httpClient = null, LoggerInterface $logger = null): HttpClientInterface
     {
         if (null === $httpClient) {
-            $httpClient = HttpClient::create();
+            $httpClient = self::createClient();
         }
+
         if (class_exists(RetryableHttpClient::class)) {
             /** @psalm-suppress MissingDependency */
             $httpClient = new RetryableHttpClient(


### PR DESCRIPTION
I have also required curl in order to do this in a simple way. I don't feel this is much of a restriction in practice, since the Symfony HTTP client is only "async" if curl is loaded, or another package is installed. Curl is pretty ubiquitous these days.