### PR TITLE
Clean outdated errors from the psalm baseline

### DIFF
--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -3,26 +3,11 @@
   <file src="src/Core/src/Credentials/PsrCacheProvider.php">
     <InvalidCatch occurrences="1"/>
     <InvalidThrow occurrences="1">
-        <code>CacheException</code>
+      <code>CacheException</code>
     </InvalidThrow>
-    <UndefinedClass occurrences="4">
-      <code>$this-&gt;cache</code>
-      <code>$this-&gt;cache</code>
-      <code>CacheException</code>
-      <code>CacheItemPoolInterface</code>
-    </UndefinedClass>
-    <UndefinedDocblockClass occurrences="1">
-      <code>CacheException</code>
-    </UndefinedDocblockClass>
   </file>
   <file src="src/Core/src/Credentials/SymfonyCacheProvider.php">
     <InvalidCatch occurrences="1"/>
-    <UndefinedClass occurrences="4">
-      <code>$this-&gt;cache</code>
-      <code>CacheException</code>
-      <code>CacheInterface</code>
-      <code>ItemInterface</code>
-    </UndefinedClass>
   </file>
   <file src="src/Core/src/Request.php">
     <RedundantCastGivenDocblockType occurrences="1">
@@ -42,22 +27,10 @@
       <code>$exception</code>
     </PossiblyUndefinedVariable>
   </file>
-  <file src="src/Integration/Flysystem/S3/src/AsyncAwsS3Adapter.php">
-    <UndefinedClass occurrences="2">
-      <code>AbstractAdapter</code>
-      <code>CanOverwriteFiles</code>
-    </UndefinedClass>
-  </file>
-  <file src="src/Integration/Laravel/Cache/src/AsyncAwsDynamoDbLock.php">
-    <UndefinedClass occurrences="1">
-      <code>Lock</code>
-    </UndefinedClass>
-  </file>
   <file src="src/Integration/Laravel/Cache/src/AsyncAwsDynamoDbStore.php">
-    <RedundantCast occurrences="1"/>
-    <UndefinedClass occurrences="1">
-      <code>LockProvider</code>
-    </UndefinedClass>
+    <RedundantCast occurrences="1">
+      <code>(int) $e-&gt;getCode()</code>
+    </RedundantCast>
   </file>
   <file src="src/Integration/Laravel/Cache/src/ServiceProvider.php">
     <UndefinedInterfaceMethod occurrences="1">
@@ -67,76 +40,24 @@
       <code>getPrefix</code>
       <code>repository</code>
     </UndefinedMethod>
-    <UndefinedClass occurrences="1">
-      <code>AbstractServiceProvider</code>
-    </UndefinedClass>
   </file>
   <file src="src/Integration/Laravel/Filesystem/src/ServiceProvider.php">
     <UndefinedInterfaceMethod occurrences="1">
       <code>$this-&gt;app</code>
     </UndefinedInterfaceMethod>
-    <UndefinedClass occurrences="1">
-      <code>AbstractServiceProvider</code>
-    </UndefinedClass>
   </file>
   <file src="src/Integration/Laravel/Mail/src/ServiceProvider.php">
     <UndefinedInterfaceMethod occurrences="1">
       <code>$this-&gt;app</code>
     </UndefinedInterfaceMethod>
-    <UndefinedClass occurrences="1">
-      <code>AbstractServiceProvider</code>
-    </UndefinedClass>
   </file>
   <file src="src/Integration/Laravel/Mail/src/Transport/AsyncAwsSesTransport.php">
     <InvalidArgument occurrences="1"/>
-    <UndefinedClass occurrences="1">
-      <code>Transport</code>
-    </UndefinedClass>
-  </file>
-  <file src="src/Integration/Laravel/Queue/src/AsyncAwsSqsQueue.php">
-    <UndefinedClass occurrences="2">
-      <code>Queue</code>
-      <code>QueueContract</code>
-    </UndefinedClass>
-  </file>
-  <file src="src/Integration/Laravel/Queue/src/Connector/AsyncAwsSqsConnector.php">
-    <UndefinedClass occurrences="1">
-      <code>ConnectorInterface</code>
-    </UndefinedClass>
-  </file>
-  <file src="src/Integration/Laravel/Queue/src/Job/AsyncAwsSqsJob.php">
-    <UndefinedClass occurrences="2">
-      <code>Job</code>
-      <code>JobContract</code>
-    </UndefinedClass>
   </file>
   <file src="src/Integration/Laravel/Queue/src/ServiceProvider.php">
     <UndefinedInterfaceMethod occurrences="1">
       <code>$this-&gt;app</code>
     </UndefinedInterfaceMethod>
