### PR TITLE
Update the GitHub Actions configuration

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -5,7 +5,7 @@ on: pull_request
 jobs:
   composer-normalize:
     name: Composer Normalize
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Set up PHP
@@ -16,7 +16,7 @@ jobs:
           tools: composer-normalize
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Normalize
         run: |
@@ -40,7 +40,7 @@ jobs:
 
   output-generated:
     name: Generated output not changed
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Set up PHP
@@ -50,7 +50,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Components tests
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -29,7 +29,7 @@ jobs:
           tools: flex
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize -j 4
@@ -165,7 +165,7 @@ jobs:
 
   root:
     name: Root tests
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -178,7 +178,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize -j 4

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   phpstan:
     name: PHPStan
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Set up PHP
@@ -19,7 +19,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get composer cache directory
         id: composer-cache
@@ -51,11 +51,11 @@ jobs:
 
   php-cs-fixer:
     name: PHP-CS-Fixer
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Cache PhpCsFixer
         uses: actions/cache@v3
@@ -71,7 +71,7 @@ jobs:
 
   psalm:
     name: Psalm
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
@@ -80,7 +80,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Get composer cache directory
         id: composer-cache

--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -8,7 +8,7 @@ jobs:
   generated-code:
     if: github.repository == 'async-aws/aws'
     name: Assert Generated Code is uptodate with last version
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Set up PHP
@@ -18,7 +18,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: master
 

--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     if: github.repository == 'async-aws/aws'
     name: Generate
-    runs-on: Ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Set up PHP
@@ -18,7 +18,7 @@ jobs:
           php-version: 8.1
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           path: 'source'
 

--- a/src/CodeGenerator/.github/workflows/checks.yml
+++ b/src/CodeGenerator/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Roave BC Check
         uses: docker://nyholm/roave-bc-check-ga

--- a/src/CodeGenerator/.github/workflows/ci.yml
+++ b/src/CodeGenerator/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download dependencies
         run: |

