### PR TITLE
Add types for most of the code generator

### DIFF
--- a/src/CodeGenerator/src/Command/GenerateCommand.php
+++ b/src/CodeGenerator/src/Command/GenerateCommand.php
@@ -27,7 +27,7 @@ use Symfony\Component\Console\Question\ChoiceQuestion;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
- * Update a existing response class or API client method.
+ * Update an existing response class or API client method.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
@@ -38,14 +38,29 @@ class GenerateCommand extends Command
 
     private $manifest;
 
+    /**
+     * @var string
+     */
     private $manifestFile;
 
+    /**
+     * @var Cache
+     */
     private $cache;
 
+    /**
+     * @var ApiGenerator
+     */
     private $generator;
 
+    /**
+     * @var ClassWriter
+     */
     private $classWriter;
 
+    /**
+     * @var ComposerWriter
+     */
     private $composerWriter;
 
     public function __construct(string $manifestFile, Cache $cache, ClassWriter $classWriter, ComposerWriter $composerWriter, ApiGenerator $generator)
@@ -59,7 +74,7 @@ class GenerateCommand extends Command
         parent::__construct();
     }
 
-    protected function configure()
+    protected function configure(): void
     {
         $this->setAliases(['update']);
         $this->setDescription('Create or update API client methods.');
@@ -140,6 +155,11 @@ class GenerateCommand extends Command
         return $manifest;
     }
 
+    /**
+     * @param string[] $serviceNames
+     *
+     * @return array|int
+     */
     private function generateServicesSequential(SymfonyStyle $io, InputInterface $input, ConsoleOutputInterface $output, array $manifest, array $endpoints, array $serviceNames)
     {
         if (\count($serviceNames) > 1) {
@@ -302,7 +322,9 @@ class GenerateCommand extends Command
     }
 
     /**
-     * @return array|int
+     * @param array<string, mixed> $manifest
+     *
+     * @return list<string>|int
      */
     private function getServiceNames(?string $inputServiceName, bool $returnAll, SymfonyStyle $io, array $manifest)
     {
@@ -331,7 +353,11 @@ class GenerateCommand extends Command
     }
 
     /**
-     * @return array|int
+     * @param array{operations: array<string, mixed>,...} $definition
+     * @param array{waiters: array<string, mixed>} $waiter
+     * @param array{methods: list<string>,...} $manifest
+     *
+     * @return string[]|int
      */
     private function getOperationNames(?string $inputOperationName, bool $returnAll, SymfonyStyle $io, array $definition, array $waiter, array $manifest)
     {

--- a/src/CodeGenerator/src/Definition/ServiceDefinition.php
+++ b/src/CodeGenerator/src/Definition/ServiceDefinition.php
@@ -13,6 +13,9 @@ use AsyncAws\CodeGenerator\Generator\GeneratorHelper;
  */
 class ServiceDefinition
 {
+    /**
+     * @var string
+     */
     private $name;
 
     private $endpoints;
@@ -29,8 +32,14 @@ class ServiceDefinition
 
     private $hooks;
 
+    /**
+     * @var array<string, list<Hook>>|null
+     */
     private $hooksByTarget;
 
+    /**
+     * @var string
+     */
     private $apiReferenceUrl;
 
     public function __construct(string $name, array $endpoints, array $definition, array $documentation, array $pagination, array $waiter, array $example, array $hooks, string $apiReferenceUrl)
@@ -155,6 +164,9 @@ class ServiceDefinition
         return Example::create($this->example['examples'][$name][0] ?? []);
     }
 
+    /**
+     * @param array<string, mixed> $extra
+     */
     private function getShape(string $name, ?Member $member, array $extra): ?Shape
     {
         if (isset($this->definition['shapes'][$name])) {
@@ -170,6 +182,9 @@ class ServiceDefinition
         return null;
     }
 
+    /**
+     * @return \Closure(string, ?Member=, array<string, mixed>=): ?Shape
+     */
     private function createClosureToFindShape(): \Closure
     {
         $definition = $this;
@@ -179,6 +194,9 @@ class ServiceDefinition
         });
     }
 
+    /**
+     * @return \Closure(): self
+     */
     private function createClosureToService(): \Closure
     {
         $definition = $this;
@@ -188,6 +206,9 @@ class ServiceDefinition
         });
     }
 
