### PR TITLE
Add support for double in XML requests

### DIFF
--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
@@ -143,6 +143,8 @@ class RestXmlSerializer implements Serializer
             case 'string':
             case 'integer':
             case 'long':
+            case 'float':
+            case 'double':
                 return $this->dumpXmlShapeString($member, $shape, $output, $input);
             case 'boolean':
                 return $this->dumpXmlShapeBoolean($member, $output, $input);


### PR DESCRIPTION
The official SDK handles float shapes by simply casting the value to string in the XML text node. So this reuses the same logic than for other shapes using this kind of handling.