### PR TITLE
Use composer to install phpstan

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -44,10 +44,7 @@ jobs:
           composer update --no-interaction --prefer-dist --optimize-autoloader
 
       - name: PHPStan
-        uses: docker://oskarstark/phpstan-ga:1.6.0
-        with:
-          entrypoint: /composer/vendor/bin/phpstan
-          args: analyze --no-progress
+        run: vendor/bin/phpstan analyze --no-progress
 
   php-cs-fixer:
     name: PHP-CS-Fixer

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 7.4
+          php-version: 8.2
           coverage: none
 
       - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "nette/php-generator": "^3.6.4",
         "nette/utils": "^3.0",
         "nyholm/symfony-bundle-test": "^2.0",
+        "phpstan/phpstan": "1.6.0",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "swaggest/json-diff": "^3.7",
         "symfony/cache": "^4.4 || ^5.0 || ^6.0 || ^7.0",


### PR DESCRIPTION
The unofficial docker image that was used does not have all the phpstan releases.

My plan (for follow-up PRs) is to update to newer versions of phpstan (and try to increase the level) as newer versions are better at finding issues.

This also makes it a lot easier to run phpstan locally.