### PR TITLE
Skip caching for manifest files loaded locally

### DIFF
--- a/src/CodeGenerator/src/Command/GenerateCommand.php
+++ b/src/CodeGenerator/src/Command/GenerateCommand.php
@@ -444,7 +444,10 @@ class GenerateCommand extends Command
     {
         $path = strtr($path, $this->loadManifest()['variables'] ?? []);
 
-        $data = $this->cache->get(__CLASS__ . ':' . $cacheKey);
+        // For files loaded from a URL, we want to cache them until the URL changes.
+        $needsCaching = false !== strpos($path, '://');
+
+        $data = $needsCaching ? $this->cache->get(__CLASS__ . ':' . $cacheKey) : null;
         if (null === $data || $path !== ($data['path'] ?? null)) {
             if (empty($patch)) {
                 $content = json_decode(file_get_contents($path), true);
@@ -461,7 +464,10 @@ class GenerateCommand extends Command
                 'path' => $path,
                 'content' => $content,
             ];
-            $this->cache->set(__CLASS__ . ':' . $cacheKey, $data);
+
+            if ($needsCaching) {
+                $this->cache->set(__CLASS__ . ':' . $cacheKey, $data);
+            }
         }
 
         return $data['content'];


### PR DESCRIPTION
When loading those service manifest files from a remote location (as done in this repo to load them from the official sdk repo), caching them until the URL changes makes sense as that uses a versioned URL.

My own use case for an out-of-tree package involves a case where I maintain those service manifest files locally because the Amazon Incentives API does not provide those files. Skipping the caching avoids having to clear the cache manually each time the files gets modified. And the cache does not improve performances as both cases are about reading a file locally.