### PR TITLE
Ensure that all internal classes of the Code Generator are tagged

### DIFF
--- a/src/CodeGenerator/src/Command/GenerateCommand.php
+++ b/src/CodeGenerator/src/Command/GenerateCommand.php
@@ -30,6 +30,8 @@ use Symfony\Component\Console\Style\SymfonyStyle;
  * Update an existing response class or API client method.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * @internal
  */
 #[AsCommand(name: 'generate', description: 'Create or update API client methods.', aliases: ['update'])]
 class GenerateCommand extends Command

--- a/src/CodeGenerator/src/Definition/ErrorWaiterAcceptor.php
+++ b/src/CodeGenerator/src/Definition/ErrorWaiterAcceptor.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
+/**
+ * @internal
+ */
 class ErrorWaiterAcceptor extends WaiterAcceptor
 {
     public function getError(): ExceptionShape

--- a/src/CodeGenerator/src/Definition/Example.php
+++ b/src/CodeGenerator/src/Definition/Example.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
+/**
+ * @internal
+ */
 class Example
 {
     /**

--- a/src/CodeGenerator/src/Definition/ExceptionShape.php
+++ b/src/CodeGenerator/src/Definition/ExceptionShape.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
+/**
+ * @internal
+ */
 class ExceptionShape extends StructureShape
 {
     public function hasError(): bool

--- a/src/CodeGenerator/src/Definition/Hook.php
+++ b/src/CodeGenerator/src/Definition/Hook.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
+/**
+ * @internal
+ */
 class Hook
 {
     /**

--- a/src/CodeGenerator/src/Definition/ListMember.php
+++ b/src/CodeGenerator/src/Definition/ListMember.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
+/**
+ * @internal
+ */
 class ListMember extends Member
 {
 }

--- a/src/CodeGenerator/src/Definition/ListShape.php
+++ b/src/CodeGenerator/src/Definition/ListShape.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
+/**
+ * @internal
+ */
 class ListShape extends Shape
 {
     public function getMember(): ListMember

--- a/src/CodeGenerator/src/Definition/MapKey.php
+++ b/src/CodeGenerator/src/Definition/MapKey.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
+/**
+ * @internal
+ */
 class MapKey extends Member
 {
 }

--- a/src/CodeGenerator/src/Definition/MapShape.php
+++ b/src/CodeGenerator/src/Definition/MapShape.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
+/**
+ * @internal
+ */
 class MapShape extends Shape
 {
     public function getValue(): MapValue

--- a/src/CodeGenerator/src/Definition/MapValue.php
+++ b/src/CodeGenerator/src/Definition/MapValue.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
+/**
+ * @internal
+ */
 class MapValue extends Member
 {
 }

--- a/src/CodeGenerator/src/Definition/Member.php
+++ b/src/CodeGenerator/src/Definition/Member.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
+/**
+ * @internal
+ */
 class Member
 {
     /**

--- a/src/CodeGenerator/src/Definition/Operation.php
+++ b/src/CodeGenerator/src/Definition/Operation.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
+/**
+ * @internal
+ */
 class Operation
 {
     /**

--- a/src/CodeGenerator/src/Definition/Pagination.php
+++ b/src/CodeGenerator/src/Definition/Pagination.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
+/**
+ * @internal
+ */
 class Pagination
 {
     /**

--- a/src/CodeGenerator/src/Definition/ServiceDefinition.php
+++ b/src/CodeGenerator/src/Definition/ServiceDefinition.php
@@ -10,6 +10,8 @@ use AsyncAws\CodeGenerator\Generator\GeneratorHelper;
  * A wrapper for the service definition array.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * @internal
  */
 class ServiceDefinition
 {

--- a/src/CodeGenerator/src/Definition/Shape.php
+++ b/src/CodeGenerator/src/Definition/Shape.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
+/**
+ * @internal
+ */
 class Shape
 {
     /**

--- a/src/CodeGenerator/src/Definition/StructureMember.php
+++ b/src/CodeGenerator/src/Definition/StructureMember.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
+/**
+ * @internal
+ */
 class StructureMember extends Member
 {
     public function getName(): string

--- a/src/CodeGenerator/src/Definition/StructureShape.php
+++ b/src/CodeGenerator/src/Definition/StructureShape.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
+/**
+ * @internal
+ */
 class StructureShape extends Shape
 {
     /**

--- a/src/CodeGenerator/src/Definition/Waiter.php
+++ b/src/CodeGenerator/src/Definition/Waiter.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
+/**
+ * @internal
+ */
 class Waiter
 {
     /**

--- a/src/CodeGenerator/src/Definition/WaiterAcceptor.php
+++ b/src/CodeGenerator/src/Definition/WaiterAcceptor.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Definition;
 
+/**
+ * @internal
+ */
 class WaiterAcceptor
 {
     public const MATCHER_STATUS = 'status';

--- a/src/CodeGenerator/src/File/Cache.php
+++ b/src/CodeGenerator/src/File/Cache.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace AsyncAws\CodeGenerator\File;
 
 /**
- * Provides methods to store and load cached data in a multi-concurent system.
+ * Provides methods to store and load cached data in a multi-concurrent system.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal
  */
 class Cache
 {

--- a/src/CodeGenerator/src/File/CachedFileDumper.php
+++ b/src/CodeGenerator/src/File/CachedFileDumper.php
@@ -6,9 +6,11 @@ namespace AsyncAws\CodeGenerator\File;
 
 /**
  * DumpFile only when it has not been modified.
- * This class takes into account that a post-process can alter the content of the file (php-cs-fier).
+ * This class takes into account that a post-process can alter the content of the file (php-cs-fixer).
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal
  */
 class CachedFileDumper extends FileDumper
 {

--- a/src/CodeGenerator/src/File/ClassWriter.php
+++ b/src/CodeGenerator/src/File/ClassWriter.php
@@ -10,6 +10,8 @@ use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassBuilder;
  * Takes a namespace definition and create a file form it.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * @internal
  */
 class ClassWriter
 {

--- a/src/CodeGenerator/src/File/ComposerWriter.php
+++ b/src/CodeGenerator/src/File/ComposerWriter.php
@@ -8,6 +8,8 @@ namespace AsyncAws\CodeGenerator\File;
  * Update composer.json requirements.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal
  */
 class ComposerWriter
 {

--- a/src/CodeGenerator/src/File/FileDumper.php
+++ b/src/CodeGenerator/src/File/FileDumper.php
@@ -12,6 +12,8 @@ use Symfony\Component\Process\Process;
  * Dump and validate a php file.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * @internal
  */
 class FileDumper
 {

--- a/src/CodeGenerator/src/Generator/ApiGenerator.php
+++ b/src/CodeGenerator/src/Generator/ApiGenerator.php
@@ -13,6 +13,8 @@ use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassRegistry;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal
  */
 class ApiGenerator
 {

--- a/src/CodeGenerator/src/Generator/Composer/RequirementsRegistry.php
+++ b/src/CodeGenerator/src/Generator/Composer/RequirementsRegistry.php
@@ -2,6 +2,9 @@
 
 namespace AsyncAws\CodeGenerator\Generator\Composer;
 
+/**
+ * @internal
+ */
 class RequirementsRegistry
 {
     /**

--- a/src/CodeGenerator/src/Generator/Naming/ClassName.php
+++ b/src/CodeGenerator/src/Generator/Naming/ClassName.php
@@ -6,6 +6,8 @@ namespace AsyncAws\CodeGenerator\Generator\Naming;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal
  */
 final class ClassName
 {

--- a/src/CodeGenerator/src/Generator/Naming/NamespaceRegistry.php
+++ b/src/CodeGenerator/src/Generator/Naming/NamespaceRegistry.php
@@ -11,6 +11,8 @@ use AsyncAws\CodeGenerator\Definition\Waiter;
 
 /**
  * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal
  */
 final class NamespaceRegistry
 {

--- a/src/CodeGenerator/src/Generator/PhpGenerator/ClassBuilder.php
+++ b/src/CodeGenerator/src/Generator/PhpGenerator/ClassBuilder.php
@@ -15,6 +15,8 @@ use Nette\PhpGenerator\Property;
  * Wrapper for Nette PhpNamespace and ClassType.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal
  */
 class ClassBuilder
 {

--- a/src/CodeGenerator/src/Generator/PhpGenerator/ClassFactory.php
+++ b/src/CodeGenerator/src/Generator/PhpGenerator/ClassFactory.php
@@ -20,6 +20,8 @@ use Nette\PhpGenerator\Property;
  * This is a slightly modified version of \Nette\PhpGenerator\Factory
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * @internal
  */
 class ClassFactory
 {

--- a/src/CodeGenerator/src/Generator/PhpGenerator/ClassRegistry.php
+++ b/src/CodeGenerator/src/Generator/PhpGenerator/ClassRegistry.php
@@ -11,6 +11,8 @@ use Nette\PhpGenerator\PhpNamespace;
  * Generate a ClassBuilder and maintains the list of generated classes.
  *
  * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal
  */
 class ClassRegistry
 {

--- a/src/CodeGenerator/src/Generator/RequestSerializer/Serializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/Serializer.php
@@ -11,6 +11,8 @@ use AsyncAws\CodeGenerator\Definition\StructureShape;
  * This will generate code to serialize request Input to a string. Ie to create request body.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * @internal
  */
 interface Serializer
 {

--- a/src/CodeGenerator/src/Generator/ResponseParser/Parser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/Parser.php
@@ -10,6 +10,8 @@ use AsyncAws\CodeGenerator\Definition\StructureShape;
  * This will generate code to parse a HTTP response body into a Result.
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
+ *
+ * @internal
  */
 interface Parser
 {

--- a/src/CodeGenerator/src/Generator/ServiceGenerator.php
+++ b/src/CodeGenerator/src/Generator/ServiceGenerator.php
@@ -16,6 +16,8 @@ use AsyncAws\CodeGenerator\Generator\ResponseParser\ParserProvider;
  *
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  * @author Jérémy Derussé <jeremy@derusse.com>
+ *
+ * @internal
  */
 class ServiceGenerator
 {


### PR DESCRIPTION
Until now, the usage of `@internal` is inconsistent in the CodeGenerator. Some parts are using it while some others are not while they are also internal.
This ensures that all classes are tagged as internal except for the ones needed as an entrypoint when using it out of tree (i.e. in this PR, everything is internal as #1484 is not merged yet).