### PR TITLE
Fix the serialization of blob shapes for the XML protocol

### DIFF
--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
@@ -140,6 +140,7 @@ class RestXmlSerializer implements Serializer
 
         switch ($shape->getType()) {
             case 'blob':
+                return $this->dumpXmlShapeBlob($member, $output, $input);
             case 'string':
             case 'integer':
             case 'long':
@@ -200,6 +201,23 @@ class RestXmlSerializer implements Serializer
             'INPUT' => $input,
             'MEMBER_CODE' => $this->dumpXmlShape($shape->getMember(), $shape->getMember()->getShape(), '$nodeList', '$item'),
         ]);
+    }
+
+    private function dumpXmlShapeBlob(Member $member, string $output, string $input): string
+    {
+        if ($member instanceof StructureMember && $member->isXmlAttribute()) {
+            $body = 'OUTPUT->setAttribute(NODE_NAME, base64_encode(INPUT));';
+        } else {
+            $body = 'OUTPUT->appendChild($document->createElement(NODE_NAME, base64_encode(INPUT)));';
+        }
+
+        $replacements = [
+            'INPUT' => $input,
+            'OUTPUT' => $output,
+            'NODE_NAME' => var_export($member->getLocationName() ?? ($member instanceof StructureMember ? $member->getName() : 'member'), true),
+        ];
+
+        return strtr($body, $replacements);
     }
 
     private function dumpXmlShapeString(Member $member, Shape $shape, string $output, string $input): string


### PR DESCRIPTION
It looks like none of the services using the rest-xml protocol rely on a blob shape as part of the input. However, as this was implemented, it should be implemented properly, i.e. with the necessary base64 encoding (the json serializers are doing that already, and response parsers were already doing the decoding even for rest-xml).