### PR TITLE
Clean code generator

### DIFF
--- a/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
@@ -99,7 +99,7 @@ class TypeGenerator
                     $classNames[] = $className = $this->namespaceRegistry->getEnum($memberShape);
                     $param = $className->getName() . '::*';
                 } else {
-                    $param = $this->getNativePhpType($param);
+                    $param = $this->getNativePhpType($memberShape->getType());
                 }
             }
 

--- a/src/CodeGenerator/src/Generator/Naming/NamespaceRegistry.php
+++ b/src/CodeGenerator/src/Generator/Naming/NamespaceRegistry.php
@@ -51,7 +51,7 @@ final class NamespaceRegistry
      */
     private $exceptionNamespace;
 
-    public function __construct(string $baseNamespace, ?string $inputNamespace = '\\Input', ?string $resultNamespace = '\\Result', ?string $testNamespace = '\\Tests', ?string $enumNamespace = '\\Enum', ?string $objectNamespace = '\\ValueObject', ?string $exceptionNamespace = '\\Exception')
+    public function __construct(string $baseNamespace, string $inputNamespace = '\\Input', string $resultNamespace = '\\Result', string $testNamespace = '\\Tests', string $enumNamespace = '\\Enum', string $objectNamespace = '\\ValueObject', string $exceptionNamespace = '\\Exception')
     {
         $this->baseNamespace = $baseNamespace;
         $this->inputNamespace = '\\' === $inputNamespace[0] ? $baseNamespace . $inputNamespace : $inputNamespace;

--- a/src/CodeGenerator/src/Generator/OperationGenerator.php
+++ b/src/CodeGenerator/src/Generator/OperationGenerator.php
@@ -72,7 +72,7 @@ class OperationGenerator
     private $exceptionGenerator;
 
     /**
-     * @var ClassName[]
+     * @var array<string, true>
      */
     private $generated = [];
 

--- a/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
@@ -46,6 +46,11 @@ class RestJsonParser implements Parser
     private $functions = [];
 
     /**
+     * @var array<string, true>
+     */
+    private $generatedFunctions = [];
+
+    /**
      * @var list<ClassName>
      */
     private $imports = [];
@@ -65,6 +70,7 @@ class RestJsonParser implements Parser
 
         $properties = [];
         $this->functions = [];
+        $this->generatedFunctions = [];
         $this->imports = [];
         foreach ($shape->getMembers() as $member) {
             if (\in_array($member->getLocation(), ['header', 'headers'])) {
@@ -205,9 +211,9 @@ class RestJsonParser implements Parser
     private function parseResponseStructure(StructureShape $shape, string $input, bool $required): string
     {
         $functionName = 'populateResult' . ucfirst($shape->getName());
-        if (!isset($this->functions[$functionName])) {
+        if (!isset($this->generatedFunctions[$functionName])) {
             // prevent recursion
-            $this->functions[$functionName] = true;
+            $this->generatedFunctions[$functionName] = true;
 
             $properties = [];
             foreach ($shape->getMembers() as $member) {
@@ -287,9 +293,9 @@ class RestJsonParser implements Parser
     {
         $shapeMember = $shape->getMember();
         $functionName = 'populateResult' . ucfirst($shape->getName());
-        if (!isset($this->functions[$functionName])) {
+        if (!isset($this->generatedFunctions[$functionName])) {
             // prevent recursion
-            $this->functions[$functionName] = true;
+            $this->generatedFunctions[$functionName] = true;
 
             if ($shapeMember->getShape() instanceof StructureShape || $shapeMember->getShape() instanceof ListShape || $shapeMember->getShape() instanceof MapShape) {
                 $listAccessorRequired = true;
@@ -332,9 +338,9 @@ class RestJsonParser implements Parser
     {
         $shapeValue = $shape->getValue();
         $functionName = 'populateResult' . ucfirst($shape->getName());
-        if (!isset($this->functions[$functionName])) {
+        if (!isset($this->generatedFunctions[$functionName])) {
             // prevent recursion
-            $this->functions[$functionName] = true;
+            $this->generatedFunctions[$functionName] = true;
 
             if (null === $locationName = $shape->getKey()->getLocationName()) {
                 // We need to use array keys


### PR DESCRIPTION
I attempted to run Psalm on the CodeGenerator folder. While it reports lots of things we don't want (like not understand some usages of references), it found 2 valid things:

- NamespaceRegistry defines all its optional arguments as nullable but does not account for `null` values. As we currently always rely on the default value (and this is an internal class), I made the argument non-nullable
- the TypeGenerator was using `$param` which might not be defined yet or be defined by a previous iteration of the loop. This could lead to actual bugs in the code generator (but fortunately, the existing services were not impacted)