-    <UndefinedClass occurrences="1">
-      <code>AbstractServiceProvider</code>
-    </UndefinedClass>
-  </file>
-  <file src="src/Integration/Monolog/CloudWatch/src/CloudWatchLogsHandler.php">
-    <UndefinedClass occurrences="1">
-      <code>AbstractProcessingHandler</code>
-    </UndefinedClass>
-  </file>
-  <file src="src/Integration/Symfony/Bundle/src/AsyncAwsBundle.php">
-    <UndefinedClass occurrences="1">
-      <code>Bundle</code>
-    </UndefinedClass>
-  </file>
-  <file src="src/Integration/Symfony/Bundle/src/DependencyInjection/AsyncAwsExtension.php">
-    <UndefinedClass occurrences="1">
-      <code>Extension</code>
-    </UndefinedClass>
-  </file>
-  <file src="src/Integration/Symfony/Bundle/src/DependencyInjection/Compiler/InjectCasterPass.php">
-    <UndefinedClass occurrences="1">
-      <code>CompilerPassInterface</code>
-    </UndefinedClass>
   </file>
   <file src="src/Integration/Symfony/Bundle/src/DependencyInjection/Configuration.php">
     <PossiblyNullReference occurrences="1">
@@ -145,25 +66,14 @@
     <PossiblyUndefinedMethod occurrences="1">
       <code>scalarNode</code>
     </PossiblyUndefinedMethod>
-    <UndefinedClass occurrences="1">
-      <code>ConfigurationInterface</code>
-    </UndefinedClass>
   </file>
-  <file src="src/Integration/Symfony/Bundle/src/Secrets/CachedEnvVarLoader.php">
-    <UndefinedClass occurrences="1">
-      <code>EnvVarLoaderInterface</code>
-    </UndefinedClass>
-  </file>
-  <file src="src/Integration/Symfony/Bundle/src/Secrets/SsmVault.php">
-    <UndefinedClass occurrences="1">
-      <code>EnvVarLoaderInterface</code>
-    </UndefinedClass>
-  </file>
-  <file src="src/Integration/Symfony/Bundle/src/VarDumper/ResultCaster.php">
-    <UndefinedClass occurrences="2">
-      <code>Stub</code>
-      <code>Stub</code>
-    </UndefinedClass>
+  <file src="src/Service/Athena/src/Result/GetQueryResultsOutput.php">
+    <InvalidReturnType occurrences="1">
+      <code>\Traversable&lt;Row&gt;</code>
+    </InvalidReturnType>
+    <PossiblyNullReference occurrences="1">
+      <code>getRows</code>
+    </PossiblyNullReference>
   </file>
   <file src="src/Service/CloudFormation/src/Result/DescribeStacksOutput.php">
     <LessSpecificReturnStatement occurrences="1">
@@ -260,6 +170,11 @@
       <code>(bool) $v</code>
     </RedundantCastGivenDocblockType>
   </file>
+  <file src="src/Service/DynamoDb/src/Input/CreateTableInput.php">
+    <RedundantCastGivenDocblockType occurrences="1">
+      <code>(bool) $v</code>
+    </RedundantCastGivenDocblockType>
+  </file>
   <file src="src/Service/DynamoDb/src/Input/ExecuteStatementInput.php">
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(bool) $v</code>
@@ -281,23 +196,10 @@
       <code>(bool) $v</code>
     </RedundantCastGivenDocblockType>
   </file>
-  <file src="src/Service/DynamoDb/src/Input/CreateTableInput.php">
-    <RedundantCastGivenDocblockType occurrences="1">
-      <code>(bool) $v</code>
-    </RedundantCastGivenDocblockType>
-  </file>
   <file src="src/Service/DynamoDb/src/Input/UpdateTableInput.php">
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(bool) $v</code>
     </RedundantCastGivenDocblockType>
-  </file>
-  <file src="src/Service/DynamoDb/src/Input/TransactWriteItemsInput.php">
-    <UndefinedConstant occurrences="1">
-      <code>\UUID_TYPE_RANDOM</code>
-    </UndefinedConstant>
-    <UndefinedFunction occurrences="1">
-      <code>uuid_create(\UUID_TYPE_RANDOM)</code>
-    </UndefinedFunction>
   </file>
   <file src="src/Service/DynamoDb/src/ValueObject/AttributeValue.php">
     <InvalidArrayOffset occurrences="2">
