### PR TITLE
Add support for configuring a custom error factory for a service

### DIFF
--- a/src/CodeGenerator/src/Command/GenerateCommand.php
+++ b/src/CodeGenerator/src/Command/GenerateCommand.php
@@ -278,6 +278,7 @@ class GenerateCommand extends Command
         $paginationArray = $this->loadFile($manifest['services'][$serviceName]['pagination'], "$serviceName-pagination", $manifest['services'][$serviceName]['patches']['pagination'] ?? []);
         $waiterArray = isset($manifest['services'][$serviceName]['waiter']) ? $this->loadFile($manifest['services'][$serviceName]['waiter'], "$serviceName-waiter", $manifest['services'][$serviceName]['patches']['waiter'] ?? []) : ['waiters' => []];
         $exampleArray = isset($manifest['services'][$serviceName]['example']) ? $this->loadFile($manifest['services'][$serviceName]['example'], "$serviceName-example", $manifest['services'][$serviceName]['patches']['example'] ?? []) : ['examples' => []];
+        $customErrorFactory = $manifest['services'][$serviceName]['error-factory'] ?? null;
 
         $operationNames = $this->getOperationNames($input->getArgument('operation'), $input->getOption('all'), $io, $definitionArray, $waiterArray, $manifest['services'][$serviceName]);
         if (\is_int($operationNames)) {
@@ -288,7 +289,7 @@ class GenerateCommand extends Command
         $definition = new ServiceDefinition($serviceName, $endpoints, $definitionArray, $documentationArray, $paginationArray, $waiterArray, $exampleArray, $manifest['services'][$serviceName]['hooks'] ?? [], $manifest['services'][$serviceName]['api-reference'] ?? null);
         $serviceGenerator = $this->generator->service($namespace = $manifest['services'][$serviceName]['namespace'] ?? sprintf('AsyncAws\\%s', $serviceName), $managedOperations);
 
-        $clientClass = $serviceGenerator->client()->generate($definition);
+        $clientClass = $serviceGenerator->client()->generate($definition, $customErrorFactory);
 
         foreach ($operationNames as $operationName) {
             if (null !== $operation = $definition->getOperation($operationName)) {

--- a/src/CodeGenerator/src/Generator/ClientGenerator.php
+++ b/src/CodeGenerator/src/Generator/ClientGenerator.php
@@ -51,7 +51,7 @@ class ClientGenerator
     /**
      * Update the API client with a constants function call.
      */
-    public function generate(ServiceDefinition $definition): ClassName
+    public function generate(ServiceDefinition $definition, ?string $customErrorFactory): ClassName
     {
         $className = $this->namespaceRegistry->getClient($definition);
         if (0 !== strpos($className->getFqdn(), 'AsyncAws\Core\\')) {
@@ -259,22 +259,26 @@ class ClientGenerator
                 ->setNullable(true)
         ;
 
-        switch ($definition->getProtocol()) {
-            case 'query':
-            case 'rest-xml':
-                $errorFactory = XmlAwsErrorFactory::class;
+        if (null !== $customErrorFactory) {
+            $errorFactory = $customErrorFactory;
+        } else {
+            switch ($definition->getProtocol()) {
+                case 'query':
+                case 'rest-xml':
+                    $errorFactory = XmlAwsErrorFactory::class;
 
-                break;
-            case 'rest-json':
-                $errorFactory = JsonRestAwsErrorFactory::class;
+                    break;
+                case 'rest-json':
+                    $errorFactory = JsonRestAwsErrorFactory::class;
 
-                break;
-            case 'json':
-                $errorFactory = JsonRpcAwsErrorFactory::class;
+                    break;
+                case 'json':
+                    $errorFactory = JsonRpcAwsErrorFactory::class;
 
-                break;
-            default:
-                throw new \LogicException(sprintf('Parser for "%s" is not implemented yet', $definition->getProtocol()));
+                    break;
+                default:
+                    throw new \LogicException(sprintf('Parser for "%s" is not implemented yet', $definition->getProtocol()));
+            }
         }
 
         $classBuilder->addUse(AwsErrorFactoryInterface::class);


### PR DESCRIPTION
The Amazon Incentives API implements a protocol compatible with the rest-xml AWS protocol _except_ for the representation of errors (they also provide a JSON protocol which is compatible with the rest-json AWS protocol _except_ the representation of errors but with a crappy representation of ThrottlingException that only returns `{"message": "Rate exceeded"}` without even a proper 429 status code).

This adds support for an optional `error-factory` entry in the manifest file allowing to force a specific implementation of the error factory. The provided class is still expected to have a constructor with no arguments like all the core factories due to the generated code.