### PR TITLE
Remove the internal tag from Core classes used in other packages

### DIFF
--- a/src/Core/src/AwsError/AwsError.php
+++ b/src/Core/src/AwsError/AwsError.php
@@ -2,9 +2,6 @@
 
 namespace AsyncAws\Core\AwsError;
 
-/**
- * @internal
- */
 final class AwsError
 {
     /**

--- a/src/Core/src/AwsError/AwsErrorFactoryFromResponseTrait.php
+++ b/src/Core/src/AwsError/AwsErrorFactoryFromResponseTrait.php
@@ -4,9 +4,6 @@ namespace AsyncAws\Core\AwsError;
 
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
-/**
- * @internal
- */
 trait AwsErrorFactoryFromResponseTrait
 {
     public function createFromResponse(ResponseInterface $response): AwsError

--- a/src/Core/src/AwsError/AwsErrorFactoryInterface.php
+++ b/src/Core/src/AwsError/AwsErrorFactoryInterface.php
@@ -4,9 +4,6 @@ namespace AsyncAws\Core\AwsError;
 
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
-/**
- * @internal
- */
 interface AwsErrorFactoryInterface
 {
     public function createFromResponse(ResponseInterface $response): AwsError;

--- a/src/Core/src/AwsError/JsonRestAwsErrorFactory.php
+++ b/src/Core/src/AwsError/JsonRestAwsErrorFactory.php
@@ -5,10 +5,7 @@ namespace AsyncAws\Core\AwsError;
 use AsyncAws\Core\Exception\UnexpectedValue;
 use AsyncAws\Core\Exception\UnparsableResponse;
 
-/**
- * @internal
- */
-class JsonRestAwsErrorFactory implements AwsErrorFactoryInterface
+final class JsonRestAwsErrorFactory implements AwsErrorFactoryInterface
 {
     use AwsErrorFactoryFromResponseTrait;
 

--- a/src/Core/src/AwsError/JsonRpcAwsErrorFactory.php
+++ b/src/Core/src/AwsError/JsonRpcAwsErrorFactory.php
@@ -5,10 +5,7 @@ namespace AsyncAws\Core\AwsError;
 use AsyncAws\Core\Exception\UnexpectedValue;
 use AsyncAws\Core\Exception\UnparsableResponse;
 
-/**
- * @internal
- */
-class JsonRpcAwsErrorFactory implements AwsErrorFactoryInterface
+final class JsonRpcAwsErrorFactory implements AwsErrorFactoryInterface
 {
     use AwsErrorFactoryFromResponseTrait;
 

--- a/src/Core/src/AwsError/XmlAwsErrorFactory.php
+++ b/src/Core/src/AwsError/XmlAwsErrorFactory.php
@@ -6,10 +6,7 @@ use AsyncAws\Core\Exception\RuntimeException;
 use AsyncAws\Core\Exception\UnexpectedValue;
 use AsyncAws\Core\Exception\UnparsableResponse;
 
-/**
- * @internal
- */
-class XmlAwsErrorFactory implements AwsErrorFactoryInterface
+final class XmlAwsErrorFactory implements AwsErrorFactoryInterface
 {
     use AwsErrorFactoryFromResponseTrait;
 

--- a/src/Core/src/Input.php
+++ b/src/Core/src/Input.php
@@ -6,8 +6,6 @@ namespace AsyncAws\Core;
  * Representation of a AWS Request.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
- *
- * @internal
  */
 abstract class Input
 {

--- a/src/Core/src/Request.php
+++ b/src/Core/src/Request.php
@@ -9,10 +9,8 @@ use AsyncAws\Core\Stream\RequestStream;
  * Representation of an HTTP Request.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
- *
- * @internal
  */
-class Request
+final class Request
 {
     /**
      * @var string

--- a/src/Core/src/RequestContext.php
+++ b/src/Core/src/RequestContext.php
@@ -9,10 +9,8 @@ use AsyncAws\Core\Exception\InvalidArgument;
  * Contains contextual information alongside a request.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
- *
- * @internal
  */
-class RequestContext
+final class RequestContext
 {
     public const AVAILABLE_OPTIONS = [
         'region' => true,

--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -31,10 +31,8 @@ use Symfony\Contracts\HttpClient\ResponseInterface;
  * The response provides a facade to manipulate HttpResponses.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
- *
- * @internal
  */
-class Response
+final class Response
 {
     /**
      * @var ResponseInterface

--- a/src/Core/src/Signer/SigningContext.php
+++ b/src/Core/src/Signer/SigningContext.php
@@ -5,11 +5,9 @@ namespace AsyncAws\Core\Signer;
 use AsyncAws\Core\Request;
 
 /**
- * @internal
- *
  * @author Jérémy Derussé <jeremy@derusse.com>
  */
-class SigningContext
+final class SigningContext
 {
     /**
      * @var Request

--- a/src/Core/src/Stream/FixedSizeStream.php
+++ b/src/Core/src/Stream/FixedSizeStream.php
@@ -8,8 +8,6 @@ use AsyncAws\Core\Exception\InvalidArgument;
  * A Stream decorator that return Chunk with the same exact size.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
- *
- * @internal
  */
 final class FixedSizeStream implements RequestStream
 {

--- a/src/Core/src/Stream/IterableStream.php
+++ b/src/Core/src/Stream/IterableStream.php
@@ -8,8 +8,6 @@ use AsyncAws\Core\Exception\InvalidArgument;
  * Convert an iterator into a Stream.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
- *
- * @internal
  */
 final class IterableStream implements ReadOnceResultStream, RequestStream
 {

--- a/src/Core/src/Stream/ReadOnceResultStream.php
+++ b/src/Core/src/Stream/ReadOnceResultStream.php
@@ -6,8 +6,6 @@ namespace AsyncAws\Core\Stream;
 
 /**
  * Marker for ResultStream that can be read only once.
- *
- * @internal
  */
 interface ReadOnceResultStream
 {

--- a/src/Core/src/Stream/RequestStream.php
+++ b/src/Core/src/Stream/RequestStream.php
@@ -7,8 +7,6 @@ namespace AsyncAws\Core\Stream;
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
  *
- * @internal
- *
  * @extends \IteratorAggregate<string>
  */
 interface RequestStream extends \IteratorAggregate

--- a/src/Core/src/Stream/RewindableStream.php
+++ b/src/Core/src/Stream/RewindableStream.php
@@ -12,8 +12,6 @@ namespace AsyncAws\Core\Stream;
  * - hash
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
- *
- * @internal
  */
 final class RewindableStream implements RequestStream
 {


### PR DESCRIPTION
Classes and interfaces from Core used in other packages should not be marked as `@internal` as they need to be covered by BC.

For a bunch of them, I made them final (when they were not already final) so that we don't need to support the use case of inheritance.