### PR TITLE
Add signature for callable types

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,6 +1,7 @@
 parameters:
     level: 5
     treatPhpDocTypesAsCertain: false
+    checkMissingCallableSignature: true
     reportUnmatchedIgnoredErrors: false
     paths:
         - src

--- a/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
@@ -89,7 +89,7 @@ class TypeGenerator
                     $param = 'array<string, ' . $param . '>';
                 }
             } elseif ($member->isStreaming()) {
-                $param = 'string|resource|callable|iterable';
+                $param = 'string|resource|(callable(int): string)|iterable<string>';
             } elseif ('timestamp' === $param = $memberShape->getType()) {
                 $param = $isObject ? '\DateTimeImmutable' : '\DateTimeImmutable|string';
             } else {

--- a/src/CodeGenerator/src/Generator/InputGenerator.php
+++ b/src/CodeGenerator/src/Generator/InputGenerator.php
@@ -210,7 +210,7 @@ class InputGenerator
                     $constructorBody .= strtr('$this->PROPERTY = $input["NAME"] ?? null;' . "\n", ['PROPERTY' => GeneratorHelper::normalizeName($member->getName()), 'NAME' => $member->getName()]);
                 }
             } elseif ($member->isStreaming()) {
-                $parameterType = 'string|resource|callable|iterable';
+                $parameterType = 'string|resource|(callable(int): string)|iterable<string>';
                 $returnType = null;
                 $constructorBody .= strtr('$this->PROPERTY = $input["NAME"] ?? null;' . "\n", ['PROPERTY' => GeneratorHelper::normalizeName($member->getName()), 'NAME' => $member->getName()]);
             } elseif ('timestamp' === $memberShape->getType()) {

--- a/src/Core/src/Stream/CallableStream.php
+++ b/src/Core/src/Stream/CallableStream.php
@@ -14,16 +14,28 @@ use AsyncAws\Core\Exception\InvalidArgument;
  */
 final class CallableStream implements ReadOnceResultStream, RequestStream
 {
+    /**
+     * @var callable(int): string
+     */
     private $content;
 
+    /**
+     * @var int
+     */
     private $chunkSize;
 
+    /**
+     * @param callable(int): string $content
+     */
     private function __construct(callable $content, int $chunkSize = 64 * 1024)
     {
         $this->content = $content;
         $this->chunkSize = $chunkSize;
     }
 
+    /**
+     * @param self|callable(int): string $content
+     */
     public static function create($content, int $chunkSize = 64 * 1024): CallableStream
     {
         if ($content instanceof self) {

--- a/src/Core/src/Stream/IterableStream.php
+++ b/src/Core/src/Stream/IterableStream.php
@@ -13,13 +13,22 @@ use AsyncAws\Core\Exception\InvalidArgument;
  */
 final class IterableStream implements ReadOnceResultStream, RequestStream
 {
+    /**
+     * @var iterable<string>
+     */
     private $content;
 
+    /**
+     * @param iterable<string> $content
+     */
     private function __construct(iterable $content)
     {
         $this->content = $content;
     }
 
+    /**
+     * @param self|iterable<string> $content
+     */
     public static function create($content): IterableStream
     {
         if ($content instanceof self) {

--- a/src/Core/src/Stream/RequestStream.php
+++ b/src/Core/src/Stream/RequestStream.php
@@ -8,6 +8,8 @@ namespace AsyncAws\Core\Stream;
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
  * @internal
+ *
+ * @extends \IteratorAggregate<string>
  */
 interface RequestStream extends \IteratorAggregate
 {

--- a/src/Core/src/Stream/ResourceStream.php
+++ b/src/Core/src/Stream/ResourceStream.php
@@ -20,12 +20,18 @@ final class ResourceStream implements RequestStream
 
     private $chunkSize;
 
+    /**
+     * @param resource $content
+     */
     private function __construct($content, int $chunkSize = 64 * 1024)
     {
         $this->content = $content;
         $this->chunkSize = $chunkSize;
     }
 
+    /**
+     * @param self|resource $content
+     */
     public static function create($content, int $chunkSize = 64 * 1024): ResourceStream
     {
         if ($content instanceof self) {

--- a/src/Core/src/Stream/RewindableStream.php
+++ b/src/Core/src/Stream/RewindableStream.php
@@ -17,10 +17,13 @@ namespace AsyncAws\Core\Stream;
  */
 final class RewindableStream implements RequestStream
 {
+    /**
+     * @var RequestStream
+     */
     private $content;
 
     /**
-     * @var RequestStream
+     * @var RequestStream|null
      */
     private $fallback;
 

--- a/src/Core/src/Stream/StreamFactory.php
+++ b/src/Core/src/Stream/StreamFactory.php
@@ -11,6 +11,9 @@ use AsyncAws\Core\Exception\InvalidArgument;
  */
 class StreamFactory
 {
+    /**
+     * @param string|resource|(callable(int): string)|iterable<string>|null $content
+     */
     public static function create($content, int $preferredChunkSize = 64 * 1024): RequestStream
     {
         if (null === $content || \is_string($content)) {

--- a/src/Core/src/Stream/StringStream.php
+++ b/src/Core/src/Stream/StringStream.php
@@ -22,6 +22,9 @@ final class StringStream implements RequestStream
         $this->content = $content;
     }
 
+    /**
+     * @param RequestStream|string $content
+     */
     public static function create($content): StringStream
     {
         if ($content instanceof self) {

--- a/src/Service/S3/src/Input/PutObjectRequest.php
+++ b/src/Service/S3/src/Input/PutObjectRequest.php
@@ -30,7 +30,7 @@ final class PutObjectRequest extends Input
     /**
      * Object data.
      *
-     * @var string|resource|callable|iterable|null
+     * @var string|resource|(callable(int): string)|iterable<string>|null
      */
     private $body;
 
@@ -395,7 +395,7 @@ final class PutObjectRequest extends Input
     /**
      * @param array{
      *   ACL?: ObjectCannedACL::*,
-     *   Body?: string|resource|callable|iterable,
+     *   Body?: string|resource|(callable(int): string)|iterable<string>,
      *   Bucket?: string,
      *   CacheControl?: string,
      *   ContentDisposition?: string,
@@ -491,7 +491,7 @@ final class PutObjectRequest extends Input
     }
 
     /**
-     * @return string|resource|callable|iterable|null
+     * @return string|resource|(callable(int): string)|iterable<string>|null
      */
     public function getBody()
     {
@@ -860,7 +860,7 @@ final class PutObjectRequest extends Input
     }
 
     /**
-     * @param string|resource|callable|iterable|null $value
+     * @param string|resource|(callable(int): string)|iterable<string>|null $value
      */
     public function setBody($value): self
     {

--- a/src/Service/S3/src/Input/UploadPartRequest.php
+++ b/src/Service/S3/src/Input/UploadPartRequest.php
@@ -14,7 +14,7 @@ final class UploadPartRequest extends Input
     /**
      * Object data.
      *
-     * @var string|resource|callable|iterable|null
+     * @var string|resource|(callable(int): string)|iterable<string>|null
      */
     private $body;
 
@@ -184,7 +184,7 @@ final class UploadPartRequest extends Input
 
     /**
      * @param array{
-     *   Body?: string|resource|callable|iterable,
+     *   Body?: string|resource|(callable(int): string)|iterable<string>,
      *   Bucket?: string,
      *   ContentLength?: string,
      *   ContentMD5?: string,
@@ -233,7 +233,7 @@ final class UploadPartRequest extends Input
     }
 
     /**
-     * @return string|resource|callable|iterable|null
+     * @return string|resource|(callable(int): string)|iterable<string>|null
      */
     public function getBody()
     {
@@ -407,7 +407,7 @@ final class UploadPartRequest extends Input
     }
 
     /**
-     * @param string|resource|callable|iterable|null $value
+     * @param string|resource|(callable(int): string)|iterable<string>|null $value
      */
     public function setBody($value): self
     {

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -1992,7 +1992,7 @@ class S3Client extends AbstractApi
      *
      * @param array{
      *   ACL?: ObjectCannedACL::*,
-     *   Body?: string|resource|callable|iterable,
+     *   Body?: string|resource|(callable(int): string)|iterable<string>,
      *   Bucket: string,
      *   CacheControl?: string,
      *   ContentDisposition?: string,
@@ -2288,7 +2288,7 @@ class S3Client extends AbstractApi
      * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-s3-2006-03-01.html#uploadpart
      *
      * @param array{
-     *   Body?: string|resource|callable|iterable,
+     *   Body?: string|resource|(callable(int): string)|iterable<string>,
      *   Bucket: string,
      *   ContentLength?: string,
      *   ContentMD5?: string,


### PR DESCRIPTION
This allow static analyser tools to report invalid callables being provided.

The only callable signature we have in the project is related to RequestStream for streaming shape members.

phpstan is updated to enforce providing such types for the future.