+    /**
+     * @return \Closure(string): ?Operation
+     */
     private function createClosureToFindOperation(): \Closure
     {
         $definition = $this;

--- a/src/CodeGenerator/src/File/Cache.php
+++ b/src/CodeGenerator/src/File/Cache.php
@@ -11,10 +11,19 @@ namespace AsyncAws\CodeGenerator\File;
  */
 class Cache
 {
+    /**
+     * @var string
+     */
     private $cacheFile;
 
+    /**
+     * @var bool
+     */
     private $splitFile;
 
+    /**
+     * @var resource
+     */
     private $handle;
 
     public function __construct(string $cacheFile)
@@ -23,6 +32,9 @@ class Cache
         $this->splitFile = is_dir($cacheFile);
     }
 
+    /**
+     * @return mixed
+     */
     public function get(string $key)
     {
         $this->lock($key);
@@ -37,6 +49,11 @@ class Cache
         }
     }
 
+    /**
+     * @param callable(mixed): mixed $callable
+     *
+     * @return mixed
+     */
     public function update(string $key, callable $callable)
     {
         $this->lock($key);
@@ -61,6 +78,9 @@ class Cache
         }
     }
 
+    /**
+     * @param mixed $content
+     */
     public function set(string $key, $content): void
     {
         $this->update($key, static function () use ($content) {
@@ -68,17 +88,18 @@ class Cache
         });
     }
 
-    private function unlock()
+    private function unlock(): void
     {
         flock($this->handle, \LOCK_UN);
         fclose($this->handle);
     }
 
