### PR TITLE
Add signature for locators in the code generator

### DIFF
--- a/src/CodeGenerator/src/Definition/ErrorWaiterAcceptor.php
+++ b/src/CodeGenerator/src/Definition/ErrorWaiterAcceptor.php
@@ -11,6 +11,12 @@ class ErrorWaiterAcceptor extends WaiterAcceptor
 {
     public function getError(): ExceptionShape
     {
-        return ($this->shapeLocator)($this->data['expected']);
+        $shape = ($this->shapeLocator)($this->data['expected']);
+
+        if (!$shape instanceof ExceptionShape) {
+            throw new \InvalidArgumentException(sprintf('The error "%s" of the waiter acceptor should have an Exception shape.', $this->data['expected']));
+        }
+
+        return $shape;
     }
 }

--- a/src/CodeGenerator/src/Definition/Member.php
+++ b/src/CodeGenerator/src/Definition/Member.php
@@ -15,10 +15,13 @@ class Member
     protected $data;
 
     /**
-     * @var \Closure
+     * @var \Closure(string, Member|null=, array<string, mixed>=): Shape
      */
     protected $shapeLocator;
 
+    /**
+     * @param \Closure(string, Member|null=, array<string, mixed>=): Shape $shapeLocator
+     */
     public function __construct(array $data, \Closure $shapeLocator)
     {
         if (isset($data['endpointdiscoveryid'])) {

--- a/src/CodeGenerator/src/Definition/ServiceDefinition.php
+++ b/src/CodeGenerator/src/Definition/ServiceDefinition.php
@@ -169,7 +169,7 @@ class ServiceDefinition
     /**
      * @param array<string, mixed> $extra
      */
-    private function getShape(string $name, ?Member $member, array $extra): ?Shape
+    private function getShape(string $name, ?Member $member, array $extra): Shape
     {
         if (isset($this->definition['shapes'][$name])) {
             $documentationMember = null;
@@ -181,11 +181,11 @@ class ServiceDefinition
             return Shape::create($name, $this->definition['shapes'][$name] + ['_documentation_main' => $documentationMain, '_documentation_member' => $documentationMember] + $extra, $this->createClosureToFindShape(), $this->createClosureToService());
         }
 
-        return null;
+        throw new \InvalidArgumentException(sprintf('The shape "%s" does not exist.', $name));
     }
 
     /**
-     * @return \Closure(string, ?Member=, array<string, mixed>=): ?Shape
+     * @return \Closure(string, ?Member=, array<string, mixed>=): Shape
      */
     private function createClosureToFindShape(): \Closure
     {
@@ -209,14 +209,20 @@ class ServiceDefinition
     }
 
     /**
-     * @return \Closure(string): ?Operation
+     * @return \Closure(string): Operation
      */
     private function createClosureToFindOperation(): \Closure
     {
         $definition = $this;
 
-        return \Closure::fromCallable(function (string $name) use ($definition): ?Operation {
-            return $definition->getOperation($name);
+        return \Closure::fromCallable(function (string $name) use ($definition): Operation {
+            $operation = $definition->getOperation($name);
+
+            if (null === $operation) {
+                throw new \InvalidArgumentException(sprintf('The operation "%s" is not defined.', $name));
+            }
+
+            return $operation;
         });
     }
 }

--- a/src/CodeGenerator/src/Definition/Shape.php
+++ b/src/CodeGenerator/src/Definition/Shape.php
@@ -15,12 +15,12 @@ class Shape
     protected $data;
 
     /**
-     * @var \Closure
+     * @var \Closure(string, Member|null=, array<string, mixed>=): Shape
      */
     protected $shapeLocator;
 
     /**
-     * @var \Closure
+     * @var \Closure(): ServiceDefinition
      */
     protected $serviceLocator;
 
@@ -33,6 +33,10 @@ class Shape
     {
     }
 
+    /**
+     * @param \Closure(string, Member|null=, array<string, mixed>=): Shape $shapeLocator
+     * @param \Closure(): ServiceDefinition $serviceLocator
+     */
     public static function create(string $name, array $data, \Closure $shapeLocator, \Closure $serviceLocator): Shape
     {
         switch ($data['type']) {

--- a/src/CodeGenerator/src/Definition/Waiter.php
+++ b/src/CodeGenerator/src/Definition/Waiter.php
@@ -15,15 +15,19 @@ class Waiter
     private $data;
 
     /**
-     * @var \Closure
+     * @var \Closure(string): Operation
      */
     private $operationLocator;
 
     /**
-     * @var \Closure
+     * @var \Closure(string, Member|null=, array<string, mixed>=): Shape
      */
     private $shapeLocator;
 
+    /**
+     * @param \Closure(string): Operation $operationLocator
+     * @param \Closure(string, Member|null=, array<string, mixed>=): Shape $shapeLocator
+     */
     public function __construct(array $data, \Closure $operationLocator, \Closure $shapeLocator)
     {
         $this->data = $data;

--- a/src/CodeGenerator/src/Definition/WaiterAcceptor.php
+++ b/src/CodeGenerator/src/Definition/WaiterAcceptor.php
@@ -23,7 +23,7 @@ class WaiterAcceptor
     protected $data;
 
     /**
-     * @var \Closure
+     * @var \Closure(string, Member|null=, array<string, mixed>=): Shape
      */
     protected $shapeLocator;
 
@@ -31,6 +31,9 @@ class WaiterAcceptor
     {
     }
 
+    /**
+     * @param \Closure(string, Member|null=, array<string, mixed>=): Shape $shapeLocator
+     */
     public static function create(array $data, \Closure $shapeLocator): self
     {
         switch ($data['matcher']) {


### PR DESCRIPTION
This also provides better failure mode in case of invalid metadata instead of failing with a TypeError (static analysis tools don't like code paths that can fail with a type error).