### PR TITLE
Use quoted literal in phpdoc when psalm needs them

### DIFF
--- a/psalm.baseline.xml
+++ b/psalm.baseline.xml
@@ -53,11 +53,6 @@
       <code><![CDATA[array_merge($options, ['Bucket' => $bucket, 'Key' => $key])]]></code>
     </InvalidArgument>
   </file>
-  <file src="src/Integration/Laravel/Cache/src/AsyncAwsDynamoDbStore.php">
-    <RedundantCast>
-      <code><![CDATA[(int) $e->getCode()]]></code>
-    </RedundantCast>
-  </file>
   <file src="src/Integration/Laravel/Cache/src/ServiceProvider.php">
     <InvalidArgument>
       <code>$config</code>
@@ -132,12 +127,6 @@
     <MoreSpecificReturnType>
       <code><![CDATA[list<AutoRollbackEvent::*>]]></code>
     </MoreSpecificReturnType>
-  </file>
-  <file src="src/Service/DynamoDb/src/ValueObject/AttributeValue.php">
-    <InvalidArrayOffset>
-      <code><![CDATA[$input['BOOL']]]></code>
-      <code><![CDATA[$input['NULL']]]></code>
-    </InvalidArrayOffset>
   </file>
   <file src="src/Service/Kinesis/src/Result/DescribeStreamOutput.php">
     <LessSpecificReturnStatement>

--- a/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
@@ -103,14 +103,23 @@ class TypeGenerator
                 }
             }
 
+            $phpdocMemberName = $member->getName();
+
+            // Psalm treats a scalar type names as keywords and makes them lowercase even in array shape keys which are not types.
+            // When a different case is needed, it requires using a quoted literal instead of an identifier.
+            // TODO remove that code once https://github.com/vimeo/psalm/issues/10008 is solved (in a release)
+            if (\in_array(strtolower($phpdocMemberName), ['bool', 'null', 'int', 'float', 'double', 'scalar']) && $phpdocMemberName !== strtolower($phpdocMemberName)) {
+                $phpdocMemberName = "'" . $phpdocMemberName . "'";
+            }
+
             if ($nullable) {
-                $body[] = sprintf('  %s?: %s,', $member->getName(), 'null|' . $param);
+                $body[] = sprintf('  %s?: %s,', $phpdocMemberName, 'null|' . $param);
             } elseif ($allNullable) {
                 // For input objects, the constructor allows to omit all members to set them later. But when provided,
                 // they should respect the nullability of the member.
-                $body[] = sprintf('  %s?: %s,', $member->getName(), $param);
+                $body[] = sprintf('  %s?: %s,', $phpdocMemberName, $param);
             } else {
-                $body[] = sprintf('  %s: %s,', $member->getName(), $param);
+                $body[] = sprintf('  %s: %s,', $phpdocMemberName, $param);
             }
         }
         $body = array_merge($body, $extra);

--- a/src/Service/DynamoDb/src/ValueObject/AttributeValue.php
+++ b/src/Service/DynamoDb/src/ValueObject/AttributeValue.php
@@ -119,8 +119,8 @@ final class AttributeValue
      *   BS?: null|string[],
      *   M?: null|array<string, AttributeValue|array>,
      *   L?: null|array<AttributeValue|array>,
-     *   NULL?: null|bool,
-     *   BOOL?: null|bool,
+     *   'NULL'?: null|bool,
+     *   'BOOL'?: null|bool,
      * } $input
      */
     public function __construct(array $input)
@@ -147,8 +147,8 @@ final class AttributeValue
      *   BS?: null|string[],
      *   M?: null|array<string, AttributeValue|array>,
      *   L?: null|array<AttributeValue|array>,
-     *   NULL?: null|bool,
-     *   BOOL?: null|bool,
+     *   'NULL'?: null|bool,
+     *   'BOOL'?: null|bool,
      * }|AttributeValue $input
      */
     public static function create($input): self


### PR DESCRIPTION
See https://github.com/vimeo/psalm/issues/10008

Psalm treats array key shapes that match their keywords as keywords and then makes them lowercase, breaking the array shape (as array keys are case sensitive).

This updates the code generator to generate string literals for the keys for this case, to ensure compatibility with both phpstan and psalm.