-    private function lock(string $key)
+    private function lock(string $key): void
     {
-        /** @phpstan-ignore-next-line */
         set_error_handler(function ($type, $msg) use (&$error) {
             $error = $msg;
+
+            return true;
         });
         $filename = $this->cacheFile;
         if ($this->splitFile) {

--- a/src/CodeGenerator/src/File/CachedFileDumper.php
+++ b/src/CodeGenerator/src/File/CachedFileDumper.php
@@ -12,10 +12,19 @@ namespace AsyncAws\CodeGenerator\File;
  */
 class CachedFileDumper extends FileDumper
 {
+    /**
+     * @var Cache
+     */
     private $cache;
 
+    /**
+     * @var array<string, array{0?: string, 1?: string}>
+     */
     private $status = [];
 
+    /**
+     * @var array<string, string>
+     */
     private $added = [];
 
     public function __construct(Cache $cache)

--- a/src/CodeGenerator/src/File/ClassWriter.php
+++ b/src/CodeGenerator/src/File/ClassWriter.php
@@ -13,10 +13,19 @@ use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassBuilder;
  */
 class ClassWriter
 {
+    /**
+     * @var string
+     */
     private $srcDirectory;
 
+    /**
+     * @var FileDumper
+     */
     private $fileDumper;
 
+    /**
+     * @var Printer
+     */
     private $printer;
 
     public function __construct(string $srcDirectory, FileDumper $fileDumper)
@@ -26,7 +35,7 @@ class ClassWriter
         $this->printer = new Printer();
     }
 
-    public function write(ClassBuilder $classBuilder)
+    public function write(ClassBuilder $classBuilder): void
     {
         $content = $this->printer->printNamespace($classBuilder->build());
 

--- a/src/CodeGenerator/src/File/ComposerWriter.php
+++ b/src/CodeGenerator/src/File/ComposerWriter.php
@@ -11,6 +11,9 @@ namespace AsyncAws\CodeGenerator\File;
  */
 class ComposerWriter
 {
+    /**
+     * @var string
+     */
     private $srcDirectory;
 
     public function __construct(string $srcDirectory)
@@ -18,6 +21,9 @@ class ComposerWriter
         $this->srcDirectory = $srcDirectory;
     }
 
+    /**
+     * @param array<string, string> $requirements
+     */
     public function setRequirements(string $namespace, array $requirements, bool $clean): void
     {
         $filename = $this->findFile($namespace);

--- a/src/CodeGenerator/src/File/FileDumper.php
+++ b/src/CodeGenerator/src/File/FileDumper.php
@@ -15,6 +15,9 @@ use Symfony\Component\Process\Process;
  */
 class FileDumper
 {
+    /**
+     * @var string[]|null
+     */
     private $phpBin;
 
     public function dump(string $filename, string $content): void
@@ -28,8 +31,8 @@ class FileDumper
     {
         if (null === $this->phpBin) {
             $executableFinder = new PhpExecutableFinder();
-            $this->phpBin = $executableFinder->find(false);
-            $this->phpBin = false === $this->phpBin ? null : array_merge([$this->phpBin], $executableFinder->findArguments());
+            $phpBin = $executableFinder->find(false);
+            $this->phpBin = false === $phpBin ? null : array_merge([$phpBin], $executableFinder->findArguments());
         }
 
         $process = new Process(array_merge($this->phpBin, ['-l', $filename]));

--- a/src/CodeGenerator/src/Generator/ApiGenerator.php
+++ b/src/CodeGenerator/src/Generator/ApiGenerator.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AsyncAws\CodeGenerator\Generator;
 
 use AsyncAws\CodeGenerator\Generator\Composer\RequirementsRegistry;
+use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassBuilder;
 use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassRegistry;
 
 /**
@@ -15,8 +16,14 @@ use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassRegistry;
  */
 class ApiGenerator
 {
+    /**
+     * @var ClassRegistry
+     */
     private $classRegistry;
 
+    /**
+     * @var RequirementsRegistry
+     */
     private $requirementsRegistry;
 
     public function __construct(?ClassRegistry $classRegistry = null, ?RequirementsRegistry $requirementsRegistry = null)
@@ -25,16 +32,25 @@ class ApiGenerator
         $this->requirementsRegistry = $requirementsRegistry ?? new RequirementsRegistry();
     }
 
+    /**
+     * @param list<string> $managedOperations
+     */
     public function service(string $baseNamespace, array $managedOperations): ServiceGenerator
     {
         return new ServiceGenerator($this->classRegistry, $this->requirementsRegistry, $baseNamespace, $managedOperations);
     }
 
+    /**
+     * @return iterable<ClassBuilder>
+     */
     public function getUpdatedClasses(): iterable
     {
         return $this->classRegistry->getRegisteredClasses();
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function getUpdatedRequirements(): array
     {
         return $this->requirementsRegistry->getRequirements();

--- a/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
@@ -34,6 +34,8 @@ class TypeGenerator
     /**
      * Return docblock information for the given shape.
      *
+     * @param string[] $extra
+     *
      * @return array{string, ClassName[]} [docblock representation, ClassName related]
      */
     public function generateDocblock(StructureShape $shape, ClassName $shapeClassName, bool $alternateClass = true, bool $allNullable = false, bool $isObject = false, array $extra = []): array

--- a/src/CodeGenerator/src/Generator/Composer/RequirementsRegistry.php
+++ b/src/CodeGenerator/src/Generator/Composer/RequirementsRegistry.php
@@ -4,6 +4,9 @@ namespace AsyncAws\CodeGenerator\Generator\Composer;
 
 class RequirementsRegistry
 {
+    /**
+     * @var array<string, string>
+     */
     private $requirements = [];
 
     public function addRequirement(string $package, string $version = '*'): void
@@ -21,6 +24,9 @@ class RequirementsRegistry
         $this->requirements[$package] = $version;
     }
 
+    /**
+     * @return array<string, string>
+     */
     public function getRequirements(): array
     {
         return $this->requirements;

--- a/src/CodeGenerator/src/Generator/HookGenerator.php
+++ b/src/CodeGenerator/src/Generator/HookGenerator.php
@@ -28,7 +28,10 @@ class HookGenerator
         throw new \RuntimeException('Hook ' . $hook->getAction() . ' is not yet implemented');
     }
 
-    private function removeLeft(array $values, $input): string
+    /**
+     * @param string[] $values
+     */
+    private function removeLeft(array $values, string $input): string
     {
         return strtr('VALUE = preg_replace("#^(VALUES)#", "", VALUE);', [
             'VALUES' => implode('|', array_map(function ($value) {

--- a/src/CodeGenerator/src/Generator/InputGenerator.php
+++ b/src/CodeGenerator/src/Generator/InputGenerator.php
@@ -523,7 +523,10 @@ PHP
         throw new \InvalidArgumentException(sprintf('Type "%s" is not yet implemented', $shape->getType()));
     }
 
-    private function addUse(StructureShape $shape, ClassBuilder $classBuilder, array $addedFqdn = [])
+    /**
+     * @param string[] $addedFqdn
+     */
+    private function addUse(StructureShape $shape, ClassBuilder $classBuilder, array $addedFqdn = []): void
     {
         foreach ($shape->getMembers() as $member) {
             $memberShape = $member->getShape();

--- a/src/CodeGenerator/src/Generator/Naming/ClassName.php
+++ b/src/CodeGenerator/src/Generator/Naming/ClassName.php
@@ -54,7 +54,7 @@ final class ClassName
     }
 
     /**
-     * Make sure we dont use a class name like Trait or Object.
+     * Make sure we don't use a class name like Trait or Object.
      */
     private static function safeClassName(string $name): string
     {

--- a/src/CodeGenerator/src/Generator/ObjectGenerator.php
+++ b/src/CodeGenerator/src/Generator/ObjectGenerator.php
@@ -59,10 +59,19 @@ class ObjectGenerator
      */
     private $serializer;
 
+    /**
+     * @var list<string>
+     */
     private $managedMethods;
 
+    /**
+     * @var array<string, bool>|null
+     */
     private $usedShapedInput;
 
+    /**
+     * @param list<string> $managedMethods
+     */
     public function __construct(ClassRegistry $classRegistry, NamespaceRegistry $namespaceRegistry, RequirementsRegistry $requirementsRegistry, array $managedMethods, ?TypeGenerator $typeGenerator = null, ?EnumGenerator $enumGenerator = null)
     {
         $this->classRegistry = $classRegistry;

--- a/src/CodeGenerator/src/Generator/PaginationGenerator.php
+++ b/src/CodeGenerator/src/Generator/PaginationGenerator.php
@@ -194,6 +194,9 @@ class PaginationGenerator
         $classBuilder->addComment("@implements \IteratorAggregate<$iteratorType>");
     }
 
+    /**
+     * @param string[] $outputToken
+     */
     private function generateOutputPaginationLoader(string $iterator, string $common, string $moreResult, array $outputToken, Pagination $pagination, ClassBuilder $classBuilder, Operation $operation): string
     {
         if (empty($outputToken)) {
@@ -291,6 +294,9 @@ class PaginationGenerator
         return $getter;
     }
 
+    /**
+     * @return array{string, string, string[], string[]}
+     */
     private function extractPageProperties(Operation $operation, Pagination $pagination): array
     {
         $more = $pagination->getMoreResults() ?? '';

--- a/src/CodeGenerator/src/Generator/PhpGenerator/ClassBuilder.php
+++ b/src/CodeGenerator/src/Generator/PhpGenerator/ClassBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace AsyncAws\CodeGenerator\Generator\PhpGenerator;
 
 use AsyncAws\CodeGenerator\Generator\Naming\ClassName;
+use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Constant;
 use Nette\PhpGenerator\Method;
 use Nette\PhpGenerator\PhpNamespace;
@@ -17,10 +18,19 @@ use Nette\PhpGenerator\Property;
  */
 class ClassBuilder
 {
+    /**
+     * @var PhpNamespace
+     */
     private $namespace;
 
+    /**
+     * @var ClassType
+     */
     private $class;
 
+    /**
+     * @var ClassName
+     */
     private $className;
 
     public function __construct(PhpNamespace $namespace)
@@ -43,6 +53,9 @@ class ClassBuilder
         return $this;
     }
 
+    /**
+     * @param string|string[] $names
+     */
     public function setExtends($names): self
     {
         $this->class->setExtends($names);
@@ -53,13 +66,6 @@ class ClassBuilder
     public function addExtend(string $name): self
     {
         $this->class->addExtend($name);
-
-        return $this;
-    }
-
-    public function setImplement($names): self
-    {
-        $this->class->setImplement($names);
 
         return $this;
     }
@@ -78,6 +84,9 @@ class ClassBuilder
         return $this;
     }
 
+    /**
+     * @param mixed $value
+     */
     public function addConstant(string $name, $value): Constant
     {
         return $this->class->addConstant($name, $value);
@@ -98,6 +107,9 @@ class ClassBuilder
         return $this->class->hasMethod($name);
     }
 
+    /**
+     * @param Method[] $methods
+     */
     public function setMethods(array $methods): self
     {
         $this->class->setMethods($methods);

--- a/src/CodeGenerator/src/Generator/PhpGenerator/ClassFactory.php
+++ b/src/CodeGenerator/src/Generator/PhpGenerator/ClassFactory.php
@@ -23,6 +23,9 @@ use Nette\PhpGenerator\Property;
  */
 class ClassFactory
 {
+    /**
+     * @param \ReflectionClass<object> $from
+     */
     public function fromClassReflection(\ReflectionClass $from): PhpNamespace
     {
         $namespace = new PhpNamespace($from->getNamespaceName());

--- a/src/CodeGenerator/src/Generator/PhpGenerator/ClassRegistry.php
+++ b/src/CodeGenerator/src/Generator/PhpGenerator/ClassRegistry.php
@@ -14,8 +14,14 @@ use Nette\PhpGenerator\PhpNamespace;
  */
 class ClassRegistry
 {
+    /**
+     * @var ClassFactory
+     */
     private $classFactory;
 
+    /**
+     * @var array<string, ClassBuilder>
+     */
     private $registered = [];
 
     public function __construct(?ClassFactory $classFactory = null)
@@ -23,6 +29,9 @@ class ClassRegistry
         $this->classFactory = $classFactory ?? new ClassFactory();
     }
 
+    /**
+     * @return iterable<ClassBuilder>
+     */
     public function getRegisteredClasses(): iterable
     {
         return $this->registered;

--- a/src/CodeGenerator/src/Generator/RequestSerializer/QuerySerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/QuerySerializer.php
@@ -24,8 +24,14 @@ use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
  */
 class QuerySerializer implements Serializer
 {
+    /**
+     * @var NamespaceRegistry
+     */
     private $namespaceRegistry;
 
+    /**
+     * @var RequirementsRegistry
+     */
     private $requirementsRegistry;
 
     public function __construct(NamespaceRegistry $namespaceRegistry, RequirementsRegistry $requirementsRegistry)
@@ -152,7 +158,7 @@ class QuerySerializer implements Serializer
         return $name;
     }
 
-    private function dumpArrayElement(string $output, string $input, string $contextProperty, Shape $shape)
+    private function dumpArrayElement(string $output, string $input, string $contextProperty, Shape $shape): string
     {
         switch (true) {
             case $shape instanceof StructureShape:

--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestJsonSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestJsonSerializer.php
@@ -24,8 +24,14 @@ use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
  */
 class RestJsonSerializer implements Serializer
 {
+    /**
+     * @var NamespaceRegistry
+     */
     private $namespaceRegistry;
 
+    /**
+     * @var RequirementsRegistry
+     */
     private $requirementsRegistry;
 
     public function __construct(NamespaceRegistry $namespaceRegistry, RequirementsRegistry $requirementsRegistry)
@@ -146,7 +152,7 @@ class RestJsonSerializer implements Serializer
         return $name;
     }
 
-    private function dumpArrayElement(string $output, string $input, string $contextProperty, Shape $shape, bool $isRequired = false)
+    private function dumpArrayElement(string $output, string $input, string $contextProperty, Shape $shape, bool $isRequired = false): string
     {
         switch (true) {
             case $shape instanceof StructureShape:
@@ -211,7 +217,7 @@ class RestJsonSerializer implements Serializer
         }
     }
 
-    private function dumpArrayMap(string $output, string $input, $contextProperty, MapShape $shape): string
+    private function dumpArrayMap(string $output, string $input, string $contextProperty, MapShape $shape): string
     {
         $mapKeyShape = $shape->getKey()->getShape();
         if (!empty($mapKeyShape->getEnum())) {

--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
@@ -21,8 +21,14 @@ use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
  */
 class RestXmlSerializer implements Serializer
 {
+    /**
+     * @var NamespaceRegistry
+     */
     private $namespaceRegistry;
 
+    /**
+     * @var RequirementsRegistry
+     */
     private $requirementsRegistry;
 
     public function __construct(NamespaceRegistry $namespaceRegistry, RequirementsRegistry $requirementsRegistry)

--- a/src/CodeGenerator/src/Generator/RequestSerializer/Serializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/Serializer.php
@@ -14,8 +14,19 @@ use AsyncAws\CodeGenerator\Definition\StructureShape;
  */
 interface Serializer
 {
+    /**
+     * Returns the body of the method, a boolean indicating whether a requestBody method is needed
+     * and optionally a list of extra parameters for the method with their type.
+     *
+     * @return array{0: string, 1: bool, 2?: array<string, string>}
+     */
     public function generateRequestBody(Operation $operation, StructureShape $shape): array;
 
+    /**
+     * Returns the return type, the body and extra arguments for the requestBody method.
+     *
+     * @return array{0: string, 1: string, 2?: array<string, string>}
+     */
     public function generateRequestBuilder(StructureShape $shape): array;
 
     public function getHeaders(Operation $operation): string;

--- a/src/CodeGenerator/src/Generator/RequestSerializer/SerializerProvider.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/SerializerProvider.php
@@ -17,8 +17,14 @@ use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
  */
 class SerializerProvider
 {
+    /**
+     * @var NamespaceRegistry
+     */
     private $namespaceRegistry;
 
+    /**
+     * @var RequirementsRegistry
+     */
     private $requirementsRegistry;
 
     public function __construct(NamespaceRegistry $namespaceRegistry, RequirementsRegistry $requirementsRegistry)

--- a/src/CodeGenerator/src/Generator/ResponseParser/ParserResult.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/ParserResult.php
@@ -12,20 +12,27 @@ use Nette\PhpGenerator\Method;
  */
 class ParserResult
 {
+    /**
+     * @var string
+     */
     private $body;
 
     /**
      * Classes to import.
      *
-     * @var ClassName[]
+     * @var list<ClassName>
      */
     private $usedClasses;
 
     /**
-     * @var Method[]
+     * @var array<string, Method>
      */
     private $extraMethods;
 
+    /**
+     * @param list<ClassName>       $usedClasses
+     * @param array<string, Method> $extraMethods
+     */
     public function __construct(string $body, array $usedClasses = [], array $extraMethods = [])
     {
         $this->body = $body;
@@ -38,11 +45,17 @@ class ParserResult
         return $this->body;
     }
 
+    /**
+     * @return list<ClassName>
+     */
     public function getUsedClasses(): array
     {
         return $this->usedClasses;
     }
 
+    /**
+     * @return array<string, Method>
+     */
     public function getExtraMethods(): array
     {
         return $this->extraMethods;

--- a/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
@@ -13,6 +13,7 @@ use AsyncAws\CodeGenerator\Definition\StructureShape;
 use AsyncAws\CodeGenerator\Generator\CodeGenerator\TypeGenerator;
 use AsyncAws\CodeGenerator\Generator\Composer\RequirementsRegistry;
 use AsyncAws\CodeGenerator\Generator\GeneratorHelper;
+use AsyncAws\CodeGenerator\Generator\Naming\ClassName;
 use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
 use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Method;
@@ -24,14 +25,29 @@ use Nette\PhpGenerator\Method;
  */
 class RestJsonParser implements Parser
 {
+    /**
+     * @var NamespaceRegistry
+     */
     private $namespaceRegistry;
 
+    /**
+     * @var RequirementsRegistry
+     */
     private $requirementsRegistry;
 
+    /**
+     * @var TypeGenerator
+     */
     private $typeGenerator;
 
+    /**
+     * @var array<string, Method>
+     */
     private $functions = [];
 
+    /**
+     * @var list<ClassName>
+     */
     private $imports = [];
 
     public function __construct(NamespaceRegistry $namespaceRegistry, RequirementsRegistry $requirementsRegistry, TypeGenerator $typeGenerator)
@@ -130,7 +146,7 @@ class RestJsonParser implements Parser
         return strtr($body, ['INPUT' => $input]);
     }
 
-    private function getInputAccessorName(Member $member)
+    private function getInputAccessorName(Member $member): string
     {
         if ($member instanceof StructureMember) {
             $shape = $member->getShape();
@@ -151,7 +167,7 @@ class RestJsonParser implements Parser
     /**
      * @param bool $inObject whether the element is building an ObjectValue
      */
-    private function parseElement(string $input, Shape $shape, bool $required, bool $inObject)
+    private function parseElement(string $input, Shape $shape, bool $required, bool $inObject): string
     {
         switch (true) {
             case $shape instanceof ListShape:

--- a/src/CodeGenerator/src/Generator/ResponseParser/RestXmlParser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/RestXmlParser.php
@@ -13,6 +13,7 @@ use AsyncAws\CodeGenerator\Definition\StructureShape;
 use AsyncAws\CodeGenerator\Generator\CodeGenerator\TypeGenerator;
 use AsyncAws\CodeGenerator\Generator\Composer\RequirementsRegistry;
 use AsyncAws\CodeGenerator\Generator\GeneratorHelper;
+use AsyncAws\CodeGenerator\Generator\Naming\ClassName;
 use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
 use Nette\PhpGenerator\ClassType;
 use Nette\PhpGenerator\Method;
@@ -24,14 +25,29 @@ use Nette\PhpGenerator\Method;
  */
 class RestXmlParser implements Parser
 {
+    /**
+     * @var NamespaceRegistry
+     */
     private $namespaceRegistry;
 
+    /**
+     * @var RequirementsRegistry
+     */
     private $requirementsRegistry;
 
+    /**
+     * @var TypeGenerator
+     */
     private $typeGenerator;
 
+    /**
+     * @var array<string, Method>
+     */
     private $functions = [];
 
+    /**
+     * @var list<ClassName>
+     */
     private $imports = [];
 
     public function __construct(NamespaceRegistry $namespaceRegistry, RequirementsRegistry $requirementsRegistry, TypeGenerator $typeGenerator)
@@ -115,7 +131,7 @@ class RestXmlParser implements Parser
         ]);
     }
 
-    private function getInputAccessor(string $currentInput, Member $member)
+    private function getInputAccessor(string $currentInput, Member $member): string
     {
         if ($member instanceof StructureMember) {
             if ($member->isXmlAttribute()) {
@@ -149,7 +165,7 @@ class RestXmlParser implements Parser
     /**
      * @param bool $inObject whether the element is building an ObjectValue
      */
-    private function parseXmlElement(string $input, Shape $shape, bool $required, bool $inObject)
+    private function parseXmlElement(string $input, Shape $shape, bool $required, bool $inObject): string
     {
         switch (true) {
             case $shape instanceof ListShape:

--- a/src/CodeGenerator/src/Generator/ResultGenerator.php
+++ b/src/CodeGenerator/src/Generator/ResultGenerator.php
@@ -91,7 +91,10 @@ class ResultGenerator
         return $className;
     }
 
-    private function addUse(StructureShape $shape, ClassBuilder $classBuilder, array $addedFqdn = [])
+    /**
+     * @param list<string> $addedFqdn
+     */
+    private function addUse(StructureShape $shape, ClassBuilder $classBuilder, array $addedFqdn = []): void
     {
         foreach ($shape->getMembers() as $member) {
             $memberShape = $member->getShape();

--- a/src/CodeGenerator/src/Generator/ServiceGenerator.php
+++ b/src/CodeGenerator/src/Generator/ServiceGenerator.php
@@ -25,7 +25,7 @@ class ServiceGenerator
     private $namespaceRegistry;
 
     /**
-     * @var array
+     * @var list<string>
      */
     private $managedOperations;
 
@@ -109,6 +109,9 @@ class ServiceGenerator
      */
     private $populator;
 
+    /**
+     * @param list<string> $managedOperations
+     */
     public function __construct(ClassRegistry $classRegistry, RequirementsRegistry $requirementsRegistry, string $baseNamespace, array $managedOperations)
     {
         $this->classRegistry = $classRegistry;


### PR DESCRIPTION
The remaining missing types are all in the `Definition` namespace. I started the work on them but they are harder to fix (and they trigger new static analysis errors due to existing type inconsistencies) so I kept them separate.