### PR TITLE
Add missing types in Core

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -11,8 +11,6 @@ parameters:
         - src/*/tests/*
         - src/**/tests/*
         - src/CodeGenerator/src/Generator/TestGenerator.php
-        - src/Core/src/AbstractApi.php # requires symfony/http-client: 5.2
-        - src/Core/src/HttpClient/AwsRetryStrategy.php # requires symfony/http-client: 5.2
         - src/Core/src/Test/TestCase.php
         - src/Integration/Laravel/Filesystem/src/AsyncAwsFilesystemManager.php
         - src/Integration/Laravel/Filesystem/src/AsyncAwsFilesystemAdapter.php

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -35,6 +35,14 @@
         }]]></code>
     </InvalidCatch>
   </file>
+  <file src="src/Core/src/Response.php">
+    <LessSpecificReturnStatement>
+      <code><![CDATA[$this->httpResponse->getHeaders(false)]]></code>
+    </LessSpecificReturnStatement>
+    <MoreSpecificReturnType>
+      <code><![CDATA[array<string, list<string>>]]></code>
+    </MoreSpecificReturnType>
+  </file>
   <file src="src/Core/src/Waiter.php">
     <PossiblyUndefinedVariable>
       <code>$exception</code>

--- a/src/Core/src/AwsClientFactory.php
+++ b/src/Core/src/AwsClientFactory.php
@@ -61,7 +61,7 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
 class AwsClientFactory
 {
     /**
-     * @var array
+     * @var array<string, mixed>
      */
     private $serviceCache;
 
