### PR TITLE
Enable more psalm rules

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -32,40 +32,21 @@
 
         <!-- types defined only in docblock are not considered as 100% trusted -->
         <RedundantCastGivenDocblockType errorLevel="info" />
-
-        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
-
-        <DeprecatedMethod errorLevel="info" />
-        <DeprecatedProperty errorLevel="info" />
-        <DeprecatedClass errorLevel="info" />
-        <DeprecatedConstant errorLevel="info" />
-        <DeprecatedFunction errorLevel="info" />
-        <DeprecatedInterface errorLevel="info" />
-        <DeprecatedTrait errorLevel="info" />
-
-        <InternalMethod errorLevel="info" />
-        <InternalProperty errorLevel="info" />
-        <InternalClass errorLevel="info" />
-
-        <MissingClosureReturnType errorLevel="info" />
-        <MissingReturnType errorLevel="info" />
-        <MissingPropertyType errorLevel="info" />
-
-        <PropertyNotSetInConstructor errorLevel="info" />
-        <MissingConstructor errorLevel="info" />
-        <MissingClosureParamType errorLevel="info" />
-        <MissingParamType errorLevel="info" />
-
-        <RedundantCondition errorLevel="info" />
-
         <DocblockTypeContradiction errorLevel="info" />
         <RedundantConditionGivenDocblockType errorLevel="info" />
 
-        <UnresolvableInclude errorLevel="info" />
+        <!-- Results are lazy-loading their properties with delayed initialization, which is not detected by Psalm. -->
+        <PropertyNotSetInConstructor errorLevel="info" />
 
-        <RawObjectIteration errorLevel="info" />
+        <!-- BC layer needs to be able to call our own deprecated method -->
 
-        <InvalidStringClass errorLevel="info" />
+        <DeprecatedMethod errorLevel="info" />
+
+        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
+
+        <MissingClosureReturnType errorLevel="info" />
+        <MissingClosureParamType errorLevel="info" />
+        <MissingParamType errorLevel="info" />
 
         <ArgumentTypeCoercion errorLevel="info" />
         <PropertyTypeCoercion errorLevel="info" />

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -236,7 +236,6 @@ abstract class AbstractApi
      */
     protected function getEndpoint(string $uri, array $query, ?string $region): string
     {
-        /** @var string $region */
         $region = $region ?? ($this->configuration->isDefault('region') ? null : $this->configuration->get('region'));
         if (!$this->configuration->isDefault('endpoint')) {
             /** @var string $endpoint */

--- a/src/Core/src/Test/ResultMockFactory.php
+++ b/src/Core/src/Test/ResultMockFactory.php
@@ -136,7 +136,7 @@ class ResultMockFactory
      */
     public static function waiter(string $class, string $finalState)
     {
-        if (Result::class !== $class) {
+        if (Waiter::class !== $class) {
             $parent = get_parent_class($class);
             if (false === $parent || Waiter::class !== $parent) {
                 throw new LogicException(sprintf('The "%s::%s" can only be used for classes that extend "%s"', __CLASS__, __METHOD__, Waiter::class));


### PR DESCRIPTION
I also reorganized the remaining disabled rules to explain better their reason.

For the `slightly lazy code writing` section, the remaining ones could probably be re-enabled quite easily by fixing the remaining 10 issues which are all in `src/Integration/Aws/DynamoDbSession` and `src/Integration/Laravel/Cache`