### PR TITLE
Fix the OperationGenerator for services with a custom endpoint discovery

### DIFF
--- a/src/CodeGenerator/src/Generator/OperationGenerator.php
+++ b/src/CodeGenerator/src/Generator/OperationGenerator.php
@@ -206,14 +206,20 @@ class OperationGenerator
         if ($operation->requiresEndpointDiscovery()) {
             $this->requirementsRegistry->addRequirement('async-aws/core', '^1.16');
             $endpointOperation = $operation->getService()->findEndpointOperationName();
-            $this->generate($endpointOperation);
+
+            if (null !== $endpointOperation) {
+                $this->generate($endpointOperation);
+            }
 
             $extra .= ", 'requiresEndpointDiscovery' => true";
         }
         if ($operation->usesEndpointDiscovery()) {
             $this->requirementsRegistry->addRequirement('async-aws/core', '^1.16');
             $endpointOperation = $operation->getService()->findEndpointOperationName();
-            $this->generate($endpointOperation);
+
+            if (null !== $endpointOperation) {
+                $this->generate($endpointOperation);
+            }
 
             $extra .= ", 'usesEndpointDiscovery' => true";
         }


### PR DESCRIPTION
Such services will not have an operation marked as being the `endpointoperation` but will instead implement the `discoverEndpoint` manually.
The `findEndpointOperationName` method returns `Operation|null` but the code was not properly handling `null` values.