@@ -86,7 +86,7 @@ class AwsClientFactory
     private $logger;
 
     /**
-     * @param Configuration|array $configuration
+     * @param Configuration|array<Configuration::OPTION_*, string|null> $configuration
      */
     public function __construct($configuration = [], ?CredentialProvider $credentialProvider = null, ?HttpClientInterface $httpClient = null, ?LoggerInterface $logger = null)
     {

--- a/src/Core/src/AwsError/AwsError.php
+++ b/src/Core/src/AwsError/AwsError.php
@@ -7,12 +7,24 @@ namespace AsyncAws\Core\AwsError;
  */
 final class AwsError
 {
+    /**
+     * @var string|null
+     */
     private $code;
 
+    /**
+     * @var string|null
+     */
     private $message;
 
+    /**
+     * @var string|null
+     */
     private $type;
 
+    /**
+     * @var string|null
+     */
     private $detail;
 
     public function __construct(?string $code, ?string $message, ?string $type, ?string $detail)

--- a/src/Core/src/AwsError/AwsErrorFactoryInterface.php
+++ b/src/Core/src/AwsError/AwsErrorFactoryInterface.php
@@ -11,5 +11,8 @@ interface AwsErrorFactoryInterface
 {
     public function createFromResponse(ResponseInterface $response): AwsError;
 
+    /**
+     * @param array<string, list<string>> $headers
+     */
     public function createFromContent(string $content, array $headers): AwsError;
 }

--- a/src/Core/src/AwsError/ChainAwsErrorFactory.php
+++ b/src/Core/src/AwsError/ChainAwsErrorFactory.php
@@ -11,6 +11,9 @@ class ChainAwsErrorFactory implements AwsErrorFactoryInterface
 {
     use AwsErrorFactoryFromResponseTrait;
 
+    /**
+     * @var AwsErrorFactoryInterface[]
+     */
     private $factories;
 
     /**

--- a/src/Core/src/AwsError/JsonRestAwsErrorFactory.php
+++ b/src/Core/src/AwsError/JsonRestAwsErrorFactory.php
@@ -23,6 +23,10 @@ class JsonRestAwsErrorFactory implements AwsErrorFactoryInterface
         }
     }
 
+    /**
+     * @param array<string, mixed>        $body
+     * @param array<string, list<string>> $headers
+     */
     private static function parseJson(array $body, array $headers): AwsError
     {
         $code = null;

--- a/src/Core/src/AwsError/JsonRpcAwsErrorFactory.php
+++ b/src/Core/src/AwsError/JsonRpcAwsErrorFactory.php
@@ -23,6 +23,10 @@ class JsonRpcAwsErrorFactory implements AwsErrorFactoryInterface
         }
     }
 
+    /**
+     * @param array<string, mixed>        $body
+     * @param array<string, list<string>> $headers
+     */
     private static function parseJson(array $body, array $headers): AwsError
     {
         $code = null;

--- a/src/Core/src/Configuration.php
+++ b/src/Core/src/Configuration.php
@@ -88,11 +88,20 @@ final class Configuration
         self::OPTION_ENDPOINT_DISCOVERY_ENABLED => 'false',
     ];
 
+    /**
+     * @var array<self::OPTION_*, string|null>
+     */
     private $data = [];
 
+    /**
+     * @var array<self::OPTION_*, bool>
+     */
     private $userData = [];
 
-    public static function create(array $options)
+    /**
+     * @param array<self::OPTION_*, string|null> $options
+     */
+    public static function create(array $options): self
     {
         if (0 < \count($invalidOptions = array_diff_key($options, self::AVAILABLE_OPTIONS))) {
             throw new InvalidArgument(sprintf('Invalid option(s) "%s" passed to "%s::%s". ', implode('", "', array_keys($invalidOptions)), __CLASS__, __METHOD__));
@@ -118,6 +127,8 @@ final class Configuration
     }
 
     /**
+     * @param self::OPTION_* $name
+     *
      * @psalm-return (
      *     $name is
      *       self::OPTION_REGION
@@ -141,6 +152,9 @@ final class Configuration
         return $this->data[$name] ?? null;
     }
 
+    /**
+     * @param self::OPTION_* $name
+     */
     public function has(string $name): bool
     {
         if (!isset(self::AVAILABLE_OPTIONS[$name])) {
@@ -150,6 +164,9 @@ final class Configuration
         return isset($this->data[$name]);
     }
 
+    /**
+     * @param self::OPTION_* $name
+     */
     public function isDefault(string $name): bool
     {
         if (!isset(self::AVAILABLE_OPTIONS[$name])) {
@@ -159,6 +176,11 @@ final class Configuration
         return empty($this->userData[$name]);
     }
 
+    /**
+     * @param array<self::OPTION_*, string|null> $options
+     *
+     * @return array<self::OPTION_*, string|null>
+     */
     private static function parseEnvironmentVariables(array $options): array
     {
         foreach (self::FALLBACK_OPTIONS as $fallbackGroup) {
@@ -187,6 +209,8 @@ final class Configuration
 
     /**
      * Look for "region" in the configured ini files.
+     *
+     * @return array<self::OPTION_*, string|null>
      */
     private static function parseIniFiles(Configuration $configuration): array
     {
@@ -215,6 +239,8 @@ final class Configuration
 
     /**
      * Add array options to the configuration object.
+     *
+     * @param array<self::OPTION_*, string|null> $options
      */
     private static function populateConfiguration(Configuration $configuration, array $options): void
     {

--- a/src/Core/src/Credentials/CacheProvider.php
+++ b/src/Core/src/Credentials/CacheProvider.php
@@ -17,10 +17,13 @@ use Symfony\Contracts\Service\ResetInterface;
 final class CacheProvider implements CredentialProvider, ResetInterface
 {
     /**
-     * @var (Credentials|null)[]
+     * @var array<string, Credentials|null>
      */
     private $cache = [];
 
+    /**
+     * @var CredentialProvider
+     */
     private $decorated;
 
     public function __construct(CredentialProvider $decorated)

--- a/src/Core/src/Credentials/ChainProvider.php
+++ b/src/Core/src/Credentials/ChainProvider.php
@@ -21,15 +21,18 @@ use Symfony\Contracts\Service\ResetInterface;
  */
 final class ChainProvider implements CredentialProvider, ResetInterface
 {
+    /**
+     * @var iterable<CredentialProvider>
+     */
     private $providers;
 
     /**
-     * @var (CredentialProvider|null)[]
+     * @var array<string, CredentialProvider|null>
      */
     private $lastSuccessfulProvider = [];
 
     /**
-     * @param CredentialProvider[] $providers
+     * @param iterable<CredentialProvider> $providers
      */
     public function __construct(iterable $providers)
     {

--- a/src/Core/src/Credentials/ConfigurationProvider.php
+++ b/src/Core/src/Credentials/ConfigurationProvider.php
@@ -20,8 +20,14 @@ final class ConfigurationProvider implements CredentialProvider
 {
     use DateFromResult;
 
+    /**
+     * @var LoggerInterface
+     */
     private $logger;
 
+    /**
+     * @var HttpClientInterface|null
+     */
     private $httpClient;
 
     public function __construct(?HttpClientInterface $httpClient = null, ?LoggerInterface $logger = null)

--- a/src/Core/src/Credentials/ContainerProvider.php
+++ b/src/Core/src/Credentials/ContainerProvider.php
@@ -22,10 +22,19 @@ final class ContainerProvider implements CredentialProvider
 {
     private const ENDPOINT = 'http://169.254.170.2';
 
+    /**
+     * @var LoggerInterface
+     */
     private $logger;
 
+    /**
+     * @var HttpClientInterface
+     */
     private $httpClient;
 
+    /**
+     * @var float
+     */
     private $timeout;
 
     public function __construct(?HttpClientInterface $httpClient = null, ?LoggerInterface $logger = null, float $timeout = 1.0)

--- a/src/Core/src/Credentials/Credentials.php
+++ b/src/Core/src/Credentials/Credentials.php
@@ -15,12 +15,24 @@ final class Credentials implements CredentialProvider
 {
     private const EXPIRATION_DRIFT = 30;
 
+    /**
+     * @var string
+     */
     private $accessKeyId;
 
+    /**
+     * @var string
+     */
     private $secretKey;
 
+    /**
+     * @var string|null
+     */
     private $sessionToken;
 
+    /**
+     * @var \DateTimeImmutable|null
+     */
     private $expireDate;
 
     public function __construct(

--- a/src/Core/src/Credentials/IniFileLoader.php
+++ b/src/Core/src/Credentials/IniFileLoader.php
@@ -24,6 +24,9 @@ final class IniFileLoader
     public const KEY_SOURCE_PROFILE = 'source_profile';
     public const KEY_WEB_IDENTITY_TOKEN_FILE = 'web_identity_token_file';
 
+    /**
+     * @var LoggerInterface
+     */
     private $logger;
 
     public function __construct(?LoggerInterface $logger = null)
@@ -34,7 +37,7 @@ final class IniFileLoader
     /**
      * @param string[] $filepaths
      *
-     * @return string[][]
+     * @return array<string, array<string, string>>
      */
     public function loadProfiles(array $filepaths): array
     {
@@ -83,6 +86,9 @@ final class IniFileLoader
         return ($homeDrive && $homePath) ? $homeDrive . $homePath : '/';
     }
 
+    /**
+     * @return array<string, string[]>
+     */
     private function parseIniFile(string $filepath): array
     {
         if (false === $data = parse_ini_string(

--- a/src/Core/src/Credentials/IniFileProvider.php
+++ b/src/Core/src/Credentials/IniFileProvider.php
@@ -22,10 +22,19 @@ final class IniFileProvider implements CredentialProvider
 {
     use DateFromResult;
 
+    /**
+     * @var IniFileLoader
+     */
     private $iniFileLoader;
 
+    /**
+     * @var LoggerInterface
+     */
     private $logger;
 
+    /**
+     * @var HttpClientInterface|null
+     */
     private $httpClient;
 
     public function __construct(?LoggerInterface $logger = null, ?IniFileLoader $iniFileLoader = null, ?HttpClientInterface $httpClient = null)
@@ -51,6 +60,10 @@ final class IniFileProvider implements CredentialProvider
         return $this->getCredentialsFromProfile($profilesData, $profile);
     }
 
+    /**
+     * @param array<string, array<string, string>> $profilesData
+     * @param array<string, bool>                  $circularCollector
+     */
     private function getCredentialsFromProfile(array $profilesData, string $profile, array $circularCollector = []): ?Credentials
     {
         if (isset($circularCollector[$profile])) {
@@ -84,6 +97,11 @@ final class IniFileProvider implements CredentialProvider
         return null;
     }
 
+    /**
+     * @param array<string, array<string, string>> $profilesData
+     * @param array<string, string>                $profileData
+     * @param array<string, bool>                  $circularCollector
+     */
     private function getCredentialsFromRole(array $profilesData, array $profileData, string $profile, array $circularCollector = []): ?Credentials
     {
         $roleArn = (string) ($profileData[IniFileLoader::KEY_ROLE_ARN] ?? '');
@@ -94,7 +112,6 @@ final class IniFileProvider implements CredentialProvider
             return null;
         }
 
-        /** @var string $sourceProfileName */
         $sourceCredentials = $this->getCredentialsFromProfile($profilesData, $sourceProfileName, $circularCollector);
         if (null === $sourceCredentials) {
             $this->logger->warning('The source profile "{profile}" does not contains valid credentials.', ['profile' => $profile]);
@@ -114,7 +131,7 @@ final class IniFileProvider implements CredentialProvider
 
         try {
             if (null === $credentials = $result->getCredentials()) {
-                throw new RuntimeException('The AsumeRole response does not contains credentials');
+                throw new RuntimeException('The AssumeRole response does not contains credentials');
             }
         } catch (\Exception $e) {
             $this->logger->warning('Failed to get credentials from assumed role in profile "{profile}: {exception}".', ['profile' => $profile, 'exception' => $e]);

--- a/src/Core/src/Credentials/InstanceProvider.php
+++ b/src/Core/src/Credentials/InstanceProvider.php
@@ -28,12 +28,24 @@ final class InstanceProvider implements CredentialProvider
     private const TOKEN_ENDPOINT = 'http://169.254.169.254/latest/api/token';
     private const METADATA_ENDPOINT = 'http://169.254.169.254/latest/meta-data/iam/security-credentials';
 
+    /**
+     * @var LoggerInterface
+     */
     private $logger;
 
+    /**
+     * @var HttpClientInterface
+     */
     private $httpClient;
 
+    /**
+     * @var float
+     */
     private $timeout;
 
+    /**
+     * @var int
+     */
     private $tokenTtl;
 
     public function __construct(?HttpClientInterface $httpClient = null, ?LoggerInterface $logger = null, float $timeout = 1.0, int $tokenTtl = 21600)
@@ -97,6 +109,8 @@ final class InstanceProvider implements CredentialProvider
 
     /**
      * Copy of Symfony\Component\HttpClient\Response::toArray without assertion on Content-Type header.
+     *
+     * @return array<string, mixed>
      */
     private function toArray(ResponseInterface $response): array
     {

--- a/src/Core/src/Credentials/PsrCacheProvider.php
+++ b/src/Core/src/Credentials/PsrCacheProvider.php
@@ -18,10 +18,19 @@ use Psr\Log\LoggerInterface;
  */
 final class PsrCacheProvider implements CredentialProvider
 {
+    /**
+     * @var CacheItemPoolInterface
+     */
     private $cache;
 
+    /**
+     * @var CredentialProvider
+     */
     private $decorated;
 
+    /**
+     * @var LoggerInterface|null
+     */
     private $logger;
 
     public function __construct(CredentialProvider $decorated, CacheItemPoolInterface $cache, ?LoggerInterface $logger = null)

--- a/src/Core/src/Credentials/SymfonyCacheProvider.php
+++ b/src/Core/src/Credentials/SymfonyCacheProvider.php
@@ -21,10 +21,19 @@ use Symfony\Contracts\Cache\ItemInterface;
  */
 final class SymfonyCacheProvider implements CredentialProvider
 {
+    /**
+     * @var CacheInterface
+     */
     private $cache;
 
+    /**
+     * @var CredentialProvider
+     */
     private $decorated;
 
+    /**
+     * @var LoggerInterface|null
+     */
     private $logger;
 
     public function __construct(CredentialProvider $decorated, CacheInterface $cache, ?LoggerInterface $logger = null)

--- a/src/Core/src/Credentials/WebIdentityProvider.php
+++ b/src/Core/src/Credentials/WebIdentityProvider.php
@@ -22,10 +22,19 @@ final class WebIdentityProvider implements CredentialProvider
 {
     use DateFromResult;
 
+    /**
+     * @var IniFileLoader
+     */
     private $iniFileLoader;
 
+    /**
+     * @var LoggerInterface
+     */
     private $logger;
 
+    /**
+     * @var HttpClientInterface|null
+     */
     private $httpClient;
 
     public function __construct(?LoggerInterface $logger = null, ?IniFileLoader $iniFileLoader = null, ?HttpClientInterface $httpClient = null)

--- a/src/Core/src/EndpointDiscovery/EndpointCache.php
+++ b/src/Core/src/EndpointDiscovery/EndpointCache.php
@@ -11,10 +11,19 @@ use AsyncAws\Core\Exception\LogicException;
  */
 class EndpointCache
 {
+    /**
+     * @var array<string, array<string, int>>
+     */
     private $endpoints = [];
 
+    /**
+     * @var array<string, array<string, int>>
+     */
     private $expired = [];
 
+    /**
+     * @param EndpointInterface[] $endpoints
+     */
     public function addEndpoints(?string $region, array $endpoints): void
     {
         $now = time();
@@ -26,7 +35,6 @@ class EndpointCache
             $this->endpoints[$region] = [];
         }
 
-        /** @var EndpointInterface $endpoint */
         foreach ($endpoints as $endpoint) {
             $this->endpoints[$region][$this->sanitizeEndpoint($endpoint->getAddress())] = $now + ($endpoint->getCachePeriodInMinutes() * 60);
         }

--- a/src/Core/src/Exception/MissingDependency.php
+++ b/src/Core/src/Exception/MissingDependency.php
@@ -6,6 +6,9 @@ namespace AsyncAws\Core\Exception;
 
 class MissingDependency extends \RuntimeException implements Exception
 {
+    /**
+     * @return self
+     */
     public static function create(string $package, string $name)
     {
         return new self(sprintf('In order to use "%s" you need to install "%s". Run "composer require %s" and all your problems are solved.', $name, $package, $package));

--- a/src/Core/src/HttpClient/AwsRetryStrategy.php
+++ b/src/Core/src/HttpClient/AwsRetryStrategy.php
@@ -14,11 +14,17 @@ use Symfony\Contracts\HttpClient\Exception\TransportExceptionInterface;
  */
 class AwsRetryStrategy extends GenericRetryStrategy
 {
+    // Override Symfony default options for a better integration of AWS servers.
     public const DEFAULT_RETRY_STATUS_CODES = [0, 423, 425, 429, 500, 502, 503, 504, 507, 510];
 
+    /**
+     * @var AwsErrorFactoryInterface
+     */
     private $awsErrorFactory;
 
-    // Override Symfony default options for a better integration of AWS servers.
+    /**
+     * @param array<int, int|string[]> $statusCodes
+     */
     public function __construct(array $statusCodes = self::DEFAULT_RETRY_STATUS_CODES, int $delayMs = 1000, float $multiplier = 2.0, int $maxDelayMs = 0, float $jitter = 0.1, ?AwsErrorFactoryInterface $awsErrorFactory = null)
     {
         parent::__construct($statusCodes, $delayMs, $multiplier, $maxDelayMs, $jitter);

--- a/src/Core/src/Request.php
+++ b/src/Core/src/Request.php
@@ -14,23 +14,41 @@ use AsyncAws\Core\Stream\RequestStream;
  */
 class Request
 {
+    /**
+     * @var string
+     */
     private $method;
 
+    /**
+     * @var string
+     */
     private $uri;
 
+    /**
+     * @var array<string, string>
+     */
     private $headers;
 
+    /**
+     * @var RequestStream
+     */
     private $body;
 
+    /**
+     * @var array<string, string>
+     */
     private $query;
 
+    /**
+     * @var string
+     */
     private $endpoint;
 
     private $parsed;
 
     /**
-     * @param string[] $query
-     * @param string[] $headers
+     * @param array<string, string> $query
+     * @param array<string, string> $headers
      */
     public function __construct(string $method, string $uri, array $query, array $headers, RequestStream $body)
     {
@@ -60,16 +78,19 @@ class Request
         return $this->uri;
     }
 
-    public function hasHeader($name): bool
+    public function hasHeader(string $name): bool
     {
         return \array_key_exists(strtolower($name), $this->headers);
     }
 
-    public function setHeader($name, ?string $value): void
+    public function setHeader(string $name, string $value): void
     {
         $this->headers[strtolower($name)] = $value;
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function getHeaders(): array
     {
         return $this->headers;
@@ -90,23 +111,23 @@ class Request
         return $this->body;
     }
 
-    public function setBody(RequestStream $body)
+    public function setBody(RequestStream $body): void
     {
         $this->body = $body;
     }
 
-    public function hasQueryAttribute($name): bool
+    public function hasQueryAttribute(string $name): bool
     {
         return \array_key_exists($name, $this->query);
     }
 
-    public function removeQueryAttribute($name): void
+    public function removeQueryAttribute(string $name): void
     {
         unset($this->query[$name]);
         $this->endpoint = '';
     }
 
-    public function setQueryAttribute($name, $value): void
+    public function setQueryAttribute(string $name, string $value): void
     {
         $this->query[$name] = $value;
         $this->endpoint = '';
@@ -117,6 +138,9 @@ class Request
         return $this->query[$name] ?? null;
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function getQuery(): array
     {
         return $this->query;

--- a/src/Core/src/RequestContext.php
+++ b/src/Core/src/RequestContext.php
@@ -2,6 +2,7 @@
 
 namespace AsyncAws\Core;
 
+use AsyncAws\Core\Exception\Http\HttpException;
 use AsyncAws\Core\Exception\InvalidArgument;
 
 /**
@@ -54,7 +55,7 @@ class RequestContext
     private $currentDate;
 
     /**
-     * @var array<string, string>
+     * @var array<string, class-string<HttpException>>
      */
     private $exceptionMapping = [];
 
@@ -64,7 +65,7 @@ class RequestContext
      *  region?: null|string,
      *  expirationDate?: null|\DateTimeImmutable,
      *  currentDate?: null|\DateTimeImmutable,
-     *  exceptionMapping?: string[],
+     *  exceptionMapping?: array<string, class-string<HttpException>>,
      *  usesEndpointDiscovery?: bool,
      *  requiresEndpointDiscovery?: bool,
      * } $options
@@ -100,6 +101,9 @@ class RequestContext
         return $this->currentDate;
     }
 
+    /**
+     * @return array<string, class-string<HttpException>>
+     */
     public function getExceptionMapping(): array
     {
         return $this->exceptionMapping;

--- a/src/Core/src/Result.php
+++ b/src/Core/src/Result.php
@@ -25,8 +25,14 @@ class Result
      */
     protected $input;
 
+    /**
+     * @var bool
+     */
     private $initialized = false;
 
+    /**
+     * @var Response
+     */
     private $response;
 
     /**
@@ -34,7 +40,7 @@ class Result
      */
     private $prefetchResults = [];
 
-    public function __construct(Response $response, ?AbstractApi $awsClient = null, $request = null)
+    public function __construct(Response $response, ?AbstractApi $awsClient = null, ?object $request = null)
     {
         $this->response = $response;
         $this->awsClient = $awsClient;

--- a/src/Core/src/Signer/SignerV4.php
+++ b/src/Core/src/Signer/SignerV4.php
@@ -44,8 +44,14 @@ class SignerV4 implements Signer
         'aws-sdk-retry' => true,
     ];
 
+    /**
+     * @var string
+     */
     private $scopeName;
 
+    /**
+     * @var string
+     */
     private $region;
 
     public function __construct(string $scopeName, string $region)
@@ -213,12 +219,15 @@ class SignerV4 implements Signer
             }
 
             $request->setQueryAttribute('X-Amz-Date', $now->format('Ymd\THis\Z'));
-            $request->setQueryAttribute('X-Amz-Expires', $duration);
+            $request->setQueryAttribute('X-Amz-Expires', (string) $duration);
         } else {
             $request->setHeader('X-Amz-Date', $now->format('Ymd\THis\Z'));
         }
     }
 
+    /**
+     * @return string[]
+     */
     private function buildCredentialString(Request $request, Credentials $credentials, \DateTimeImmutable $now, bool $isPresign): array
     {
         $credentialScope = [$now->format('Ymd'), $this->region, $this->scopeName, 'aws4_request'];
@@ -263,6 +272,9 @@ class SignerV4 implements Signer
         $request->setBody(StringStream::create(''));
     }
 
+    /**
+     * @return array<string, string>
+     */
     private function buildCanonicalHeaders(Request $request, bool $isPresign): array
     {
         // Case-insensitively aggregate all of the headers.
@@ -284,6 +296,9 @@ class SignerV4 implements Signer
         return $canonicalHeaders;
     }
 
+    /**
+     * @param array<string, string> $canonicalHeaders
+     */
     private function buildCanonicalRequest(Request $request, array $canonicalHeaders, string $bodyDigest): string
     {
         return implode("\n", [
@@ -334,6 +349,9 @@ class SignerV4 implements Signer
         ]);
     }
 
+    /**
+     * @param string[] $credentialScope
+     */
     private function buildSigningKey(Credentials $credentials, array $credentialScope): string
     {
         $signingKey = 'AWS4' . $credentials->getSecretKey();

--- a/src/Core/src/Signer/SigningContext.php
+++ b/src/Core/src/Signer/SigningContext.php
@@ -11,14 +11,29 @@ use AsyncAws\Core\Request;
  */
 class SigningContext
 {
+    /**
+     * @var Request
+     */
     private $request;
 
+    /**
+     * @var \DateTimeImmutable
+     */
     private $now;
 
+    /**
+     * @var string
+     */
     private $credentialString;
 
+    /**
+     * @var string
+     */
     private $signingKey;
 
+    /**
+     * @var string
+     */
     private $signature = '';
 
     public function __construct(

--- a/src/Core/src/Stream/FixedSizeStream.php
+++ b/src/Core/src/Stream/FixedSizeStream.php
@@ -13,8 +13,14 @@ use AsyncAws\Core\Exception\InvalidArgument;
  */
 final class FixedSizeStream implements RequestStream
 {
+    /**
+     * @var RequestStream
+     */
     private $content;
 
+    /**
+     * @var int
+     */
     private $chunkSize;
 
     private function __construct(RequestStream $content, int $chunkSize = 64 * 1024)

--- a/src/Core/src/Stream/ResourceStream.php
+++ b/src/Core/src/Stream/ResourceStream.php
@@ -18,6 +18,9 @@ final class ResourceStream implements RequestStream
      */
     private $content;
 
+    /**
+     * @var int
+     */
     private $chunkSize;
 
     /**

--- a/src/Core/src/Stream/ResponseBodyResourceStream.php
+++ b/src/Core/src/Stream/ResponseBodyResourceStream.php
@@ -18,12 +18,15 @@ class ResponseBodyResourceStream implements ResultStream
      */
     private $resource;
 
+    /**
+     * @param resource $resource
+     */
     public function __construct($resource)
     {
         $this->resource = $resource;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getContentAsString();
     }

--- a/src/Core/src/Stream/ResponseBodyStream.php
+++ b/src/Core/src/Stream/ResponseBodyStream.php
@@ -28,6 +28,9 @@ class ResponseBodyStream implements ResultStream
      */
     private $fallback;
 
+    /**
+     * @var bool
+     */
     private $partialRead = false;
 
     public function __construct(ResponseStreamInterface $responseStream)
@@ -35,7 +38,7 @@ class ResponseBodyStream implements ResultStream
         $this->responseStream = $responseStream;
     }
 
-    public function __toString()
+    public function __toString(): string
     {
         return $this->getContentAsString();
     }
@@ -75,9 +78,9 @@ class ResponseBodyStream implements ResultStream
             // Use getChunks() to read stream content to $this->fallback
             foreach ($this->getChunks() as $chunk) {
             }
+            \assert(null !== $this->fallback);
         }
 
-        /** @psalm-suppress PossiblyNullReference */
         return $this->fallback->getContentAsString();
     }
 
@@ -90,9 +93,9 @@ class ResponseBodyStream implements ResultStream
             // Use getChunks() to read stream content to $this->fallback
             foreach ($this->getChunks() as $chunk) {
             }
+            \assert(null !== $this->fallback);
         }
 
-        /** @psalm-suppress PossiblyNullReference */
         return $this->fallback->getContentAsResource();
     }
 }

--- a/src/Core/src/Stream/StringStream.php
+++ b/src/Core/src/Stream/StringStream.php
@@ -13,8 +13,14 @@ use AsyncAws\Core\Exception\InvalidArgument;
  */
 final class StringStream implements RequestStream
 {
+    /**
+     * @var string
+     */
     private $content;
 
+    /**
+     * @var int|null
+     */
     private $lengthCache;
 
     private function __construct(string $content)

--- a/src/Core/src/Test/Http/SimpleMockedResponse.php
+++ b/src/Core/src/Test/Http/SimpleMockedResponse.php
@@ -12,14 +12,23 @@ use Symfony\Component\HttpClient\Response\MockResponse;
  */
 class SimpleMockedResponse extends MockResponse
 {
+    /**
+     * @var array<string, list<string>>
+     */
     private $headers = [];
 
+    /**
+     * @var string
+     */
     private $content = '';
 
+    /**
+     * @var int
+     */
     private $statusCode;
 
     /**
-     * @param array $headers ['name'=>'value'] OR ['name'=>['value']]
+     * @param array<string, string|list<string>> $headers ['name'=>'value'] OR ['name'=>['value']]
      */
     public function __construct(string $content = '', array $headers = [], int $statusCode = 200)
     {
@@ -54,6 +63,9 @@ class SimpleMockedResponse extends MockResponse
         return $this->content;
     }
 
+    /**
+     * @return array<string, mixed>
+     */
     public function toArray(bool $throw = true): array
     {
         return json_decode($this->getContent($throw), true);
@@ -64,6 +76,9 @@ class SimpleMockedResponse extends MockResponse
         throw new LogicException('Not implemented');
     }
 
+    /**
+     * @return list<string>
+     */
     private function getFlatHeaders()
     {
         $flat = [];

--- a/src/Core/src/Test/InternalTestCase.php
+++ b/src/Core/src/Test/InternalTestCase.php
@@ -3,29 +3,45 @@
 namespace AsyncAws\Core\Test;
 
 /**
- * Because AsyncAws use symfony/phpunit-bridge and don't requires phpunit/phpunit,
- * this class may not exits but is required by the generator and static analyzer tools.
+ * Because AsyncAws use symfony/phpunit-bridge and doesn't require phpunit/phpunit,
+ * this class may not exist but is required by the generator and static analyzer tools.
  *
  * @internal use AsyncAws\Core\Test\TestCase instead
  */
 class InternalTestCase
 {
+    /**
+     * @param mixed $expected
+     * @param mixed $actual
+     */
     public static function assertEqualsCanonicalizing($expected, $actual, string $message = ''): void
     {
     }
 
+    /**
+     * @param mixed $expected
+     * @param mixed $actual
+     */
     public static function assertEqualsIgnoringCase($expected, $actual, string $message = ''): void
     {
     }
 
+    /**
+     * @param mixed $expected
+     * @param mixed $actual
+     */
     public static function assertSame($expected, $actual, string $message = ''): void
     {
     }
 
-    public static function assertJsonStringEqualsJsonString($expected, $actual, string $message = ''): void
+    public static function assertJsonStringEqualsJsonString(string $expected, string $actual, string $message = ''): void
     {
     }
 
+    /**
+     * @param \DOMDocument|string $expected
+     * @param \DOMDocument|string $actual
+     */
     public static function assertXmlStringEqualsXmlString($expected, $actual, string $message = ''): void
     {
     }

--- a/src/Core/src/Test/ResultMockFactory.php
+++ b/src/Core/src/Test/ResultMockFactory.php
@@ -28,7 +28,8 @@ class ResultMockFactory
      *
      * @template T of Result
      *
-     * @psalm-param class-string<T> $class
+     * @param class-string<T>      $class
+     * @param array<string, mixed> $additionalContent
      *
      * @return T
      */
@@ -64,7 +65,8 @@ class ResultMockFactory
      *
      * @template T of Result
      *
-     * @psalm-param class-string<T> $class
+     * @param class-string<T>      $class
+     * @param array<string, mixed> $data
      *
      * @return T
      */
@@ -166,9 +168,12 @@ class ResultMockFactory
     /**
      * Try to add some values to the properties not defined in $data.
      *
+     * @param \ReflectionClass<object> $reflectionClass
+     * @param array<string, mixed>     $data
+     *
      * @throws \ReflectionException
      */
-    private static function addUndefinedProperties(\ReflectionClass $reflectionClass, $object, array $data): void
+    private static function addUndefinedProperties(\ReflectionClass $reflectionClass, object $object, array $data): void
     {
         foreach ($reflectionClass->getProperties(\ReflectionProperty::IS_PRIVATE) as $property) {
             if (\array_key_exists($property->getName(), $data) || \array_key_exists(ucfirst($property->getName()), $data)) {
@@ -220,6 +225,8 @@ class ResultMockFactory
 
     /**
      * Set input and aws client to handle pagination.
+     *
+     * @param \ReflectionClass<object> $reflectionClass
      */
     private static function addPropertiesOnResult(\ReflectionClass $reflectionClass, object $object, string $class): void
     {

--- a/src/Core/src/Test/TestCase.php
+++ b/src/Core/src/Test/TestCase.php
@@ -11,7 +11,7 @@ class TestCase extends PHPUnitTestCase
     /**
      * Asserts that two Body documents are equal.
      */
-    public static function assertHttpFormEqualsHttpForm(string $expected, string $actual, string $message = '')
+    public static function assertHttpFormEqualsHttpForm(string $expected, string $actual, string $message = ''): void
     {
         $expectedArray = preg_split('/[\n&\s]+/', trim($expected));
         $actualArray = preg_split('/[\n&\s]+/', trim($actual));
@@ -22,7 +22,7 @@ class TestCase extends PHPUnitTestCase
     /**
      * Asserts that two Body documents are equal.
      */
-    public static function assertUrlEqualsUrl(string $expected, string $actual, string $message = '')
+    public static function assertUrlEqualsUrl(string $expected, string $actual, string $message = ''): void
     {
         $actualUrl = parse_url($actual);
         $expectedUrl = parse_url($expected);
@@ -45,7 +45,7 @@ class TestCase extends PHPUnitTestCase
     /**
      * Asserts that two Body documents are equal.
      */
-    public static function assertRequestEqualsHttpRequest(string $expected, Request $actual, string $message = '')
+    public static function assertRequestEqualsHttpRequest(string $expected, Request $actual, string $message = ''): void
     {
         $expected = explode("\n\n", trim($expected));
         $headers = $expected[0];

--- a/src/Core/src/Waiter.php
+++ b/src/Core/src/Waiter.php
@@ -54,7 +54,7 @@ class Waiter
      */
     private $resolved = false;
 
-    public function __construct(Response $response, AbstractApi $awsClient, $request)
+    public function __construct(Response $response, AbstractApi $awsClient, ?object $request)
     {
         $this->response = $response;
         $this->awsClient = $awsClient;

--- a/src/Core/tests/Unit/Signer/SignerV4Test.php
+++ b/src/Core/tests/Unit/Signer/SignerV4Test.php
@@ -51,7 +51,7 @@ class SignerV4Test extends TestCase
             'X-Amz-Algorithm' => 'AWS4-HMAC-SHA256',
             'X-Amz-Security-Token' => 'token',
             'X-Amz-Date' => '20200101T000000Z',
-            'X-Amz-Expires' => 3600,
+            'X-Amz-Expires' => '3600',
             'X-Amz-Credential' => 'key/20200101/eu-west-1/sqs/aws4_request',
             'X-Amz-SignedHeaders' => 'header;host',
             'X-Amz-Signature' => '27d875a8ba472ef2c315e2120e7718c4187b4b07f6b787264858227586c0445a',

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -2628,9 +2628,6 @@ class S3Client extends AbstractApi
         return 's3v4';
     }
 
-    /**
-     * @return callable[]
-     */
     protected function getSignerFactories(): array
     {
         return [


### PR DESCRIPTION
This is part of my work to increase the phpstan level. At level 6, phpstan wants all properties and methods to define their types. This does the work in the Core package (excluding the generated Sts client).