### PR TITLE
Improve the timestamp conversion for the rest-json protocol

### DIFF
--- a/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
@@ -121,8 +121,10 @@ class RestJsonParser implements Parser
                 throw new \RuntimeException(sprintf('Timestamp format %s is not yet implemented', $format));
         }
 
-        if (!$required) {
-            $body = 'isset(INPUT) ? ' . $body . ' : null';
+        if ($required) {
+            $body = '/** @var \DateTimeImmutable $d */ $d = ' . $body;
+        } else {
+            $body = 'isset(INPUT) && ($d = ' . $body . ') ? $d : null';
         }
 
         return strtr($body, ['INPUT' => $input]);

--- a/src/Service/Iot/src/Result/ListThingTypesResponse.php
+++ b/src/Service/Iot/src/Result/ListThingTypesResponse.php
@@ -140,8 +140,8 @@ class ListThingTypesResponse extends Result implements \IteratorAggregate
     {
         return new ThingTypeMetadata([
             'deprecated' => isset($json['deprecated']) ? filter_var($json['deprecated'], \FILTER_VALIDATE_BOOLEAN) : null,
-            'deprecationDate' => isset($json['deprecationDate']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['deprecationDate'])) : null,
-            'creationDate' => isset($json['creationDate']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['creationDate'])) : null,
+            'deprecationDate' => isset($json['deprecationDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['deprecationDate']))) ? $d : null,
+            'creationDate' => isset($json['creationDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['creationDate']))) ? $d : null,
         ]);
     }
 

--- a/src/Service/MediaConvert/src/Result/CreateJobResponse.php
+++ b/src/Service/MediaConvert/src/Result/CreateJobResponse.php
@@ -1200,7 +1200,7 @@ class CreateJobResponse extends Result
             'Arn' => isset($json['arn']) ? (string) $json['arn'] : null,
             'BillingTagsSource' => isset($json['billingTagsSource']) ? (string) $json['billingTagsSource'] : null,
             'ClientRequestToken' => isset($json['clientRequestToken']) ? (string) $json['clientRequestToken'] : null,
-            'CreatedAt' => isset($json['createdAt']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['createdAt'])) : null,
+            'CreatedAt' => isset($json['createdAt']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['createdAt']))) ? $d : null,
             'CurrentPhase' => isset($json['currentPhase']) ? (string) $json['currentPhase'] : null,
             'ErrorCode' => isset($json['errorCode']) ? (int) $json['errorCode'] : null,
             'ErrorMessage' => isset($json['errorMessage']) ? (string) $json['errorMessage'] : null,
@@ -1715,7 +1715,7 @@ class CreateJobResponse extends Result
         return new QueueTransition([
             'DestinationQueue' => isset($json['destinationQueue']) ? (string) $json['destinationQueue'] : null,
             'SourceQueue' => isset($json['sourceQueue']) ? (string) $json['sourceQueue'] : null,
-            'Timestamp' => isset($json['timestamp']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['timestamp'])) : null,
+            'Timestamp' => isset($json['timestamp']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['timestamp']))) ? $d : null,
         ]);
     }
 
@@ -1844,9 +1844,9 @@ class CreateJobResponse extends Result
     private function populateResultTiming(array $json): Timing
     {
         return new Timing([
-            'FinishTime' => isset($json['finishTime']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['finishTime'])) : null,
-            'StartTime' => isset($json['startTime']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['startTime'])) : null,
-            'SubmitTime' => isset($json['submitTime']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['submitTime'])) : null,
+            'FinishTime' => isset($json['finishTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['finishTime']))) ? $d : null,
+            'StartTime' => isset($json['startTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['startTime']))) ? $d : null,
+            'SubmitTime' => isset($json['submitTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['submitTime']))) ? $d : null,
         ]);
     }
 

--- a/src/Service/MediaConvert/src/Result/GetJobResponse.php
+++ b/src/Service/MediaConvert/src/Result/GetJobResponse.php
@@ -1200,7 +1200,7 @@ class GetJobResponse extends Result
             'Arn' => isset($json['arn']) ? (string) $json['arn'] : null,
             'BillingTagsSource' => isset($json['billingTagsSource']) ? (string) $json['billingTagsSource'] : null,
             'ClientRequestToken' => isset($json['clientRequestToken']) ? (string) $json['clientRequestToken'] : null,
-            'CreatedAt' => isset($json['createdAt']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['createdAt'])) : null,
+            'CreatedAt' => isset($json['createdAt']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['createdAt']))) ? $d : null,
             'CurrentPhase' => isset($json['currentPhase']) ? (string) $json['currentPhase'] : null,
             'ErrorCode' => isset($json['errorCode']) ? (int) $json['errorCode'] : null,
             'ErrorMessage' => isset($json['errorMessage']) ? (string) $json['errorMessage'] : null,
