### PR TITLE
Improve the XML serialization of numeric types

### DIFF
--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
@@ -141,11 +141,12 @@ class RestXmlSerializer implements Serializer
         switch ($shape->getType()) {
             case 'blob':
             case 'string':
+                return $this->dumpXmlShapeString($member, $shape, $output, $input);
             case 'integer':
             case 'long':
             case 'float':
             case 'double':
-                return $this->dumpXmlShapeString($member, $shape, $output, $input);
+                return $this->dumpXmlShapeNumeric($member, $output, $input);
             case 'boolean':
                 return $this->dumpXmlShapeBoolean($member, $output, $input);
         }
@@ -226,6 +227,23 @@ class RestXmlSerializer implements Serializer
                 'PROPERTY' => $member->getLocationName() ?? ($member instanceof StructureMember ? $member->getName() : 'member'),
             ];
         }
+
+        return strtr($body, $replacements);
+    }
+
+    private function dumpXmlShapeNumeric(Member $member, string $output, string $input): string
+    {
+        if ($member instanceof StructureMember && $member->isXmlAttribute()) {
+            $body = 'OUTPUT->setAttribute(NODE_NAME, (string) INPUT);';
+        } else {
+            $body = 'OUTPUT->appendChild($document->createElement(NODE_NAME, (string) INPUT));';
+        }
+
+        $replacements = [
+            'INPUT' => $input,
+            'OUTPUT' => $output,
+            'NODE_NAME' => var_export($member->getLocationName() ?? ($member instanceof StructureMember ? $member->getName() : 'member'), true),
+        ];
 
         return strtr($body, $replacements);
     }

--- a/src/Service/CloudFront/src/ValueObject/Paths.php
+++ b/src/Service/CloudFront/src/ValueObject/Paths.php
@@ -66,7 +66,7 @@ final class Paths
         if (null === $v = $this->quantity) {
             throw new InvalidArgument(sprintf('Missing parameter "Quantity" for "%s". The value cannot be null.', __CLASS__));
         }
-        $node->appendChild($document->createElement('Quantity', $v));
+        $node->appendChild($document->createElement('Quantity', (string) $v));
         if (null !== $v = $this->items) {
             $node->appendChild($nodeList = $document->createElement('Items'));
             foreach ($v as $item) {

--- a/src/Service/Route53/src/ValueObject/ResourceRecordSet.php
+++ b/src/Service/Route53/src/ValueObject/ResourceRecordSet.php
@@ -541,7 +541,7 @@ final class ResourceRecordSet
             $node->appendChild($document->createElement('SetIdentifier', $v));
         }
         if (null !== $v = $this->weight) {
-            $node->appendChild($document->createElement('Weight', $v));
+            $node->appendChild($document->createElement('Weight', (string) $v));
         }
         if (null !== $v = $this->region) {
             if (!ResourceRecordSetRegion::exists($v)) {
@@ -564,7 +564,7 @@ final class ResourceRecordSet
             $node->appendChild($document->createElement('MultiValueAnswer', $v ? 'true' : 'false'));
         }
         if (null !== $v = $this->ttl) {
-            $node->appendChild($document->createElement('TTL', $v));
+            $node->appendChild($document->createElement('TTL', (string) $v));
         }
         if (null !== $v = $this->resourceRecords) {
             $node->appendChild($nodeList = $document->createElement('ResourceRecords'));

--- a/src/Service/S3/src/ValueObject/CORSRule.php
+++ b/src/Service/S3/src/ValueObject/CORSRule.php
@@ -152,7 +152,7 @@ final class CORSRule
             }
         }
         if (null !== $v = $this->maxAgeSeconds) {
-            $node->appendChild($document->createElement('MaxAgeSeconds', $v));
+            $node->appendChild($document->createElement('MaxAgeSeconds', (string) $v));
         }
     }
 }

--- a/src/Service/S3/src/ValueObject/CompletedPart.php
+++ b/src/Service/S3/src/ValueObject/CompletedPart.php
@@ -139,7 +139,7 @@ final class CompletedPart
             $node->appendChild($document->createElement('ChecksumSHA256', $v));
         }
         if (null !== $v = $this->partNumber) {
-            $node->appendChild($document->createElement('PartNumber', $v));
+            $node->appendChild($document->createElement('PartNumber', (string) $v));
         }
     }
 }


### PR DESCRIPTION
Once we start adding property types in #1467, static analysis tools complain about passing non-string content to `createElement`.
This solves this by separating the handling of strings from the handling of numeric shapes in the code generator, to cast the value to string.