### PR TITLE
Remove the unused generated classes during code generation

### DIFF
--- a/src/CodeGenerator/composer.json
+++ b/src/CodeGenerator/composer.json
@@ -12,6 +12,7 @@
         "nette/php-generator": "^3.6.4",
         "nette/utils": "^3.0",
         "symfony/console": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/finder": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "symfony/http-client": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "symfony/http-client-contracts": "^1.0 || ^2.0 || ^3.0",
         "symfony/process": "^4.4 || ^5.0 || ^6.0 || ^7.0",

--- a/src/CodeGenerator/src/File/UnusedClassCleaner.php
+++ b/src/CodeGenerator/src/File/UnusedClassCleaner.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace AsyncAws\CodeGenerator\File;
+
+use AsyncAws\CodeGenerator\Definition\Shape;
+use AsyncAws\CodeGenerator\Definition\StructureShape;
+use AsyncAws\CodeGenerator\File\Location\DirectoryResolver;
+use AsyncAws\CodeGenerator\Generator\Naming\ClassName;
+use AsyncAws\CodeGenerator\Generator\Naming\NamespaceRegistry;
+use AsyncAws\CodeGenerator\Generator\PhpGenerator\ClassBuilder;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * @internal
+ */
+final class UnusedClassCleaner
+{
+    /**
+     * @var DirectoryResolver
+     */
+    private $directoryResolver;
+
+    public function __construct(DirectoryResolver $directoryResolver)
+    {
+        $this->directoryResolver = $directoryResolver;
+    }
+
+    /**
+     * @param iterable<ClassBuilder> $generatedClasses
+     */
+    public function cleanUnusedClasses(NamespaceRegistry $namespaceRegistry, iterable $generatedClasses): void
+    {
+        $usedClassNames = [];
+        foreach ($generatedClasses as $class) {
+            $usedClassNames[$class->getClassName()->getFqdn()] = true;
+        }
+
+        foreach ($this->getCleanableNamespaces($namespaceRegistry) as $className) {
+            $namespace = $className->getNamespace();
+            $directory = $this->directoryResolver->resolveDirectory($namespace);
+
+            if (!is_dir($directory)) {
+                continue;
+            }
+
+            $finder = (new Finder())
+                ->name('*.php')
+                ->files()
+                ->in($directory);
+
+            foreach ($finder as $file) {
+                $fileClassName = $namespace . '\\' . str_replace('/', '\\', substr($file->getRelativePathname(), 0, -4));
+
+                if (isset($usedClassNames[$fileClassName])) {
+                    continue;
+                }
+
+                unlink($file->getPathname());
+            }
+        }
+    }
+
+    /**
+     * @return iterable<ClassName>
+     */
+    private function getCleanableNamespaces(NamespaceRegistry $namespaceRegistry): iterable
+    {
+        $fakeLocator = function () {
+            throw new \BadMethodCallException('Unexpected call on the fake shape');
+        };
+
+        $fakeStructureShape = Shape::create('AsyncAwsFakeShape', ['type' => 'structure'], $fakeLocator, $fakeLocator);
+        \assert($fakeStructureShape instanceof StructureShape);
+
+        yield $namespaceRegistry->getEnum(Shape::create('AsyncAwsFakeShape', ['type' => 'string'], $fakeLocator, $fakeLocator));
+        yield $namespaceRegistry->getException($fakeStructureShape);
+        yield $namespaceRegistry->getInput($fakeStructureShape);
+        yield $namespaceRegistry->getResult($fakeStructureShape);
+        yield $namespaceRegistry->getObject($fakeStructureShape);
+    }
+}

--- a/src/CodeGenerator/src/Generator/ServiceGenerator.php
+++ b/src/CodeGenerator/src/Generator/ServiceGenerator.php
@@ -191,4 +191,9 @@ class ServiceGenerator
     {
         return $this->object ?? $this->object = new ObjectGenerator($this->classRegistry, $this->namespaceRegistry, $this->requirementsRegistry, $this->managedOperations, $this->type(), $this->enum());
     }
+
+    public function getNamespaceRegistry(): NamespaceRegistry
+    {
+        return $this->namespaceRegistry;
+    }
 }

--- a/src/CodeGenerator/src/Runner.php
+++ b/src/CodeGenerator/src/Runner.php
@@ -8,6 +8,7 @@ use AsyncAws\CodeGenerator\File\CachedFileDumper;
 use AsyncAws\CodeGenerator\File\ClassWriter;
 use AsyncAws\CodeGenerator\File\ComposerWriter;
 use AsyncAws\CodeGenerator\File\Location\DirectoryResolver;
+use AsyncAws\CodeGenerator\File\UnusedClassCleaner;
 use AsyncAws\CodeGenerator\Generator\ApiGenerator;
 use Symfony\Component\Console\Application;
 
@@ -18,7 +19,7 @@ final class Runner
         $application = new Application('AsyncAws', '0.1.0');
 
         $cache = new Cache($cacheDirectory);
-        $command = new GenerateCommand($manifest, $cache, new ClassWriter($directoryResolver, new CachedFileDumper($cache)), new ComposerWriter($directoryResolver), new ApiGenerator());
+        $command = new GenerateCommand($manifest, $cache, new ClassWriter($directoryResolver, new CachedFileDumper($cache)), new ComposerWriter($directoryResolver), new ApiGenerator(), new UnusedClassCleaner($directoryResolver));
         $application->add($command);
         $application->setDefaultCommand($command->getName(), true);
 


### PR DESCRIPTION
This ensures that operations that are attempted to be added and then reverted don't leak generated objects.
Tests are not cleaned automatically because they are not fully managed by the generator.

Refs #1482 