### PR TITLE
Fix the dynamodb store

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "3.17.*",
+        "friendsofphp/php-cs-fixer": "~3.17.0",
         "illuminate/cache": "^6.18.13 || ^7.10 || ^8.0 || ^9.0",
         "illuminate/filesystem": "^6.18.13 || ^7.10 || ^8.0",
         "illuminate/mail": "^6.18.13 || ^7.10 || ^8.0",

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -15,6 +15,5 @@ parameters:
         - src/Integration/Laravel/Filesystem/src/AsyncAwsFilesystemAdapter.php
 
     ignoreErrors:
-        - '#^Parameter \#1 \$input of method AsyncAws\\DynamoDb\\DynamoDbClient::\w+\(\) expects array\{[^\)]+\}\|AsyncAws\\DynamoDb\\Input\\\w+Input, array\{[^\)]+\} given\.#'
         - '#PHPDoc tag @throws with type Psr\\Cache\\CacheException is not subtype of Throwable$#'
         - '#^Dead catch - JsonException is never thrown in the try block\.$#'

--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -50,11 +50,6 @@
   </file>
   <file src="src/Integration/Aws/SimpleS3/src/SimpleS3Client.php">
     <InvalidArgument>
-      <code><![CDATA[array_merge($options, [
-            'Bucket' => $bucket,
-            'Key' => $key,
-            'Body' => $object,
-        ])]]></code>
       <code><![CDATA[array_merge($options, ['Bucket' => $bucket, 'Key' => $key])]]></code>
     </InvalidArgument>
   </file>
@@ -73,14 +68,6 @@
     </InvalidArgument>
   </file>
   <file src="src/Integration/Laravel/Cache/src/AsyncAwsDynamoDbStore.php">
-    <InvalidArgument>
-      <code><![CDATA[[
-            'TableName' => $this->table,
-            'KeySchema' => [
-                new KeySchemaElement(['AttributeName' => 'key', 'KeyType' => KeyType::HASH]),
-            ],
-        ]]]></code>
-    </InvalidArgument>
     <RedundantCast>
       <code><![CDATA[(int) $e->getCode()]]></code>
     </RedundantCast>

--- a/src/Integration/Laravel/Cache/src/AsyncAwsDynamoDbStore.php
+++ b/src/Integration/Laravel/Cache/src/AsyncAwsDynamoDbStore.php
@@ -2,15 +2,10 @@
 
 namespace AsyncAws\Illuminate\Cache;
 
-use AsyncAws\Core\Exception\Http\HttpException;
 use AsyncAws\Core\Exception\RuntimeException;
 use AsyncAws\DynamoDb\DynamoDbClient;
-use AsyncAws\DynamoDb\Enum\KeyType;
-use AsyncAws\DynamoDb\Enum\ScalarAttributeType;
 use AsyncAws\DynamoDb\Exception\ConditionalCheckFailedException;
-use AsyncAws\DynamoDb\ValueObject\AttributeDefinition;
 use AsyncAws\DynamoDb\ValueObject\AttributeValue;
-use AsyncAws\DynamoDb\ValueObject\KeySchemaElement;
 use Illuminate\Contracts\Cache\LockProvider;
 use Illuminate\Contracts\Cache\Store;
 use Illuminate\Support\Carbon;
@@ -399,43 +394,7 @@ class AsyncAwsDynamoDbStore implements LockProvider, Store
      */
     public function flush()
     {
-        try {
-            // Delete the table
-            $this->dynamoDb->deleteTable(['TableName' => $this->table]);
-        } catch (HttpException $e) {
-            $code = (int) $e->getCode();
-            if (404 !== $code) {
-                // Any error but "table not found"
-                throw new RuntimeException('Could not flush DynamoDb cache. Table could not be deleted.', $code, $e);
-            }
-        }
-
-        // Wait until table is removed
-        $response = $this->dynamoDb->tableNotExists(['TableName' => $this->table]);
-        $response->wait(100, 3);
-        if (!$response->isSuccess()) {
-            throw new RuntimeException('Could not flush DynamoDb cache. Table could not be deleted.');
-        }
-
-        // Create a new table
-        $this->dynamoDb->createTable([
-            'TableName' => $this->table,
-            'KeySchema' => [
-                new KeySchemaElement(['AttributeName' => $this->keyAttribute, 'KeyType' => KeyType::HASH]),
-            ],
-            'AttributeDefinitions' => [
-                new AttributeDefinition(['AttributeName' => $this->keyAttribute, 'AttributeType' => ScalarAttributeType::S]),
-            ],
-        ]);
-
-        // Wait until table is created
-        $response = $this->dynamoDb->tableExists(['TableName' => $this->table]);
-        $response->wait(100, 3);
-        if (!$response->isSuccess()) {
-            throw new RuntimeException('Could not flush DynamoDb cache. Table could not be created.');
-        }
-
-        return true;
+        throw new RuntimeException('DynamoDb does not support flushing an entire table. Please create a new table.');
     }
 
     /**

--- a/src/Integration/Laravel/Cache/src/AsyncAwsDynamoDbStore.php
+++ b/src/Integration/Laravel/Cache/src/AsyncAwsDynamoDbStore.php
@@ -6,7 +6,9 @@ use AsyncAws\Core\Exception\Http\HttpException;
 use AsyncAws\Core\Exception\RuntimeException;
 use AsyncAws\DynamoDb\DynamoDbClient;
 use AsyncAws\DynamoDb\Enum\KeyType;
+use AsyncAws\DynamoDb\Enum\ScalarAttributeType;
 use AsyncAws\DynamoDb\Exception\ConditionalCheckFailedException;
+use AsyncAws\DynamoDb\ValueObject\AttributeDefinition;
 use AsyncAws\DynamoDb\ValueObject\AttributeValue;
 use AsyncAws\DynamoDb\ValueObject\KeySchemaElement;
 use Illuminate\Contracts\Cache\LockProvider;
@@ -419,7 +421,10 @@ class AsyncAwsDynamoDbStore implements LockProvider, Store
         $this->dynamoDb->createTable([
             'TableName' => $this->table,
             'KeySchema' => [
-                new KeySchemaElement(['AttributeName' => 'key', 'KeyType' => KeyType::HASH]),
+                new KeySchemaElement(['AttributeName' => $this->keyAttribute, 'KeyType' => KeyType::HASH]),
+            ],
+            'AttributeDefinitions' => [
+                new AttributeDefinition(['AttributeName' => $this->keyAttribute, 'AttributeType' => ScalarAttributeType::S]),
             ],
         ]);
 


### PR DESCRIPTION
When recreating the table during cache clearing, the call was missing the required `AttributeDefinitions` key to define the type of the attributes of the key.
And the `KeySchemaElement` was hardcoding the attribute name as `key` instead of accounting for the fact that the controller allows to customize it.

This is an error that was actually detected by static analysis. I was working on checking the content of our baseline files.