### PR TITLE
Fix EventBridge CHANGELOG according to released version

### DIFF
--- a/src/Service/EventBridge/CHANGELOG.md
+++ b/src/Service/EventBridge/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## NOT RELEASED
 
-## 1.4.1
+## 1.5.0
 
 ### Added
 


### PR DESCRIPTION
I tagged 1.5.0 instead of 1.4.1 :facepalm: 