### PR TITLE
Upgrade psalm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "nette/utils": "^3.0",
         "nyholm/symfony-bundle-test": "^2.0",
         "phpstan/phpstan": "1.10.21",
-        "psalm/phar": "5.11.0",
+        "psalm/phar": "5.14.1",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "swaggest/json-diff": "^3.7",
         "symfony/cache": "^4.4 || ^5.0 || ^6.0 || ^7.0",

--- a/src/Core/src/Stream/ResourceStream.php
+++ b/src/Core/src/Stream/ResourceStream.php
@@ -42,7 +42,7 @@ final class ResourceStream implements RequestStream
         }
         if (\is_resource($content)) {
             if (!stream_get_meta_data($content)['seekable']) {
-                throw new InvalidArgument(sprintf('The give body is not seekable.'));
+                throw new InvalidArgument('The given body is not seekable.');
             }
 
             return new self($content, $chunkSize);

--- a/src/Integration/Symfony/Bundle/src/DependencyInjection/AsyncAwsExtension.php
+++ b/src/Integration/Symfony/Bundle/src/DependencyInjection/AsyncAwsExtension.php
@@ -261,7 +261,7 @@ class AsyncAwsExtension extends Extension
 
         if ($config['secrets']['cache']['enabled']) {
             if (!interface_exists(CacheInterface::class)) {
-                throw new InvalidConfigurationException(sprintf('You have enabled "async_aws.secrets.cache" but the "symfony/cache" package is not installed. Try running "composer require symfony/cache"'));
+                throw new InvalidConfigurationException('You have enabled "async_aws.secrets.cache" but the "symfony/cache" package is not installed. Try running "composer require symfony/cache"');
             }
 
             $container->register(CachedEnvVarLoader::class)


### PR DESCRIPTION
The new version detects usages of sprintf that don't pass any argument except the string, as this can be done by writing the string directly. So I fixed the 2 reported cases.