### PR TITLE
Ignore vendor's deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
         "monolog/monolog": "^1.1 || ^2.0",
         "nette/php-generator": "^3.6.4",
         "nette/utils": "^3.0",
-        "nyholm/symfony-bundle-test": "1.x-dev#0555e4898e1b05655a4bdf52ba10c7f56611a514 as 1.9.0",
+        "nyholm/symfony-bundle-test": "^2.0",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "swaggest/json-diff": "^3.7",
         "symfony/cache": "^4.4 || ^5.0 || ^6.0 || ^7.0",

--- a/src/Integration/Symfony/Bundle/tests/Functional/PublicServicePass.php
+++ b/src/Integration/Symfony/Bundle/tests/Functional/PublicServicePass.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace AsyncAws\Symfony\Bundle\Tests\Functional;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class PublicServicePass implements CompilerPassInterface
+{
+    /**
+     * A regex to match the services that should be public.
+     *
+     * @var string
+     */
+    private $regex;
+
+    /**
+     * @param string $regex
+     */
+    public function __construct($regex = '|.*|')
+    {
+        $this->regex = $regex;
+    }
+
+    public function process(ContainerBuilder $container): void
+    {
+        foreach ($container->getDefinitions() as $id => $definition) {
+            if (preg_match($this->regex, $id)) {
+                $definition->setPublic(true);
+            }
+        }
+
+        foreach ($container->getAliases() as $id => $alias) {
+            if (preg_match($this->regex, $id)) {
+                $alias->setPublic(true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes error

```
1x: Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "Nyholm\BundleTest\CompilerPass\PublicServicePass" now to avoid errors or add an explicit @return annotation to suppress this message.
      1x in BundleInitializationTest::setUp from AsyncAws\Symfony\Bundle\Tests\Functional
```