### PR TITLE
Improve the parsing of values coming from headers

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -83,6 +83,7 @@ return (new PhpCsFixer\Config())
         'ordered_class_elements' => ['sort_algorithm' => 'none'],
         'class_attributes_separation' => ['elements' => ['property' => 'one', 'method' => 'one']],
         'array_indentation' => true,
+        'ternary_to_null_coalescing' => true,
     ])
     ->setFinder($finder)
 ;

--- a/src/CodeGenerator/src/Generator/ClientGenerator.php
+++ b/src/CodeGenerator/src/Generator/ClientGenerator.php
@@ -98,8 +98,8 @@ class ClientGenerator
                 return false;
             }
 
-            $configRegion = isset($config['signRegion']) ? $config['signRegion'] : $region;
-            $defaultConfigRegion = isset($defaultConfig['signRegion']) ? $defaultConfig['signRegion'] : $region;
+            $configRegion = $config['signRegion'] ?? $region;
+            $defaultConfigRegion = $defaultConfig['signRegion'] ?? $region;
             if ($configRegion !== $defaultConfigRegion) {
                 return false;
             }

--- a/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
@@ -169,20 +169,6 @@ class TypeGenerator
         return [$type, $doc, $memberClassNames];
     }
 
-    public function getFilterConstant(Shape $shape): ?string
-    {
-        switch ($shape->getType()) {
-            case 'integer':
-            case 'long':
-                return 'FILTER_VALIDATE_INT';
-            case 'boolean':
-                return 'FILTER_VALIDATE_BOOLEAN';
-            case 'string':
-            default:
-                return null;
-        }
-    }
-
     private function getNativePhpType(string $parameterType): string
     {
         switch ($parameterType) {

--- a/src/Integration/Flysystem/S3/tests/Integration/AsyncAwsS3AdapterTest.php
+++ b/src/Integration/Flysystem/S3/tests/Integration/AsyncAwsS3AdapterTest.php
@@ -100,8 +100,8 @@ class AsyncAwsS3AdapterTest extends TestCase
 
     protected function createFilesystemAdapter(): AdapterInterface
     {
-        $bucket = isset($_SERVER['FLYSYSTEM_AWS_S3_BUCKET']) ? $_SERVER['FLYSYSTEM_AWS_S3_BUCKET'] : 'flysystem-bucket-v1';
-        $prefix = isset($_SERVER['FLYSYSTEM_AWS_S3_PREFIX']) ? $_SERVER['FLYSYSTEM_AWS_S3_PREFIX'] : static::$adapterPrefix;
+        $bucket = $_SERVER['FLYSYSTEM_AWS_S3_BUCKET'] ?? 'flysystem-bucket-v1';
+        $prefix = $_SERVER['FLYSYSTEM_AWS_S3_PREFIX'] ?? static::$adapterPrefix;
 
         return new AsyncAwsS3Adapter($this->s3Client(), $bucket, $prefix);
     }
@@ -115,7 +115,7 @@ class AsyncAwsS3AdapterTest extends TestCase
         $key = $_SERVER['FLYSYSTEM_AWS_S3_KEY'] ?? null;
         $secret = $_SERVER['FLYSYSTEM_AWS_S3_SECRET'] ?? null;
         $bucket = $_SERVER['FLYSYSTEM_AWS_S3_BUCKET'] ?? null;
-        $region = isset($_SERVER['FLYSYSTEM_AWS_S3_REGION']) ? $_SERVER['FLYSYSTEM_AWS_S3_REGION'] : 'eu-central-1';
+        $region = $_SERVER['FLYSYSTEM_AWS_S3_REGION'] ?? 'eu-central-1';
 
         if (!$key || !$secret || !$bucket) {
             self::$docker = true;

--- a/src/Service/S3/src/Result/GetObjectOutput.php
+++ b/src/Service/S3/src/Result/GetObjectOutput.php
@@ -506,13 +506,13 @@ class GetObjectOutput extends Result
         $this->expiration = $headers['x-amz-expiration'][0] ?? null;
         $this->restore = $headers['x-amz-restore'][0] ?? null;
         $this->lastModified = isset($headers['last-modified'][0]) ? new \DateTimeImmutable($headers['last-modified'][0]) : null;
-        $this->contentLength = isset($headers['content-length'][0]) ? filter_var($headers['content-length'][0], \FILTER_VALIDATE_INT) : null;
+        $this->contentLength = isset($headers['content-length'][0]) ? (int) $headers['content-length'][0] : null;
         $this->etag = $headers['etag'][0] ?? null;
         $this->checksumCrc32 = $headers['x-amz-checksum-crc32'][0] ?? null;
         $this->checksumCrc32C = $headers['x-amz-checksum-crc32c'][0] ?? null;
         $this->checksumSha1 = $headers['x-amz-checksum-sha1'][0] ?? null;
         $this->checksumSha256 = $headers['x-amz-checksum-sha256'][0] ?? null;
-        $this->missingMeta = isset($headers['x-amz-missing-meta'][0]) ? filter_var($headers['x-amz-missing-meta'][0], \FILTER_VALIDATE_INT) : null;
+        $this->missingMeta = isset($headers['x-amz-missing-meta'][0]) ? (int) $headers['x-amz-missing-meta'][0] : null;
         $this->versionId = $headers['x-amz-version-id'][0] ?? null;
         $this->cacheControl = $headers['cache-control'][0] ?? null;
         $this->contentDisposition = $headers['content-disposition'][0] ?? null;
@@ -530,8 +530,8 @@ class GetObjectOutput extends Result
         $this->storageClass = $headers['x-amz-storage-class'][0] ?? null;
         $this->requestCharged = $headers['x-amz-request-charged'][0] ?? null;
         $this->replicationStatus = $headers['x-amz-replication-status'][0] ?? null;
-        $this->partsCount = isset($headers['x-amz-mp-parts-count'][0]) ? filter_var($headers['x-amz-mp-parts-count'][0], \FILTER_VALIDATE_INT) : null;
-        $this->tagCount = isset($headers['x-amz-tagging-count'][0]) ? filter_var($headers['x-amz-tagging-count'][0], \FILTER_VALIDATE_INT) : null;
+        $this->partsCount = isset($headers['x-amz-mp-parts-count'][0]) ? (int) $headers['x-amz-mp-parts-count'][0] : null;
+        $this->tagCount = isset($headers['x-amz-tagging-count'][0]) ? (int) $headers['x-amz-tagging-count'][0] : null;
         $this->objectLockMode = $headers['x-amz-object-lock-mode'][0] ?? null;
         $this->objectLockRetainUntilDate = isset($headers['x-amz-object-lock-retain-until-date'][0]) ? new \DateTimeImmutable($headers['x-amz-object-lock-retain-until-date'][0]) : null;
         $this->objectLockLegalHoldStatus = $headers['x-amz-object-lock-legal-hold'][0] ?? null;

--- a/src/Service/S3/src/Result/HeadObjectOutput.php
+++ b/src/Service/S3/src/Result/HeadObjectOutput.php
@@ -534,13 +534,13 @@ class HeadObjectOutput extends Result
         $this->restore = $headers['x-amz-restore'][0] ?? null;
         $this->archiveStatus = $headers['x-amz-archive-status'][0] ?? null;
         $this->lastModified = isset($headers['last-modified'][0]) ? new \DateTimeImmutable($headers['last-modified'][0]) : null;
-        $this->contentLength = isset($headers['content-length'][0]) ? filter_var($headers['content-length'][0], \FILTER_VALIDATE_INT) : null;
+        $this->contentLength = isset($headers['content-length'][0]) ? (int) $headers['content-length'][0] : null;
         $this->checksumCrc32 = $headers['x-amz-checksum-crc32'][0] ?? null;
         $this->checksumCrc32C = $headers['x-amz-checksum-crc32c'][0] ?? null;
         $this->checksumSha1 = $headers['x-amz-checksum-sha1'][0] ?? null;
         $this->checksumSha256 = $headers['x-amz-checksum-sha256'][0] ?? null;
         $this->etag = $headers['etag'][0] ?? null;
-        $this->missingMeta = isset($headers['x-amz-missing-meta'][0]) ? filter_var($headers['x-amz-missing-meta'][0], \FILTER_VALIDATE_INT) : null;
+        $this->missingMeta = isset($headers['x-amz-missing-meta'][0]) ? (int) $headers['x-amz-missing-meta'][0] : null;
         $this->versionId = $headers['x-amz-version-id'][0] ?? null;
         $this->cacheControl = $headers['cache-control'][0] ?? null;
         $this->contentDisposition = $headers['content-disposition'][0] ?? null;
@@ -557,7 +557,7 @@ class HeadObjectOutput extends Result
         $this->storageClass = $headers['x-amz-storage-class'][0] ?? null;
         $this->requestCharged = $headers['x-amz-request-charged'][0] ?? null;
         $this->replicationStatus = $headers['x-amz-replication-status'][0] ?? null;
-        $this->partsCount = isset($headers['x-amz-mp-parts-count'][0]) ? filter_var($headers['x-amz-mp-parts-count'][0], \FILTER_VALIDATE_INT) : null;
+        $this->partsCount = isset($headers['x-amz-mp-parts-count'][0]) ? (int) $headers['x-amz-mp-parts-count'][0] : null;
         $this->objectLockMode = $headers['x-amz-object-lock-mode'][0] ?? null;
         $this->objectLockRetainUntilDate = isset($headers['x-amz-object-lock-retain-until-date'][0]) ? new \DateTimeImmutable($headers['x-amz-object-lock-retain-until-date'][0]) : null;
         $this->objectLockLegalHoldStatus = $headers['x-amz-object-lock-legal-hold'][0] ?? null;


### PR DESCRIPTION
- integer values are casted instead of using `FILTER_VALIDATE_INT`, as done when reading from JSON or XML bodies
- required fields are read without assigning `null` as fallback in the Result object (consistent with the behavior in JSON or XML bodies)

Relates to #1481 