### PR TITLE
Configure phpstan to not complain about safety checks

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,6 @@
 parameters:
     level: 5
+    treatPhpDocTypesAsCertain: false
     reportUnmatchedIgnoredErrors: false
     paths:
         - src
@@ -22,39 +23,7 @@ parameters:
         - '#PHPDoc tag @throws with type Psr\\Cache\\CacheException is not subtype of Throwable$#'
         - '#^Dead catch - JsonException is never thrown in the try block\.$#'
         - '#^Unsafe access to private property AsyncAws\\Flysystem\\S3\\AsyncAwsS3Adapter::\$[^ ]+ through static::\.$#'
-        - '#^Variable \$s3SignerOptions in empty\(\) always exists and is always falsy.#'
         - '#^Method AsyncAws\\[^\\]+\\Result\\[^ ]+ should return #'
         - '#^Parameter \#1 \$input of class AsyncAws\\[^\\]+\\ValueObject\\[^ ]+ constructor expects #'
         - '#^Argument 1 of AsyncAws\\Scheduler\\ValueObject\\ScheduleGroupSummary::__construct expects #'
         - '#^Property AsyncAws\\Sqs\\Input\\SendMessageRequest::\$messageSystemAttributes \([^)]+\) does not accept non-empty-array#'
-        - message: '#always exists and is not nullable\.$#'
-          paths:
-              - src/Core/src/Sts/ValueObject
-              - src/Service/AppSync/src/ValueObject
-              - src/Service/Athena/src/ValueObject
-              - src/Service/CodeBuild/src/ValueObject
-              - src/Service/CodeCommit/src/ValueObject
-              - src/Service/CloudFormation/src/ValueObject
-              - src/Service/CloudFront/src/ValueObject
-              - src/Service/CloudWatch/src/ValueObject
-              - src/Service/CloudWatchLogs/src/ValueObject
-              - src/Service/CognitoIdentityProvider/src/ValueObject
-              - src/Service/DynamoDb/src/ValueObject
-              - src/Service/Firehose/src/ValueObject
-              - src/Service/Iam/src/ValueObject
-              - src/Service/Kms/src/ValueObject/KeyMetadata.php
-              - src/Service/Kms/src/ValueObject/Tag.php
-              - src/Service/Kinesis/src/ValueObject
-              - src/Service/Lambda/src/ValueObject
-              - src/Service/MediaConvert/src/ValueObject
-              - src/Service/Iot/src/ValueObject/Tag.php
-              - src/Service/Rekognition/src/ValueObject
-              - src/Service/Route53/src/ValueObject
-              - src/Service/S3/src/ValueObject
-              - src/Service/Scheduler/src/ValueObject
-              - src/Service/Ses/src/ValueObject
-              - src/Service/Sns/src/ValueObject
-              - src/Service/Sqs/src/ValueObject
-              - src/Service/Ssm/src/ValueObject
-              - src/Service/TimestreamQuery/src/ValueObject
-              - src/Service/TimestreamWrite/src/ValueObject


### PR DESCRIPTION
Based on the discussion in https://github.com/async-aws/aws/pull/1417#issuecomment-1569221082, it is expected that the code performs safety checks even though the phpdoc describes a precise type.

Instead of ignoring errors (which might also ignore actual errors where the condition is useless), this configures phpstan to operate in such mode (thanks to the updated version of phpstan)