### PR TITLE
Remove usage of ::set-output in GitHub Actions

### DIFF
--- a/.github/workflows/bin/refresh
+++ b/.github/workflows/bin/refresh
@@ -232,4 +232,4 @@ foreach ($services as $service => $hasChange) {
 }
 
 // forward version to .github action
-echo PHP_EOL, '::set-output name=last::'.$lastVersion, PHP_EOL;
+file_put_contents($_SERVER['GITHUB_OUTPUT'], 'last='.$lastVersion.\PHP_EOL, FILE_APPEND);

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer
         uses: actions/cache@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer
         uses: actions/cache@v3
@@ -185,7 +185,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer
         uses: actions/cache@v3

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer
         uses: actions/cache@v3
@@ -84,7 +84,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer
         uses: actions/cache@v3

--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Get composer cache directory
         id: composer-cache
-        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache Composer
         uses: actions/cache@v3

--- a/src/Core/.github/workflows/branch_alias.yml
+++ b/src/Core/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Integration/Aws/DynamoDbSession/.github/workflows/branch_alias.yml
+++ b/src/Integration/Aws/DynamoDbSession/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Integration/Aws/SimpleS3/.github/workflows/branch_alias.yml
+++ b/src/Integration/Aws/SimpleS3/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Integration/Flysystem/S3/.github/workflows/branch_alias.yml
+++ b/src/Integration/Flysystem/S3/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Integration/Laravel/Cache/.github/workflows/branch_alias.yml
+++ b/src/Integration/Laravel/Cache/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Integration/Laravel/Filesystem/.github/workflows/branch_alias.yml
+++ b/src/Integration/Laravel/Filesystem/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Integration/Laravel/Mail/.github/workflows/branch_alias.yml
+++ b/src/Integration/Laravel/Mail/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Integration/Laravel/Queue/.github/workflows/branch_alias.yml
+++ b/src/Integration/Laravel/Queue/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Integration/Monolog/CloudWatch/.github/workflows/branch_alias.yml
+++ b/src/Integration/Monolog/CloudWatch/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Integration/Symfony/Bundle/.github/workflows/branch_alias.yml
+++ b/src/Integration/Symfony/Bundle/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/.template/.github/workflows/branch_alias.yml
+++ b/src/Service/.template/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/AppSync/.github/workflows/branch_alias.yml
+++ b/src/Service/AppSync/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/Athena/.github/workflows/branch_alias.yml
+++ b/src/Service/Athena/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/CloudFormation/.github/workflows/branch_alias.yml
+++ b/src/Service/CloudFormation/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/CloudFront/.github/workflows/branch_alias.yml
+++ b/src/Service/CloudFront/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/CloudWatch/.github/workflows/branch_alias.yml
+++ b/src/Service/CloudWatch/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/CloudWatchLogs/.github/workflows/branch_alias.yml
+++ b/src/Service/CloudWatchLogs/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/CodeBuild/.github/workflows/branch_alias.yml
+++ b/src/Service/CodeBuild/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/CodeCommit/.github/workflows/branch_alias.yml
+++ b/src/Service/CodeCommit/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/CodeDeploy/.github/workflows/branch_alias.yml
+++ b/src/Service/CodeDeploy/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/CognitoIdentityProvider/.github/workflows/branch_alias.yml
+++ b/src/Service/CognitoIdentityProvider/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/Comprehend/.github/workflows/branch_alias.yml
+++ b/src/Service/Comprehend/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/DynamoDb/.github/workflows/branch_alias.yml
+++ b/src/Service/DynamoDb/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/Ecr/.github/workflows/branch_alias.yml
+++ b/src/Service/Ecr/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/ElastiCache/.github/workflows/branch_alias.yml
+++ b/src/Service/ElastiCache/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/EventBridge/.github/workflows/branch_alias.yml
+++ b/src/Service/EventBridge/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/Firehose/.github/workflows/branch_alias.yml
+++ b/src/Service/Firehose/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/Iam/.github/workflows/branch_alias.yml
+++ b/src/Service/Iam/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/Iot/.github/workflows/branch_alias.yml
+++ b/src/Service/Iot/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/IotData/.github/workflows/branch_alias.yml
+++ b/src/Service/IotData/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/Kinesis/.github/workflows/branch_alias.yml
+++ b/src/Service/Kinesis/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/Kms/.github/workflows/branch_alias.yml
+++ b/src/Service/Kms/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/Lambda/.github/workflows/branch_alias.yml
+++ b/src/Service/Lambda/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/RdsDataService/.github/workflows/branch_alias.yml
+++ b/src/Service/RdsDataService/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/Rekognition/.github/workflows/branch_alias.yml
+++ b/src/Service/Rekognition/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/Route53/.github/workflows/branch_alias.yml
+++ b/src/Service/Route53/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/S3/.github/workflows/branch_alias.yml
+++ b/src/Service/S3/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/Scheduler/.github/workflows/branch_alias.yml
+++ b/src/Service/Scheduler/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/SecretsManager/.github/workflows/branch_alias.yml
+++ b/src/Service/SecretsManager/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/Ses/.github/workflows/branch_alias.yml
+++ b/src/Service/Ses/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/Sns/.github/workflows/branch_alias.yml
+++ b/src/Service/Sns/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/Sqs/.github/workflows/branch_alias.yml
+++ b/src/Service/Sqs/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/Ssm/.github/workflows/branch_alias.yml
+++ b/src/Service/Ssm/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/StepFunctions/.github/workflows/branch_alias.yml
+++ b/src/Service/StepFunctions/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/TimestreamQuery/.github/workflows/branch_alias.yml
+++ b/src/Service/TimestreamQuery/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/TimestreamWrite/.github/workflows/branch_alias.yml
+++ b/src/Service/TimestreamWrite/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/Translate/.github/workflows/branch_alias.yml
+++ b/src/Service/Translate/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |

--- a/src/Service/XRay/.github/workflows/branch_alias.yml
+++ b/src/Service/XRay/.github/workflows/branch_alias.yml
@@ -23,7 +23,7 @@ jobs:
           echo "Last tag was $TAG"
           ARR=(${TAG//./ })
           ARR[1]=$((${ARR[1]}+1))
-          echo ::set-output name=alias::${ARR[0]}.${ARR[1]}
+          echo "alias=${ARR[0]}.${ARR[1]}" >> $GITHUB_OUTPUT
 
       - name: Checkout main repo
         run: |


### PR DESCRIPTION
This removes usage of this deprecated feature.