### PR TITLE
Add missing types in the generator

### DIFF
--- a/src/CodeGenerator/src/Command/GenerateCommand.php
+++ b/src/CodeGenerator/src/Command/GenerateCommand.php
@@ -39,6 +39,9 @@ class GenerateCommand extends Command
 {
     protected static $defaultName = 'generate';
 
+    /**
+     * @var array|null
+     */
     private $manifest;
 
     /**
@@ -124,6 +127,9 @@ class GenerateCommand extends Command
         return 0;
     }
 
+    /**
+     * @return array|int
+     */
     private function generateServicesParallel(SymfonyStyle $io, InputInterface $input, ConsoleOutputInterface $output, array $manifest, array $endpoints, array $serviceNames)
     {
         $progress = (new SymfonyStyle($input, $output->section()))->createProgressBar();
@@ -278,6 +284,9 @@ class GenerateCommand extends Command
         return $serviceEndpoints;
     }
 
+    /**
+     * @return array|int
+     */
     private function generateService(SymfonyStyle $io, InputInterface $input, array $manifest, array $endpoints, string $serviceName)
     {
         $definitionArray = $this->loadFile($manifest['services'][$serviceName]['source'], "$serviceName-source", $manifest['services'][$serviceName]['patches']['source'] ?? []);

--- a/src/CodeGenerator/src/Definition/ServiceDefinition.php
+++ b/src/CodeGenerator/src/Definition/ServiceDefinition.php
@@ -20,18 +20,39 @@ class ServiceDefinition
      */
     private $name;
 
+    /**
+     * @var array
+     */
     private $endpoints;
 
+    /**
+     * @var array
+     */
     private $definition;
 
+    /**
+     * @var array
+     */
     private $documentation;
 
+    /**
+     * @var array
+     */
     private $pagination;
 
+    /**
+     * @var array
+     */
     private $waiter;
 
+    /**
+     * @var array
+     */
     private $example;
 
+    /**
+     * @var array
+     */
     private $hooks;
 
     /**


### PR DESCRIPTION
This adds the missing types in the CodeGenerator to prepare enabling the level 6 of phpstan except for the iterable type in the array (which I will keep disabled).

For now, I decided to avoid defining the array shapes for those Definition classes as it becomes quite complex (I actually have a branch locally with such an attempt).