### PR TITLE
Make the code generator manage the async-aws/core requirement

### DIFF
--- a/src/CodeGenerator/src/File/ComposerWriter.php
+++ b/src/CodeGenerator/src/File/ComposerWriter.php
@@ -28,6 +28,8 @@ class ComposerWriter
                 $content['require']['ext-dom'],
                 $content['require']['ext-SimpleXML'],
                 $content['require']['ext-filter'],
+                $content['require']['async-aws/core'],
+                $content['require']['symfony/polyfill-uuid'],
             );
         }
         $content['require'] = $requirements + $content['require'];

--- a/src/CodeGenerator/src/Generator/ClientGenerator.php
+++ b/src/CodeGenerator/src/Generator/ClientGenerator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AsyncAws\CodeGenerator\Generator;
 
 use AsyncAws\CodeGenerator\Definition\ServiceDefinition;
+use AsyncAws\CodeGenerator\Generator\Composer\RequirementsRegistry;
 use AsyncAws\CodeGenerator\Generator\Naming\ClassName;
 use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
 use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassRegistry;
@@ -35,10 +36,16 @@ class ClientGenerator
      */
     private $namespaceRegistry;
 
-    public function __construct(ClassRegistry $classRegistry, NamespaceRegistry $namespaceRegistry)
+    /**
+     * @var RequirementsRegistry
+     */
+    private $requirementsRegistry;
+
+    public function __construct(ClassRegistry $classRegistry, NamespaceRegistry $namespaceRegistry, RequirementsRegistry $requirementsRegistry)
     {
         $this->classRegistry = $classRegistry;
         $this->namespaceRegistry = $namespaceRegistry;
+        $this->requirementsRegistry = $requirementsRegistry;
     }
 
     /**
@@ -47,6 +54,9 @@ class ClientGenerator
     public function generate(ServiceDefinition $definition): ClassName
     {
         $className = $this->namespaceRegistry->getClient($definition);
+        if (0 !== strpos($className->getFqdn(), 'AsyncAws\Core\\')) {
+            $this->requirementsRegistry->addRequirement('async-aws/core', '^1.9');
+        }
         $classBuilder = $this->classRegistry->register($className->getFqdn(), true);
 
         $supportedVersions = eval(sprintf('class A%s extends %s {

--- a/src/CodeGenerator/src/Generator/InputGenerator.php
+++ b/src/CodeGenerator/src/Generator/InputGenerator.php
@@ -321,7 +321,9 @@ class InputGenerator
                 }
 
                 if ('querystring' === $requestPart && $usesEndpointDiscovery) {
-                    $this->requirementsRegistry->addRequirement('async-aws/core', '^1.19');
+                    if (0 !== strpos($classBuilder->getClassName()->getFqdn(), 'AsyncAws\Core\\')) {
+                        $this->requirementsRegistry->addRequirement('async-aws/core', '^1.19');
+                    }
                 }
 
                 $memberShape = $member->getShape();
@@ -452,7 +454,9 @@ class InputGenerator
         $uriStringCode = preg_replace('/(^""\.|\.""$|\.""\.)/', '', $uriStringCode);
 
         if ($usesEndpointDiscovery && '"/"' !== $uriStringCode) {
-            $this->requirementsRegistry->addRequirement('async-aws/core', '^1.19');
+            if (0 !== strpos($classBuilder->getClassName()->getFqdn(), 'AsyncAws\Core\\')) {
+                $this->requirementsRegistry->addRequirement('async-aws/core', '^1.19');
+            }
         }
 
         $body['uri'] .= '$uriString = ' . $uriStringCode . ';';

--- a/src/CodeGenerator/src/Generator/OperationGenerator.php
+++ b/src/CodeGenerator/src/Generator/OperationGenerator.php
@@ -204,7 +204,9 @@ class OperationGenerator
         }
 
         if ($operation->requiresEndpointDiscovery()) {
-            $this->requirementsRegistry->addRequirement('async-aws/core', '^1.16');
+            if (0 !== strpos($classBuilder->getClassName()->getFqdn(), 'AsyncAws\Core\\')) {
+                $this->requirementsRegistry->addRequirement('async-aws/core', '^1.16');
+            }
             $endpointOperation = $operation->getService()->findEndpointOperationName();
 
             if (null !== $endpointOperation) {
@@ -214,7 +216,9 @@ class OperationGenerator
             $extra .= ", 'requiresEndpointDiscovery' => true";
         }
         if ($operation->usesEndpointDiscovery()) {
-            $this->requirementsRegistry->addRequirement('async-aws/core', '^1.16');
+            if (0 !== strpos($classBuilder->getClassName()->getFqdn(), 'AsyncAws\Core\\')) {
+                $this->requirementsRegistry->addRequirement('async-aws/core', '^1.16');
+            }
             $endpointOperation = $operation->getService()->findEndpointOperationName();
 
             if (null !== $endpointOperation) {

--- a/src/CodeGenerator/src/Generator/ServiceGenerator.php
+++ b/src/CodeGenerator/src/Generator/ServiceGenerator.php
@@ -119,7 +119,7 @@ class ServiceGenerator
 
     public function client(): ClientGenerator
     {
-        return $this->client ?? $this->client = new ClientGenerator($this->classRegistry, $this->namespaceRegistry);
+        return $this->client ?? $this->client = new ClientGenerator($this->classRegistry, $this->namespaceRegistry, $this->requirementsRegistry);
     }
 
     public function operation(): OperationGenerator

--- a/src/Service/.template/composer.json
+++ b/src/Service/.template/composer.json
@@ -11,9 +11,7 @@
         "foobar"
     ],
     "require": {
-        "php": "^7.2.5 || ^8.0",
-        "ext-json": "*",
-        "async-aws/core": "^1.9"
+        "php": "^7.2.5 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Service/CloudFormation/composer.json
+++ b/src/Service/CloudFormation/composer.json
@@ -14,7 +14,7 @@
         "php": "^7.2.5 || ^8.0",
         "ext-SimpleXML": "*",
         "ext-filter": "*",
-        "async-aws/core": "^1.2"
+        "async-aws/core": "^1.9"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
As the registry now supports properly combining multiple min versions for a semver requirement, we can make the code generator manage the async-aws/core requirement of generated services even when they don't require special features instead of relying on the template to add it.

The generators now also avoid adding a requirement on async-aws/core if the generator code is inside the Core package to avoid generating a self-referencing requirement (this was fine before only because the Sts client was not relying on the special features that were adding such a requirement).

This also removes the json extension from the template as it is managed by the code generator anyway and makes the symfony/polyfill-uuid requirement cleanable in case a service does not need it anymore.