--- a/src/Core/.github/workflows/checks.yml
+++ b/src/Core/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: fetch tags
         run: git fetch --depth=1 origin +refs/tags/*:refs/tags/*

--- a/src/Core/.github/workflows/ci.yml
+++ b/src/Core/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Integration/Aws/DynamoDbSession/.github/workflows/checks.yml
+++ b/src/Integration/Aws/DynamoDbSession/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Integration/Aws/DynamoDbSession/.github/workflows/ci.yml
+++ b/src/Integration/Aws/DynamoDbSession/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download dependencies
         run: |

--- a/src/Integration/Aws/SimpleS3/.github/workflows/checks.yml
+++ b/src/Integration/Aws/SimpleS3/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Integration/Aws/SimpleS3/.github/workflows/ci.yml
+++ b/src/Integration/Aws/SimpleS3/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download dependencies
         run: |

--- a/src/Integration/Flysystem/S3/.github/workflows/checks.yml
+++ b/src/Integration/Flysystem/S3/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Integration/Flysystem/S3/.github/workflows/ci.yml
+++ b/src/Integration/Flysystem/S3/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Integration/Laravel/Cache/.github/workflows/checks.yml
+++ b/src/Integration/Laravel/Cache/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Integration/Laravel/Cache/.github/workflows/ci.yml
+++ b/src/Integration/Laravel/Cache/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download dependencies
         run: |

--- a/src/Integration/Laravel/Filesystem/.github/workflows/checks.yml
+++ b/src/Integration/Laravel/Filesystem/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Integration/Laravel/Filesystem/.github/workflows/ci.yml
+++ b/src/Integration/Laravel/Filesystem/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download dependencies
         run: |

--- a/src/Integration/Laravel/Mail/.github/workflows/checks.yml
+++ b/src/Integration/Laravel/Mail/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Integration/Laravel/Mail/.github/workflows/ci.yml
+++ b/src/Integration/Laravel/Mail/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download dependencies
         run: |

--- a/src/Integration/Laravel/Queue/.github/workflows/checks.yml
+++ b/src/Integration/Laravel/Queue/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Integration/Laravel/Queue/.github/workflows/ci.yml
+++ b/src/Integration/Laravel/Queue/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download dependencies
         run: |

--- a/src/Integration/Monolog/CloudWatch/.github/workflows/checks.yml
+++ b/src/Integration/Monolog/CloudWatch/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Integration/Monolog/CloudWatch/.github/workflows/ci.yml
+++ b/src/Integration/Monolog/CloudWatch/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download dependencies
         run: |

--- a/src/Integration/Symfony/Bundle/.github/workflows/checks.yml
+++ b/src/Integration/Symfony/Bundle/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Integration/Symfony/Bundle/.github/workflows/ci.yml
+++ b/src/Integration/Symfony/Bundle/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Download dependencies
         run: |

--- a/src/Service/.template/.github/workflows/checks.yml
+++ b/src/Service/.template/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/.template/.github/workflows/ci.yml
+++ b/src/Service/.template/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/AppSync/.github/workflows/checks.yml
+++ b/src/Service/AppSync/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/AppSync/.github/workflows/ci.yml
+++ b/src/Service/AppSync/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/Athena/.github/workflows/checks.yml
+++ b/src/Service/Athena/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/Athena/.github/workflows/ci.yml
+++ b/src/Service/Athena/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/CloudFormation/.github/workflows/checks.yml
+++ b/src/Service/CloudFormation/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/CloudFormation/.github/workflows/ci.yml
+++ b/src/Service/CloudFormation/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/CloudFront/.github/workflows/checks.yml
+++ b/src/Service/CloudFront/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/CloudFront/.github/workflows/ci.yml
+++ b/src/Service/CloudFront/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/CloudWatch/.github/workflows/checks.yml
+++ b/src/Service/CloudWatch/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/CloudWatch/.github/workflows/ci.yml
+++ b/src/Service/CloudWatch/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/CloudWatchLogs/.github/workflows/checks.yml
+++ b/src/Service/CloudWatchLogs/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/CloudWatchLogs/.github/workflows/ci.yml
+++ b/src/Service/CloudWatchLogs/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/CodeBuild/.github/workflows/checks.yml
+++ b/src/Service/CodeBuild/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/CodeBuild/.github/workflows/ci.yml
+++ b/src/Service/CodeBuild/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/CodeCommit/.github/workflows/checks.yml
+++ b/src/Service/CodeCommit/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/CodeCommit/.github/workflows/ci.yml
+++ b/src/Service/CodeCommit/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/CodeDeploy/.github/workflows/checks.yml
+++ b/src/Service/CodeDeploy/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/CodeDeploy/.github/workflows/ci.yml
+++ b/src/Service/CodeDeploy/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/CognitoIdentityProvider/.github/workflows/checks.yml
+++ b/src/Service/CognitoIdentityProvider/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/CognitoIdentityProvider/.github/workflows/ci.yml
+++ b/src/Service/CognitoIdentityProvider/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/Comprehend/.github/workflows/checks.yml
+++ b/src/Service/Comprehend/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/Comprehend/.github/workflows/ci.yml
+++ b/src/Service/Comprehend/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/DynamoDb/.github/workflows/checks.yml
+++ b/src/Service/DynamoDb/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/DynamoDb/.github/workflows/ci.yml
+++ b/src/Service/DynamoDb/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/Ecr/.github/workflows/checks.yml
+++ b/src/Service/Ecr/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/Ecr/.github/workflows/ci.yml
+++ b/src/Service/Ecr/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/ElastiCache/.github/workflows/checks.yml
+++ b/src/Service/ElastiCache/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/ElastiCache/.github/workflows/ci.yml
+++ b/src/Service/ElastiCache/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/EventBridge/.github/workflows/checks.yml
+++ b/src/Service/EventBridge/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/EventBridge/.github/workflows/ci.yml
+++ b/src/Service/EventBridge/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/Firehose/.github/workflows/checks.yml
+++ b/src/Service/Firehose/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/Firehose/.github/workflows/ci.yml
+++ b/src/Service/Firehose/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/Iam/.github/workflows/checks.yml
+++ b/src/Service/Iam/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/Iam/.github/workflows/ci.yml
+++ b/src/Service/Iam/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/Iot/.github/workflows/checks.yml
+++ b/src/Service/Iot/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/Iot/.github/workflows/ci.yml
+++ b/src/Service/Iot/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/IotData/.github/workflows/checks.yml
+++ b/src/Service/IotData/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/IotData/.github/workflows/ci.yml
+++ b/src/Service/IotData/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/Kinesis/.github/workflows/checks.yml
+++ b/src/Service/Kinesis/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/Kinesis/.github/workflows/ci.yml
+++ b/src/Service/Kinesis/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/Kms/.github/workflows/checks.yml
+++ b/src/Service/Kms/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/Kms/.github/workflows/ci.yml
+++ b/src/Service/Kms/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/Lambda/.github/workflows/checks.yml
+++ b/src/Service/Lambda/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/Lambda/.github/workflows/ci.yml
+++ b/src/Service/Lambda/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/RdsDataService/.github/workflows/checks.yml
+++ b/src/Service/RdsDataService/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/RdsDataService/.github/workflows/ci.yml
+++ b/src/Service/RdsDataService/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/Rekognition/.github/workflows/checks.yml
+++ b/src/Service/Rekognition/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/Rekognition/.github/workflows/ci.yml
+++ b/src/Service/Rekognition/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/Route53/.github/workflows/checks.yml
+++ b/src/Service/Route53/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/Route53/.github/workflows/ci.yml
+++ b/src/Service/Route53/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/S3/.github/workflows/checks.yml
+++ b/src/Service/S3/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/S3/.github/workflows/ci.yml
+++ b/src/Service/S3/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/Scheduler/.github/workflows/checks.yml
+++ b/src/Service/Scheduler/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/Scheduler/.github/workflows/ci.yml
+++ b/src/Service/Scheduler/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/SecretsManager/.github/workflows/checks.yml
+++ b/src/Service/SecretsManager/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/SecretsManager/.github/workflows/ci.yml
+++ b/src/Service/SecretsManager/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/Ses/.github/workflows/checks.yml
+++ b/src/Service/Ses/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/Ses/.github/workflows/ci.yml
+++ b/src/Service/Ses/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/Sns/.github/workflows/checks.yml
+++ b/src/Service/Sns/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/Sns/.github/workflows/ci.yml
+++ b/src/Service/Sns/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/Sqs/.github/workflows/checks.yml
+++ b/src/Service/Sqs/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/Sqs/.github/workflows/ci.yml
+++ b/src/Service/Sqs/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/Ssm/.github/workflows/checks.yml
+++ b/src/Service/Ssm/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/Ssm/.github/workflows/ci.yml
+++ b/src/Service/Ssm/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/StepFunctions/.github/workflows/checks.yml
+++ b/src/Service/StepFunctions/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/StepFunctions/.github/workflows/ci.yml
+++ b/src/Service/StepFunctions/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/TimestreamQuery/.github/workflows/checks.yml
+++ b/src/Service/TimestreamQuery/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/TimestreamQuery/.github/workflows/ci.yml
+++ b/src/Service/TimestreamQuery/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/TimestreamWrite/.github/workflows/checks.yml
+++ b/src/Service/TimestreamWrite/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/TimestreamWrite/.github/workflows/ci.yml
+++ b/src/Service/TimestreamWrite/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/Translate/.github/workflows/checks.yml
+++ b/src/Service/Translate/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/Translate/.github/workflows/ci.yml
+++ b/src/Service/Translate/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize

--- a/src/Service/XRay/.github/workflows/checks.yml
+++ b/src/Service/XRay/.github/workflows/checks.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Modify composer.json
         run: |

--- a/src/Service/XRay/.github/workflows/ci.yml
+++ b/src/Service/XRay/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Initialize tests
         run: make initialize


### PR DESCRIPTION
This makes 2 changes:

- use `actions/checkout@v3` to avoid using the deprecated node12 runtime
- updates the runner to `ubuntu-latest` instead of `ubuntu-20.04` so that it uses the 22.04 runner (and updates to new ones when available)