### PR TITLE
Fix the parsing of long values in headers

### DIFF
--- a/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
@@ -171,6 +171,7 @@ class TypeGenerator
     {
         switch ($shape->getType()) {
             case 'integer':
+            case 'long':
                 return 'FILTER_VALIDATE_INT';
             case 'boolean':
                 return 'FILTER_VALIDATE_BOOLEAN';

--- a/src/Service/S3/src/Result/GetObjectOutput.php
+++ b/src/Service/S3/src/Result/GetObjectOutput.php
@@ -506,7 +506,7 @@ class GetObjectOutput extends Result
         $this->expiration = $headers['x-amz-expiration'][0] ?? null;
         $this->restore = $headers['x-amz-restore'][0] ?? null;
         $this->lastModified = isset($headers['last-modified'][0]) ? new \DateTimeImmutable($headers['last-modified'][0]) : null;
-        $this->contentLength = $headers['content-length'][0] ?? null;
+        $this->contentLength = isset($headers['content-length'][0]) ? filter_var($headers['content-length'][0], \FILTER_VALIDATE_INT) : null;
         $this->etag = $headers['etag'][0] ?? null;
         $this->checksumCrc32 = $headers['x-amz-checksum-crc32'][0] ?? null;
         $this->checksumCrc32C = $headers['x-amz-checksum-crc32c'][0] ?? null;

--- a/src/Service/S3/src/Result/HeadObjectOutput.php
+++ b/src/Service/S3/src/Result/HeadObjectOutput.php
@@ -534,7 +534,7 @@ class HeadObjectOutput extends Result
         $this->restore = $headers['x-amz-restore'][0] ?? null;
         $this->archiveStatus = $headers['x-amz-archive-status'][0] ?? null;
         $this->lastModified = isset($headers['last-modified'][0]) ? new \DateTimeImmutable($headers['last-modified'][0]) : null;
-        $this->contentLength = $headers['content-length'][0] ?? null;
+        $this->contentLength = isset($headers['content-length'][0]) ? filter_var($headers['content-length'][0], \FILTER_VALIDATE_INT) : null;
         $this->checksumCrc32 = $headers['x-amz-checksum-crc32'][0] ?? null;
         $this->checksumCrc32C = $headers['x-amz-checksum-crc32c'][0] ?? null;
         $this->checksumSha1 = $headers['x-amz-checksum-sha1'][0] ?? null;


### PR DESCRIPTION
I missed this in #1471 as I looked for places using `long` in the code, but this type was going through the default case.