@@ -1715,7 +1715,7 @@ class GetJobResponse extends Result
         return new QueueTransition([
             'DestinationQueue' => isset($json['destinationQueue']) ? (string) $json['destinationQueue'] : null,
             'SourceQueue' => isset($json['sourceQueue']) ? (string) $json['sourceQueue'] : null,
-            'Timestamp' => isset($json['timestamp']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['timestamp'])) : null,
+            'Timestamp' => isset($json['timestamp']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['timestamp']))) ? $d : null,
         ]);
     }
 
@@ -1844,9 +1844,9 @@ class GetJobResponse extends Result
     private function populateResultTiming(array $json): Timing
     {
         return new Timing([
-            'FinishTime' => isset($json['finishTime']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['finishTime'])) : null,
-            'StartTime' => isset($json['startTime']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['startTime'])) : null,
-            'SubmitTime' => isset($json['submitTime']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['submitTime'])) : null,
+            'FinishTime' => isset($json['finishTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['finishTime']))) ? $d : null,
+            'StartTime' => isset($json['startTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['startTime']))) ? $d : null,
+            'SubmitTime' => isset($json['submitTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['submitTime']))) ? $d : null,
         ]);
     }
 

--- a/src/Service/MediaConvert/src/Result/ListJobsResponse.php
+++ b/src/Service/MediaConvert/src/Result/ListJobsResponse.php
@@ -1265,7 +1265,7 @@ class ListJobsResponse extends Result implements \IteratorAggregate
             'Arn' => isset($json['arn']) ? (string) $json['arn'] : null,
             'BillingTagsSource' => isset($json['billingTagsSource']) ? (string) $json['billingTagsSource'] : null,
             'ClientRequestToken' => isset($json['clientRequestToken']) ? (string) $json['clientRequestToken'] : null,
-            'CreatedAt' => isset($json['createdAt']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['createdAt'])) : null,
+            'CreatedAt' => isset($json['createdAt']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['createdAt']))) ? $d : null,
             'CurrentPhase' => isset($json['currentPhase']) ? (string) $json['currentPhase'] : null,
             'ErrorCode' => isset($json['errorCode']) ? (int) $json['errorCode'] : null,
             'ErrorMessage' => isset($json['errorMessage']) ? (string) $json['errorMessage'] : null,
@@ -1780,7 +1780,7 @@ class ListJobsResponse extends Result implements \IteratorAggregate
         return new QueueTransition([
             'DestinationQueue' => isset($json['destinationQueue']) ? (string) $json['destinationQueue'] : null,
             'SourceQueue' => isset($json['sourceQueue']) ? (string) $json['sourceQueue'] : null,
-            'Timestamp' => isset($json['timestamp']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['timestamp'])) : null,
+            'Timestamp' => isset($json['timestamp']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['timestamp']))) ? $d : null,
         ]);
     }
 
@@ -1909,9 +1909,9 @@ class ListJobsResponse extends Result implements \IteratorAggregate
     private function populateResultTiming(array $json): Timing
     {
         return new Timing([
-            'FinishTime' => isset($json['finishTime']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['finishTime'])) : null,
-            'StartTime' => isset($json['startTime']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['startTime'])) : null,
-            'SubmitTime' => isset($json['submitTime']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['submitTime'])) : null,
+            'FinishTime' => isset($json['finishTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['finishTime']))) ? $d : null,
+            'StartTime' => isset($json['startTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['startTime']))) ? $d : null,
+            'SubmitTime' => isset($json['submitTime']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['submitTime']))) ? $d : null,
         ]);
     }
 

--- a/src/Service/Scheduler/src/Result/GetScheduleGroupOutput.php
+++ b/src/Service/Scheduler/src/Result/GetScheduleGroupOutput.php
@@ -76,8 +76,8 @@ class GetScheduleGroupOutput extends Result
         $data = $response->toArray();
 
         $this->arn = isset($data['Arn']) ? (string) $data['Arn'] : null;
