### PR TITLE
Increase the phpstan level to level 6

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -2,6 +2,7 @@ parameters:
     level: 5
     treatPhpDocTypesAsCertain: false
     checkMissingCallableSignature: true
+    checkMissingIterableValueType: false
     reportUnmatchedIgnoredErrors: false
     paths:
         - src

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,12 +15,6 @@ parameters:
         - src/Integration/Laravel/Filesystem/src/AsyncAwsFilesystemAdapter.php
 
     ignoreErrors:
-        - '#^Parameter \#1 \$input of class AsyncAws\\[^\\]+\\ValueObject\\[^ ]+ constructor expects (array\(\)\|)?array\([^\)]+\), array\([^\)]+\) given\.#'
         - '#^Parameter \#1 \$input of method AsyncAws\\DynamoDb\\DynamoDbClient::\w+\(\) expects array\{[^\)]+\}\|AsyncAws\\DynamoDb\\Input\\\w+Input, array\{[^\)]+\} given\.#'
-        - '#Method AsyncAws\\[^:]+::[^(]+\(\) should return array<[^>]+> but returns array<int(\|string)?, string>\.$#'
         - '#PHPDoc tag @throws with type Psr\\Cache\\CacheException is not subtype of Throwable$#'
         - '#^Dead catch - JsonException is never thrown in the try block\.$#'
-        - '#^Method AsyncAws\\[^\\]+\\Result\\[^ ]+ should return #'
-        - '#^Parameter \#1 \$input of class AsyncAws\\[^\\]+\\ValueObject\\[^ ]+ constructor expects #'
-        - '#^Argument 1 of AsyncAws\\Scheduler\\ValueObject\\ScheduleGroupSummary::__construct expects #'
-        - '#^Property AsyncAws\\Sqs\\Input\\SendMessageRequest::\$messageSystemAttributes \([^)]+\) does not accept non-empty-array#'

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-    level: 5
+    level: 6
     treatPhpDocTypesAsCertain: false
     checkMissingCallableSignature: true
     checkMissingIterableValueType: false

--- a/src/Core/src/AwsError/XmlAwsErrorFactory.php
+++ b/src/Core/src/AwsError/XmlAwsErrorFactory.php
@@ -13,11 +13,6 @@ final class XmlAwsErrorFactory implements AwsErrorFactoryInterface
     public function createFromContent(string $content, array $headers): AwsError
     {
         try {
-            /**
-             * @phpstan-ignore-next-line
-             *
-             * @psalm-suppress InvalidArgument
-             */
             set_error_handler(static function ($errno, $errstr) {
                 throw new RuntimeException($errstr, $errno);
             });

--- a/src/Integration/Monolog/CloudWatch/src/CloudWatchLogsHandler.php
+++ b/src/Integration/Monolog/CloudWatch/src/CloudWatchLogsHandler.php
@@ -104,8 +104,6 @@ class CloudWatchLogsHandler extends AbstractProcessingHandler
         $this->options = $options;
 
         /**
-         * @phpstan-ignore-next-line
-         *
          * @psalm-suppress ArgumentTypeCoercion
          */
         parent::__construct($level, $bubble);

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -2464,7 +2464,7 @@ class S3Client extends AbstractApi
             $bucketLen < 3 || $bucketLen > 63
             || filter_var($bucket, \FILTER_VALIDATE_IP) // Cannot look like an IP address
             || !preg_match('/^[a-z0-9]([a-z0-9\-]*[a-z0-9])?$/', $bucket) // Bucket cannot have dot (because of TLS)
-            || filter_var(parse_url($configuration->get('endpoint'), \PHP_URL_HOST), \FILTER_VALIDATE_IP) // Custom endpoint cannot look like an IP address @phpstan-ignore-line
+            || filter_var(parse_url($configuration->get('endpoint'), \PHP_URL_HOST), \FILTER_VALIDATE_IP) // Custom endpoint cannot look like an IP address
             || filter_var($configuration->get('pathStyleEndpoint'), \FILTER_VALIDATE_BOOLEAN)
         ) {
             return parent::getEndpoint($uri, $query, $region);


### PR DESCRIPTION
This keeps `checkMissingIterableValueType` disabled as our generated code does not provide iterable value types for the nested array shapes (if we were to do it, we should probably rely on phpstan type aliases to avoid increasing the size of the phpdoc too much, but this gets more complex even though it would actually bring full type safety for constructors).