### PR TITLE
Add support for generating code for discovered endpoint using the URI

### DIFF
--- a/src/CodeGenerator/src/Generator/Composer/RequirementsRegistry.php
+++ b/src/CodeGenerator/src/Generator/Composer/RequirementsRegistry.php
@@ -8,6 +8,16 @@ class RequirementsRegistry
 
     public function addRequirement(string $package, string $version = '*'): void
     {
+        if (isset($this->requirements[$package]) && '*' !== $this->requirements[$package]) {
+            if ('*' === $version) {
+                return; // Keep the existing requirement as it is specific.
+            }
+
+            if (version_compare(ltrim($this->requirements[$package], '^'), ltrim($version, '^'), '>')) {
+                return; // Keep the existing requirement if it is for a higher version.
+            }
+        }
+
         $this->requirements[$package] = $version;
     }
 

--- a/src/CodeGenerator/src/Generator/InputGenerator.php
+++ b/src/CodeGenerator/src/Generator/InputGenerator.php
@@ -72,6 +72,11 @@ class InputGenerator
      */
     private $generated = [];
 
+    /**
+     * @var RequirementsRegistry
+     */
+    private $requirementsRegistry;
+
     public function __construct(ClassRegistry $classRegistry, NamespaceRegistry $namespaceRegistry, RequirementsRegistry $requirementsRegistry, ObjectGenerator $objectGenerator, ?TypeGenerator $typeGenerator = null, ?EnumGenerator $enumGenerator = null, ?HookGenerator $hookGenerator = null)
     {
         $this->classRegistry = $classRegistry;
@@ -81,6 +86,7 @@ class InputGenerator
         $this->enumGenerator = $enumGenerator ?? new EnumGenerator($this->classRegistry, $this->namespaceRegistry);
         $this->hookGenerator = $hookGenerator ?? new HookGenerator();
         $this->serializer = new SerializerProvider($this->namespaceRegistry, $requirementsRegistry);
+        $this->requirementsRegistry = $requirementsRegistry;
     }
 
     /**
@@ -315,7 +321,7 @@ class InputGenerator
                 }
 
                 if ('querystring' === $requestPart && $usesEndpointDiscovery) {
-                    throw new \InvalidArgumentException('Query string is not compatible with endpoint discovery');
+                    $this->requirementsRegistry->addRequirement('async-aws/core', '^1.19');
                 }
 
                 $memberShape = $member->getShape();
@@ -446,7 +452,7 @@ class InputGenerator
         $uriStringCode = preg_replace('/(^""\.|\.""$|\.""\.)/', '', $uriStringCode);
 
         if ($usesEndpointDiscovery && '"/"' !== $uriStringCode) {
-            throw new \InvalidArgumentException('URI is not compatible with endpoint discovery');
+            $this->requirementsRegistry->addRequirement('async-aws/core', '^1.19');
         }
 
         $body['uri'] .= '$uriString = ' . $uriStringCode . ';';

--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Added
 
 - Support for Athena
+- Support for using endpoint discovery with parameters passed in the query string or the path
 
 ### Fixed
 


### PR DESCRIPTION
The core package has been updated to support those, so the code generator can rely on them.
This makes the RequirementRegistry smarter by merging requirements for the same package added in multiple places by keeping the requirement with the highest lower bound. For now, this supports only the `*` requirement and requirements using the `^` operator as they are the only requirements used by the code generators.

This leverages #1415 in the code generator (this PR assumes that the next release of Core including this patch will be 1.19 as this deserves a minor version IMO as it brings a new feature). The changelog entry added in Core actually corresponds to the change in #1415.