-        $this->creationDate = isset($data['CreationDate']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $data['CreationDate'])) : null;
-        $this->lastModificationDate = isset($data['LastModificationDate']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $data['LastModificationDate'])) : null;
+        $this->creationDate = isset($data['CreationDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $data['CreationDate']))) ? $d : null;
+        $this->lastModificationDate = isset($data['LastModificationDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $data['LastModificationDate']))) ? $d : null;
         $this->name = isset($data['Name']) ? (string) $data['Name'] : null;
         $this->state = isset($data['State']) ? (string) $data['State'] : null;
     }

--- a/src/Service/Scheduler/src/Result/GetScheduleOutput.php
+++ b/src/Service/Scheduler/src/Result/GetScheduleOutput.php
@@ -224,17 +224,17 @@ class GetScheduleOutput extends Result
         $data = $response->toArray();
 
         $this->arn = isset($data['Arn']) ? (string) $data['Arn'] : null;
-        $this->creationDate = isset($data['CreationDate']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $data['CreationDate'])) : null;
+        $this->creationDate = isset($data['CreationDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $data['CreationDate']))) ? $d : null;
         $this->description = isset($data['Description']) ? (string) $data['Description'] : null;
-        $this->endDate = isset($data['EndDate']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $data['EndDate'])) : null;
+        $this->endDate = isset($data['EndDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $data['EndDate']))) ? $d : null;
         $this->flexibleTimeWindow = empty($data['FlexibleTimeWindow']) ? null : $this->populateResultFlexibleTimeWindow($data['FlexibleTimeWindow']);
         $this->groupName = isset($data['GroupName']) ? (string) $data['GroupName'] : null;
         $this->kmsKeyArn = isset($data['KmsKeyArn']) ? (string) $data['KmsKeyArn'] : null;
-        $this->lastModificationDate = isset($data['LastModificationDate']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $data['LastModificationDate'])) : null;
+        $this->lastModificationDate = isset($data['LastModificationDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $data['LastModificationDate']))) ? $d : null;
         $this->name = isset($data['Name']) ? (string) $data['Name'] : null;
         $this->scheduleExpression = isset($data['ScheduleExpression']) ? (string) $data['ScheduleExpression'] : null;
         $this->scheduleExpressionTimezone = isset($data['ScheduleExpressionTimezone']) ? (string) $data['ScheduleExpressionTimezone'] : null;
-        $this->startDate = isset($data['StartDate']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $data['StartDate'])) : null;
+        $this->startDate = isset($data['StartDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $data['StartDate']))) ? $d : null;
         $this->state = isset($data['State']) ? (string) $data['State'] : null;
         $this->target = empty($data['Target']) ? null : $this->populateResultTarget($data['Target']);
     }

--- a/src/Service/Scheduler/src/Result/ListScheduleGroupsOutput.php
+++ b/src/Service/Scheduler/src/Result/ListScheduleGroupsOutput.php
@@ -110,8 +110,8 @@ class ListScheduleGroupsOutput extends Result implements \IteratorAggregate
     {
         return new ScheduleGroupSummary([
             'Arn' => isset($json['Arn']) ? (string) $json['Arn'] : null,
-            'CreationDate' => isset($json['CreationDate']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['CreationDate'])) : null,
-            'LastModificationDate' => isset($json['LastModificationDate']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['LastModificationDate'])) : null,
+            'CreationDate' => isset($json['CreationDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['CreationDate']))) ? $d : null,
+            'LastModificationDate' => isset($json['LastModificationDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['LastModificationDate']))) ? $d : null,
             'Name' => isset($json['Name']) ? (string) $json['Name'] : null,
             'State' => isset($json['State']) ? (string) $json['State'] : null,
         ]);

--- a/src/Service/Scheduler/src/Result/ListSchedulesOutput.php
+++ b/src/Service/Scheduler/src/Result/ListSchedulesOutput.php
@@ -111,9 +111,9 @@ class ListSchedulesOutput extends Result implements \IteratorAggregate
     {
         return new ScheduleSummary([
             'Arn' => isset($json['Arn']) ? (string) $json['Arn'] : null,
-            'CreationDate' => isset($json['CreationDate']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['CreationDate'])) : null,
+            'CreationDate' => isset($json['CreationDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['CreationDate']))) ? $d : null,
             'GroupName' => isset($json['GroupName']) ? (string) $json['GroupName'] : null,
-            'LastModificationDate' => isset($json['LastModificationDate']) ? \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['LastModificationDate'])) : null,
+            'LastModificationDate' => isset($json['LastModificationDate']) && ($d = \DateTimeImmutable::createFromFormat('U.u', sprintf('%.6F', $json['LastModificationDate']))) ? $d : null,
             'Name' => isset($json['Name']) ? (string) $json['Name'] : null,
             'State' => isset($json['State']) ? (string) $json['State'] : null,
             'Target' => empty($json['Target']) ? null : $this->populateResultTargetSummary($json['Target']),


### PR DESCRIPTION
This will use the same generated code than for the json rpc protocol.

This will help solving static analysis as it avoids passing `false` for invalid timestamp values.