@@ -450,30 +352,6 @@
       <code>empty($s3SignerOptions)</code>
     </TypeDoesNotContainType>
   </file>
-  <file src="src/Service/Scheduler/src/Input/CreateScheduleGroupInput.php">
-    <UndefinedConstant occurrences="1">
-      <code>\UUID_TYPE_RANDOM</code>
-    </UndefinedConstant>
-    <UndefinedFunction occurrences="1">
-      <code>uuid_create(\UUID_TYPE_RANDOM)</code>
-    </UndefinedFunction>
-  </file>
-  <file src="src/Service/Scheduler/src/Input/CreateScheduleInput.php">
-    <UndefinedConstant occurrences="1">
-      <code>\UUID_TYPE_RANDOM</code>
-    </UndefinedConstant>
-    <UndefinedFunction occurrences="1">
-      <code>uuid_create(\UUID_TYPE_RANDOM)</code>
-    </UndefinedFunction>
-  </file>
-  <file src="src/Service/Scheduler/src/Input/UpdateScheduleInput.php">
-    <UndefinedConstant occurrences="1">
-      <code>\UUID_TYPE_RANDOM</code>
-    </UndefinedConstant>
-    <UndefinedFunction occurrences="1">
-      <code>uuid_create(\UUID_TYPE_RANDOM)</code>
-    </UndefinedFunction>
-  </file>
   <file src="src/Service/Scheduler/src/Result/ListScheduleGroupsOutput.php">
     <InvalidArgument occurrences="1"/>
   </file>
@@ -484,12 +362,6 @@
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(bool) $v</code>
     </RedundantCastGivenDocblockType>
-    <UndefinedConstant occurrences="1">
-      <code>\UUID_TYPE_RANDOM</code>
-    </UndefinedConstant>
-    <UndefinedFunction occurrences="1">
-      <code>uuid_create(\UUID_TYPE_RANDOM)</code>
-    </UndefinedFunction>
   </file>
   <file src="src/Service/SecretsManager/src/Input/DeleteSecretRequest.php">
     <RedundantCastGivenDocblockType occurrences="1">
@@ -500,22 +372,6 @@
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(bool) $v</code>
     </RedundantCastGivenDocblockType>
-  </file>
-  <file src="src/Service/SecretsManager/src/Input/PutSecretValueRequest.php">
-    <UndefinedConstant occurrences="1">
-      <code>\UUID_TYPE_RANDOM</code>
-    </UndefinedConstant>
-    <UndefinedFunction occurrences="1">
-      <code>uuid_create(\UUID_TYPE_RANDOM)</code>
-    </UndefinedFunction>
-  </file>
-  <file src="src/Service/SecretsManager/src/Input/UpdateSecretRequest.php">
-    <UndefinedConstant occurrences="1">
-      <code>\UUID_TYPE_RANDOM</code>
-    </UndefinedConstant>
-    <UndefinedFunction occurrences="1">
-      <code>uuid_create(\UUID_TYPE_RANDOM)</code>
-    </UndefinedFunction>
   </file>
   <file src="src/Service/Ssm/src/Input/GetParameterRequest.php">
     <RedundantCastGivenDocblockType occurrences="1">
@@ -542,21 +398,5 @@
     <RedundantCastGivenDocblockType occurrences="1">
       <code>(bool) $v</code>
     </RedundantCastGivenDocblockType>
-  </file>
-  <file src="src/Service/TimestreamQuery/src/Input/QueryRequest.php">
-    <UndefinedConstant occurrences="1">
-      <code>\UUID_TYPE_RANDOM</code>
-    </UndefinedConstant>
-    <UndefinedFunction occurrences="1">
-      <code>uuid_create(\UUID_TYPE_RANDOM)</code>
-    </UndefinedFunction>
-  </file>
-  <file src="src/Service/Athena/src/Result/GetQueryResultsOutput.php">
-      <InvalidReturnType occurrences="1">
-          <code>\Traversable&lt;Row&gt;</code>
-      </InvalidReturnType>
-      <PossiblyNullReference occurrences="1">
-          <code>getRows</code>
-      </PossiblyNullReference>
   </file>
 </files>


### PR DESCRIPTION
This regenerates the Psalm baseline to get rid of errors that are not relevant anymore. This has 2 benefits:

- if a PR regenerates the baseline to add new errors in it, it won't have a huge diff removing those
- if a PR changes code and introduces new issues, there is no risk to ignore them silently if we are unlucky that it matches an old baseline entry