### PR TITLE
Refactor the flysystem adapter to use private constants

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -21,7 +21,6 @@ parameters:
         - '#Method AsyncAws\\[^:]+::[^(]+\(\) should return array<[^>]+> but returns array<int(\|string)?, string>\.$#'
         - '#PHPDoc tag @throws with type Psr\\Cache\\CacheException is not subtype of Throwable$#'
         - '#^Dead catch - JsonException is never thrown in the try block\.$#'
-        - '#^Unsafe access to private property AsyncAws\\Flysystem\\S3\\AsyncAwsS3Adapter::\$[^ ]+ through static::\.$#'
         - '#^Method AsyncAws\\[^\\]+\\Result\\[^ ]+ should return #'
         - '#^Parameter \#1 \$input of class AsyncAws\\[^\\]+\\ValueObject\\[^ ]+ constructor expects #'
         - '#^Argument 1 of AsyncAws\\Scheduler\\ValueObject\\ScheduleGroupSummary::__construct expects #'

--- a/src/Integration/Flysystem/S3/src/AsyncAwsS3Adapter.php
+++ b/src/Integration/Flysystem/S3/src/AsyncAwsS3Adapter.php
@@ -23,7 +23,7 @@ class AsyncAwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
 {
     public const PUBLIC_GRANT_URI = 'http://acs.amazonaws.com/groups/global/AllUsers';
 
-    private static $resultMap = [
+    private const RESULT_MAP = [
         'Body' => 'contents',
         'ContentLength' => 'size',
         'ContentType' => 'mimetype',
@@ -34,7 +34,7 @@ class AsyncAwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
         'VersionId' => 'versionid',
     ];
 
-    private static $metaOptions = [
+    private const META_OPTIONS = [
         'ACL',
         'CacheControl',
         'ContentDisposition',
@@ -496,7 +496,7 @@ class AsyncAwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
             $options['ContentType'] = $mimetype;
         }
 
-        foreach (static::$metaOptions as $option) {
+        foreach (self::META_OPTIONS as $option) {
             if (!$config->has($option)) {
                 continue;
             }
@@ -537,9 +537,9 @@ class AsyncAwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
             }
         }
 
-        if ($this->isOnlyDir($result['path'])) {
+        if ($this->isOnlyDir($path)) {
             $result['type'] = 'dir';
-            $result['path'] = rtrim($result['path'], '/');
+            $result['path'] = rtrim($path, '/');
 
             return $result;
         }
@@ -571,7 +571,7 @@ class AsyncAwsS3Adapter extends AbstractAdapter implements CanOverwriteFiles
     private function resultMap(object $object): array
     {
         $result = [];
-        foreach (static::$resultMap as $from => $to) {
+        foreach (self::RESULT_MAP as $from => $to) {
             $methodName = 'get' . $from;
             if (method_exists($object, $methodName)) {
                 $result[$to] = \call_user_func([$object, $methodName]);


### PR DESCRIPTION
This resolves some errors reported by phpstan at level 6.
The remaining ones are all about missing precise types for arrays, because the Flysystem API does not describe them. However, as I plan to disable this check when bumping the phpstan level (because our generated code is also incompatible with this check), I'm fine with those for now.

My refactoring also stops using `static::` to access private elements, which breaks when extending the class (phpstan is able to detect this, but the errors were ignored instead of fixing them).