### PR TITLE
Avoid generating populator for the exception fields

### DIFF
--- a/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
@@ -177,6 +177,11 @@ class PopulatorGenerator
         $nonHeaders = [];
         $body = '';
         foreach ($shape->getMembers() as $member) {
+            // Avoid conflicts with PHP properties. Those AWS members are included in the AWSError anyway.
+            if ($forException && \in_array(strtolower($member->getName()), ['code', 'message'])) {
+                continue;
+            }
+
             if ('header' !== $member->getLocation()) {
                 $nonHeaders[$member->getName()] = $member;
 


### PR DESCRIPTION
Some AWS services define the Message member of the exception shapes, even though it is part of the standard AWS exception representation already. We want to keep the message containing the full parsed information.