### PR TITLE
Add test to assert CHANGELOG format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,8 @@ jobs:
 
       - name: Checkout code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Initialize tests
         run: make initialize -j 4

--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -165,6 +165,8 @@
 
 ## 1.7.2
 
+### Changed
+
 - Make sure we can get credentials even if the cache storage fails
 - Clear `realpath` cache to make sure we get the latest credentials token
 
@@ -236,14 +238,14 @@
 - Support for CloudFront in `AwsClientFactory`
 - Support for RdsDataService in `AwsClientFactory`
 
-### Fixed
-
-- Allows non-AWS regions when using custom endpoints
-
 ### Changed
 
 - Add more context to error logs
 - Log level for 404 responses changed to "info".
+
+### Fixed
+
+- Allows non-AWS regions when using custom endpoints
 
 ## 1.2.0
 
@@ -256,7 +258,7 @@
 - Support for global and regional endpoints
 - Add a `Configuration::optionExists` to allow third parties to check if an option is available (needed by libraries supporting several versions of core)
 
-### Deprecation
+### Deprecated
 
 - Clients extending `AbstractApi` should override `getEndpointMetata`. The method will be abstract in 2.0
 - Custom endpoints should not contain `%region%` and `%service` placeholder. They won't be replaced anymore in 2.0
@@ -321,6 +323,13 @@
 
 ## 0.5.0
 
+### Removed
+
+- The input's `validate()` function was merged with the `request()` function.
+- `Configuration::isDefault()`.
+- Protected property `AbstractApi::$logger`.
+- `AsyncAws\Core\StreamableBody` in favor of `AsyncAws\Core\Stream\ResponseBodyStream`.
+
 ### Added
 
 - Add support for multiregion via `@region` input parameter.
@@ -333,13 +342,6 @@
 - Internal `AsyncAws\Core\Response` to encapsulate the HTTP client.
 - Internal `AsyncAws\Core\RequestContext`.
 - Internal `AsyncAws\Core\Stream\RewindableStream`.
-
-### Removed
-
-- The input's `validate()` function was merged with the `request()` function.
-- `Configuration::isDefault()`.
-- Protected property `AbstractApi::$logger`.
-- `AsyncAws\Core\StreamableBody` in favor of `AsyncAws\Core\Stream\ResponseBodyStream`.
 
 ### Changed
 
@@ -360,6 +362,11 @@
 
 ## 0.4.0
 
+### Removed
+
+- Public `AbstractApi::request()` was removed.
+- Protected function `AbstractApi::getEndpoint()` was made private.
+
 ### Added
 
 - Test class `AsyncAws\Core\Test\SimpleStreamableBody`
@@ -371,11 +378,6 @@
 - Renamed `AsyncAws\Core\Request::getUrl()` to `AsyncAws\Core\Request::getEndpoint()`
 - Class `AsyncAws\Core\Stream\StreamFactory` is not internal anymore.
 - Removed `requestBody()`, `requestHeaders()`, `requestQuery()` and `requestUri()` input classes. They are replaced with `request()`.
-
-### Removed
-
-- Public `AbstractApi::request()` was removed.
-- Protected function `AbstractApi::getEndpoint()` was made private.
 
 ### Fixed
 

--- a/src/Integration/Aws/DynamoDbSession/CHANGELOG.md
+++ b/src/Integration/Aws/DynamoDbSession/CHANGELOG.md
@@ -10,13 +10,13 @@
 
 ## 1.0.1
 
-### Updated
+### Changed
 
 - Fix deprecations triggered by php 8.1
 
 ## 1.0.0
 
-### Updated
+### Changed
 
 - Use async-aws/dynamo-db: ^1.0
 

--- a/src/Integration/Aws/SimpleS3/CHANGELOG.md
+++ b/src/Integration/Aws/SimpleS3/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## 2.0.0
 
-### BC Break
+### BC-BREAK
 
 - Upgrade to `async-aws/s3` 2.0
 
@@ -22,7 +22,7 @@
 
 ## 1.0.0
 
-No changes since 0.1.2.
+- Empty release
 
 ## 0.1.2
 

--- a/src/Integration/Monolog/CloudWatch/CHANGELOG.md
+++ b/src/Integration/Monolog/CloudWatch/CHANGELOG.md
@@ -10,13 +10,13 @@
 
 ## 1.0.1
 
-### Updated
+### Changed
 
 - Remove unnecessary sequenceToken from log events
 
 ## 1.0.0
 
-### Updated
+### Changed
 
 - Use async-aws/cloud-watch-logs: ^1.0
 
@@ -32,7 +32,7 @@
 
 ## 0.2.0
 
-### Deprecation
+### Deprecated
 
 - `CloudWatchLogsHandler` constructor arguments changed
 

--- a/src/Service/Athena/CHANGELOG.md
+++ b/src/Service/Athena/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## NOT RELEASED
 
-### Changed
-
-- Allow passing explicit null values for optional fields of input objects
-
 ### Added
 
 - Added `il-central-1` region
+
+### Changed
+
+- Allow passing explicit null values for optional fields of input objects
 
 ## 2.0.0
 

--- a/src/Service/CloudFormation/CHANGELOG.md
+++ b/src/Service/CloudFormation/CHANGELOG.md
@@ -84,17 +84,17 @@
 
 ## 0.4.0
 
+### Removed
+
+- Dependency on `symfony/http-client-contracts`
+- All `validate()` methods on the inputs. They are merged with `request()`.
+
 ### Changed
 
 - Moved value objects to a dedicated namespace.
 - Results' `populateResult()` has only one argument. It takes a `AsyncAws\Core\Response`.
 - Using `DateTimeImmutable` instead of `DateTimeInterface`
 - The `AsyncAws\CloudFormation\Enum\*`, `AsyncAws\CloudFormation\Input\*` and `AsyncAws\CloudFormation\ValueObject*` classes are marked final.
-
-### Removed
-
-- Dependency on `symfony/http-client-contracts`
-- All `validate()` methods on the inputs. They are merged with `request()`.
 
 ## 0.3.0
 

--- a/src/Service/CloudWatchLogs/CHANGELOG.md
+++ b/src/Service/CloudWatchLogs/CHANGELOG.md
@@ -51,14 +51,14 @@
 
 ## 1.2.0
 
-### Fixed
-
-- Assert the provided Input can be json-encoded.
-
 ### Added
 
 - AWS api-change: Update documentation
 - Added operation `createLogGroup`
+
+### Fixed
+
+- Assert the provided Input can be json-encoded.
 
 ## 1.1.0
 

--- a/src/Service/DynamoDb/CHANGELOG.md
+++ b/src/Service/DynamoDb/CHANGELOG.md
@@ -106,13 +106,13 @@
 
 ## 0.3.0
 
-### Added
-
-- Added operation `UpdateTimeToLiveInput`
-
 ### Removed
 
 - Removes methods `getServiceCode`, `getSignatureVersion` and `getSignatureScopeName` from Client.
+
+### Added
+
+- Added operation `UpdateTimeToLiveInput`
 
 ### Fixed
 

--- a/src/Service/Ecr/CHANGELOG.md
+++ b/src/Service/Ecr/CHANGELOG.md
@@ -10,15 +10,12 @@
 
 ### Added
 
+- AWS api-change: Add support for the `il-central-1` region
 - Avoid overriding the exception message with the raw message
 
 ### Changed
 
 - Improve parameter type and return type in phpdoc
-
-### Added
-
-- AWS api-change: Add support for the `il-central-1` region
 
 ## 1.4.0
 
@@ -48,14 +45,14 @@
 
 ## 1.0.0
 
-### Fixed
-
-- Assert the provided Input can be json-encoded.
-
 ### Added
 
 - AWS api-change: Added `ap-northeast-3` region
 - AWS enhancement: Documentation updates
+
+### Fixed
+
+- Assert the provided Input can be json-encoded.
 
 ## 0.1.2
 
@@ -66,13 +63,13 @@
 
 ## 0.1.1
 
-### Fixed
-
-- AWS api-change: Added us-isob-east-1 region
-
 ### Deprecated
 
 - AWS api-change: `GetAuthorizationTokenRequest::$registryIds` has been deprecated
+
+### Fixed
+
+- AWS api-change: Added us-isob-east-1 region
 
 ## 0.1.0
 

--- a/src/Service/EventBridge/CHANGELOG.md
+++ b/src/Service/EventBridge/CHANGELOG.md
@@ -40,14 +40,14 @@
 
 ## 1.2.0
 
-### Fixed
-
-- Assert the provided Input can be json-encoded.
-
 ### Added
 
 - AWS api-change: Adds TraceHeader to PutEventsRequestEntry to support AWS X-Ray trace-ids on events generated using the PutEvents operation.
 - AWS enhancement: Documentation updates
+
+### Fixed
+
+- Assert the provided Input can be json-encoded.
 
 ## 1.1.0
 

--- a/src/Service/Lambda/CHANGELOG.md
+++ b/src/Service/Lambda/CHANGELOG.md
@@ -79,18 +79,18 @@
 
 ## 1.5.0
 
-### Fixed
+### Added
 
-- Assert the provided Input can be json-encoded.
+- AWS api-change: Lambda Python 3.9 runtime launch
+- AWS api-change: Adds support for Lambda functions powered by AWS Graviton2 processors. Customers can now select the CPU architecture for their functions.
 
 ### Changed
 
 - AWS enhancement: Documentation updates for Amazon Lambda.
 
-### Added
+### Fixed
 
-- AWS api-change: Lambda Python 3.9 runtime launch
-- AWS api-change: Adds support for Lambda functions powered by AWS Graviton2 processors. Customers can now select the CPU architecture for their functions.
+- Assert the provided Input can be json-encoded.
 
 ## 1.4.0
 
@@ -154,17 +154,17 @@
 
 ## 0.4.0
 
+### Removed
+
+- Dependency on `symfony/http-client-contracts`
+- All `validate()` methods on the inputs. They are merged with `request()`.
+
 ### Changed
 
 - Moved value objects to a dedicated namespace.
 - Results' `populateResult()` has only one argument. It takes a `AsyncAws\Core\Response`.
 - Using `DateTimeImmutable` instead of `DateTimeInterface`
 - The `AsyncAws\Lambda\Enum\*`, `AsyncAws\Lambda\Input\*` and `AsyncAws\Lambda\ValueObject*` classes are marked final.
-
-### Removed
-
-- Dependency on `symfony/http-client-contracts`
-- All `validate()` methods on the inputs. They are merged with `request()`.
 
 ## 0.3.0
 

--- a/src/Service/LocationService/CHANGELOG.md
+++ b/src/Service/LocationService/CHANGELOG.md
@@ -2,27 +2,24 @@
 
 ## NOT RELEASED
 
-### Changed
-
-- Allow passing explicit null values for optional fields of input objects
-
 ### Added
 
 - AWS api-change: Added `fips-us-gov-west-1` region
+
+### Changed
+
+- Allow passing explicit null values for optional fields of input objects
 
 ## 0.1.1
 
 ### Added
 
 - Avoid overriding the exception message with the raw message
+- AWS api-change: This release adds support for authenticating with Amazon Location Service's Places & Routes APIs with an API Key. Also, with this release developers can publish tracked device position updates to Amazon EventBridge.
 
 ### Changed
 
 - Improve parameter type and return type in phpdoc
-
-### Added
-
-- AWS api-change: This release adds support for authenticating with Amazon Location Service's Places & Routes APIs with an API Key. Also, with this release developers can publish tracked device position updates to Amazon EventBridge.
 
 ## 0.1.0
 

--- a/src/Service/MediaConvert/CHANGELOG.md
+++ b/src/Service/MediaConvert/CHANGELOG.md
@@ -2,31 +2,28 @@
 
 ## NOT RELEASED
 
-### Changed
-
-- Allow passing explicit null values for optional fields of input objects
-- Change the way `AudioSelectorGroup` and `AudioSelector` are populated
-
 ### Added
 
 - AWS api-change: This release includes additional audio channel tags in Quicktime outputs, support for film grain synthesis for AV1 outputs, ability to create audio-only FLAC outputs, and ability to specify Amazon S3 destination storage class.
 - AWS api-change: This release supports the creation of of audio-only tracks in CMAF output groups.
 - AWS api-change: This release adds the ability to replace video frames without modifying the audio essence.
 
+### Changed
+
+- Allow passing explicit null values for optional fields of input objects
+- Change the way `AudioSelectorGroup` and `AudioSelector` are populated
+
 ## 0.1.1
 
 ### Added
 
 - Avoid overriding the exception message with the raw message
+- AWS api-change: This release introduces the bandwidth reduction filter for the HEVC encoder, increases the limits of outputs per job, and updates support for the Nagra SDK to version 1.14.7.
+- AWS enhancement: Documentation updates.
 
 ### Changed
 
 - Improve parameter type and return type in phpdoc
-
-### Added
-
-- AWS api-change: This release introduces the bandwidth reduction filter for the HEVC encoder, increases the limits of outputs per job, and updates support for the Nagra SDK to version 1.14.7.
-- AWS enhancement: Documentation updates.
 
 ## 0.1.0
 

--- a/src/Service/RdsDataService/CHANGELOG.md
+++ b/src/Service/RdsDataService/CHANGELOG.md
@@ -41,13 +41,13 @@
 
 ## 0.1.3
 
-### Fixed
-
-- Assert the provided Input can be json-encoded.
-
 ### Added
 
 - AWS api-change: With the Data API, you can now use UUID and JSON data types as input to your database.
+
+### Fixed
+
+- Assert the provided Input can be json-encoded.
 
 ## 0.1.2
 

--- a/src/Service/Rekognition/CHANGELOG.md
+++ b/src/Service/Rekognition/CHANGELOG.md
@@ -5,9 +5,6 @@
 ### Changed
 
 - Allow passing explicit null values for optional fields of input objects
-
-### Changed
-
 - AWS enhancement: Documentation updates.
 
 ## 1.0.1

--- a/src/Service/Route53/CHANGELOG.md
+++ b/src/Service/Route53/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## NOT RELEASED
 
-### Changed
-
-- Allow passing explicit null values for optional fields of input objects
-
 ### Added
 
 - AWS api-change: Add hostedzonetype filter to ListHostedZones API.
+
+### Changed
+
+- Allow passing explicit null values for optional fields of input objects
 
 ## 2.0.0
 
@@ -36,6 +36,8 @@
 
 ## 1.0.0
 
+### Changed
+
 - AWS api-change: Add new APIs to support Route 53 IP Based Routing
 - AWS enhancement: SDK doc update for Route 53 to update some parameters with new information.
 - AWS enhancement: Documentation updates.
@@ -44,7 +46,7 @@
 - AWS api-change: Amazon Route 53 now supports the Europe (Spain) Region (eu-south-2) for latency records, geoproximity records, and private DNS for Amazon VPCs in that region.
 - AWS api-change: Amazon Route 53 now supports the Asia Pacific (Hyderabad) Region (ap-south-2) for latency records, geoproximity records, and private DNS for Amazon VPCs in that region.
 
-### 0.1.2
+## 0.1.2
 
 ### Added
 

--- a/src/Service/S3/CHANGELOG.md
+++ b/src/Service/S3/CHANGELOG.md
@@ -2,18 +2,18 @@
 
 ## NOT RELEASED
 
-### Fixed
+### Added
 
-- Fix the format of the `objectLockRetainUntilDate` field in requests
+- AWS api-change: This release adds a new field COMPLETED to the ReplicationStatus Enum. You can now use this field to validate the replication status of S3 objects using the AWS SDK.
 
 ### Changed
 
 - Allow passing explicit null values for optional fields of input objects
 - AWS enhancement: Documentation updates.
 
-### Added
+### Fixed
 
-- AWS api-change: This release adds a new field COMPLETED to the ReplicationStatus Enum. You can now use this field to validate the replication status of S3 objects using the AWS SDK.
+- Fix the format of the `objectLockRetainUntilDate` field in requests
 
 ## 2.0.0
 
@@ -55,14 +55,14 @@
 
 ## 1.12.0
 
+### Changed
+
+- Set default value to `false` for the `sendChunkedBody` option.
+
 ### Fixed
 
 - Format datetime with `RFC7231` to provide a workaround for unsupported `RFC822` format.
 - Broken path to host when operation's URL contains a query string.
-
-### Changed
-
-- Set default value to `false` for the `sendChunkedBody` option.
 
 ## 1.11.0
 
@@ -174,15 +174,15 @@
 - Support for PHP 8
 - Added `S3Client::deleteBucket()`
 
+### Deprecated
+
+- `PutObjectAclRequest::getContentMD5()`
+- `PutObjectAclRequest::setContentMD5()`
+
 ### Fixed
 
 - Fixed an issue in Metadata not beeing sent to AWS in `PutObject`, `CopyObject` and `CreateMultipartUpload`
 - Internal AWS prefix were added to Metadata's name in `GetObject` and `HeadObject`.
-
-### Deprecated by AWS
-
-- `PutObjectAclRequest::getContentMD5()`
-- `PutObjectAclRequest::setContentMD5()`
 
 ## 1.2.0
 
@@ -190,13 +190,13 @@
 
 - Changed from "path  style" endpoints (https://amazon.com/bucket) to "host style" endpoints (https://bucket.amazon.com). To keep the old behavior, use `s3PathStyleEndpoint: true` configuration option.
 
+### Deprecated
+
+- Protected methods `getServiceCode`, `getSignatureVersion` and `getSignatureScopeName` of `S3Client` are deprecated and will be removed in 2.0
+
 ### Fixed
 
 - Fixed issue when Bucket or Object's Key contained a special char like `#`
-
-### Deprecation
-
-- Protected methods `getServiceCode`, `getSignatureVersion` and `getSignatureScopeName` of `S3Client` are deprecated and will be removed in 2.0
 
 ## 1.1.0
 
@@ -216,6 +216,11 @@
 
 ## 0.4.0
 
+### Removed
+
+- Dependency on `symfony/http-client-contracts`
+- All `validate()` methods on the inputs. They are merged with `request()`.
+
 ### Added
 
 - Support for presign
@@ -228,11 +233,6 @@
 - Moved value objects to a dedicated namespace.
 - Results' `populateResult()` has only one argument. It takes a `AsyncAws\Core\Response`.
 - Using `DateTimeImmutable` instead of `DateTimeInterface`
-
-### Removed
-
-- Dependency on `symfony/http-client-contracts`
-- All `validate()` methods on the inputs. They are merged with `request()`.
 
 ## 0.3.0
 

--- a/src/Service/SecretsManager/CHANGELOG.md
+++ b/src/Service/SecretsManager/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## NOT RELEASED
 
-### Changed
-
-- Allow passing explicit null values for optional fields of input objects
-
 ### Added
 
 - AWS api-change: Add additional InvalidRequestException to list of possible exceptions for ListSecret.
+
+### Changed
+
+- Allow passing explicit null values for optional fields of input objects
 
 ## 2.0.0
 

--- a/src/Service/Ses/CHANGELOG.md
+++ b/src/Service/Ses/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## NOT RELEASED
 
-### Changed
-
-- Allow passing explicit null values for optional fields of input objects
-
 ### Added
 
 - AWS api-change: Added `fips-ca-central-1`, `fips-us-east-2` and `fips-us-west-1` regions
+
+### Changed
+
+- Allow passing explicit null values for optional fields of input objects
 
 ## 1.6.0
 
@@ -70,7 +70,7 @@
 
 ## 1.1.0
 
-### Deprecation
+### Deprecated
 
 - Protected methods `getServiceCode`, `getSignatureVersion` and `getSignatureScopeName` of `SesClient` are deprecated and will be removed in 2.0
 
@@ -82,16 +82,16 @@
 
 ## 0.4.0
 
+### Removed
+
+- Dependency on `symfony/http-client-contracts`
+- All `validate()` methods on the inputs. They are merged with `request()`.
+
 ### Changed
 
 - Moved value objects to a dedicated namespace.
 - Results' `populateResult()` has only one argument. It takes a `AsyncAws\Core\Response`.
 - The `AsyncAws\Ses\Input\*` and `AsyncAws\Ses\ValueObject*` classes are marked final.
-
-### Removed
-
-- Dependency on `symfony/http-client-contracts`
-- All `validate()` methods on the inputs. They are merged with `request()`.
 
 ## 0.3.0
 

--- a/src/Service/Sns/CHANGELOG.md
+++ b/src/Service/Sns/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## NOT RELEASED
 
-### Changed
-
-- Allow passing explicit null values for optional fields of input objects
-
 ### Added
 
 - AWS api-change: Remove `ValidationException`
+
+### Changed
+
+- Allow passing explicit null values for optional fields of input objects
 
 ## 1.5.0
 
@@ -108,16 +108,16 @@
 
 ## 0.4.0
 
+### Removed
+
+- Dependency on `symfony/http-client-contracts`
+- All `validate()` methods on the inputs. They are merged with `request()`.
+
 ### Changed
 
 - Moved value objects to a dedicated namespace.
 - Results' `populateResult()` has only one argument. It takes a `AsyncAws\Core\Response`.
 - The `AsyncAws\Sns\Input\*` and `AsyncAws\Sns\ValueObject*` classes are marked final.
-
-### Removed
-
-- Dependency on `symfony/http-client-contracts`
-- All `validate()` methods on the inputs. They are merged with `request()`.
 
 ## 0.3.0
 

--- a/src/Service/Sqs/CHANGELOG.md
+++ b/src/Service/Sqs/CHANGELOG.md
@@ -80,7 +80,7 @@
 
 ## 1.2.0
 
-### Deprecation
+### Deprecated
 
 - Protected methods `getServiceCode`, `getSignatureVersion` and `getSignatureScopeName` of `SqsClient` are deprecated and will be removed in 2.0
 
@@ -105,16 +105,16 @@
 
 ## 0.4.0
 
+### Removed
+
+- Dependency on `symfony/http-client-contracts`
+- All `validate()` methods on the inputs. They are merged with `request()`.
+
 ### Changed
 
 - Moved value objects to a dedicated namespace.
 - Results' `populateResult()` has only one argument. It takes a `AsyncAws\Core\Response`.
 - The `AsyncAws\Sqs\Enum\*`, `AsyncAws\Sqs\Input\*` and `AsyncAws\Sqs\ValueObject*` classes are marked final.
-
-### Removed
-
-- Dependency on `symfony/http-client-contracts`
-- All `validate()` methods on the inputs. They are merged with `request()`.
 
 ## 0.3.0
 

--- a/src/Service/Ssm/CHANGELOG.md
+++ b/src/Service/Ssm/CHANGELOG.md
@@ -64,15 +64,15 @@
 
 ## 1.1.0
 
+### Removed
+
+- The following regions are no longer supported by AWS and has been remove from
+  the client: `ssm-facade-fips-us-east-1`, `ssm-facade-fips-us-east-2`, `ssm-facade-fips-us-gov-east-1`,
+  `ssm-facade-fips-us-gov-west-1`, `ssm-facade-fips-us-west-1`, `ssm-facade-fips-us-west-2`.
+
 ### Added
 
 - AWS api-change: Added region `fips-ca-central-1`
-
-### Removed
-
-The following regions are no longer supported by AWS and has been remove from
-the client: `ssm-facade-fips-us-east-1`, `ssm-facade-fips-us-east-2`, `ssm-facade-fips-us-gov-east-1`,
-`ssm-facade-fips-us-gov-west-1`, `ssm-facade-fips-us-west-1`, `ssm-facade-fips-us-west-2`.
 
 ## 1.0.0
 
@@ -82,13 +82,13 @@ the client: `ssm-facade-fips-us-east-1`, `ssm-facade-fips-us-east-2`, `ssm-facad
 
 ## 0.2.0
 
-### Changed
-
-- parameter `type` of `putParameter` is optional.
-
 ### Removed
 
 - Removes methods `getServiceCode`, `getSignatureVersion` and `getSignatureScopeName` from Client.
+
+### Changed
+
+- parameter `type` of `putParameter` is optional.
 
 ## 0.1.2
 

--- a/src/Service/StepFunctions/CHANGELOG.md
+++ b/src/Service/StepFunctions/CHANGELOG.md
@@ -39,11 +39,12 @@
 
 ## 0.1.1
 
-## Added
+### Added
 
 - Added operation `sendTaskFailure`
 - Added operation `sendTaskHeartbeat`
 - Added operation `sendTaskSuccess`
+
 ## 0.1.0
 
 First version

--- a/tests/Unit/ChangelogTest.php
+++ b/tests/Unit/ChangelogTest.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Test\Unit;
+
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Finder\Finder;
+
+/**
+ * Verify CHANGELOG entries are present.
+ */
+class ChangelogTest extends TestCase
+{
+    /**
+     * @dataProvider provideChangedlogFiles
+     */
+    public function testChangelogFormat(string $changelogPath)
+    {
+        $lines = explode("\n", file_get_contents($changelogPath));
+
+        self::assertGreaterThan(3, \count($lines), 'CHANGELOG must not be empty');
+        self::assertSame('# Change Log', $lines[0], 'CHANGELOG MUST start with "# Change Log"');
+        self::assertSame('', $lines[1], 'CHANGELOG MUST have a second line empty');
+        self::assertSame('## NOT RELEASED', $lines[2], 'CHANGELOG MUST have a "## NOT RELEASED" section');
+
+        $inTitle1 = false;
+
+        $inTitle2 = false;
+        $title2Empty = false;
+
+        $inTitle3 = false;
+        $title3Empty = false;
+
+        $title3Choices = [
+            '### BC-BREAK', '### Removed', // Major
+            '### Added', '### Deprecated', // Minor
+            '### Changed', '### Fixed', '### Security', // Patch
+        ];
+        $lastTitle3 = -1;
+        $needEmptyLine = false;
+        $wasEmptyLine = false;
+        $finalWords = false;
+        foreach ($lines as $index => $line) {
+            if ($needEmptyLine) {
+                self::assertSame('', $line, 'CHANGELOG line ' . $index . ' MUST be empty');
+                $needEmptyLine = false;
+                $wasEmptyLine = true;
+
+                continue;
+            }
+            self::assertFalse($finalWords, 'CHANGELOG line ' . $index . ' MUST not contains anything after "First version"');
+            if ('' === $line) {
+                $wasEmptyLine = true;
+
+                continue;
+            }
+
+            if (0 === strpos($line, '# ')) {
+                self::assertFalse($inTitle1, 'CHANGELOG line ' . $index . ' MUST contain a single Title');
+                $inTitle1 = true;
+                $needEmptyLine = true;
+                $wasEmptyLine = false;
+
+                continue;
+            }
+
+            if (0 === strpos($line, '## ')) {
+                self::assertTrue($wasEmptyLine, 'CHANGELOG line ' . ($index - 1) . ' MUST be empty');
+                self::assertTrue($inTitle1, 'CHANGELOG line ' . $index . ' MUST have title2 inside a title1');
+                self::assertFalse($title2Empty, 'CHANGELOG line ' . $index . ' MUST not have empty title2');
+                self::assertFalse($title3Empty, 'CHANGELOG line ' . $index . ' MUST not have empty title3');
+                self::assertMatchesRegularExpression('/^## (NOT RELEASED|\d+\.\d+\.\d+)$/', $line, 'CHANGELOG line ' . $index . ' MUST be "## X.Y.Z"');
+                $inTitle2 = true;
+                $inTitle3 = false;
+                $lastTitle3 = -1;
+                $title2Empty = '## NOT RELEASED' !== $line; // allows having empty section for `## NOT RELEASED`
+                $title3Empty = false;
+                $wasEmptyLine = false;
+
+                $needEmptyLine = true;
+
+                continue;
+            }
+
+            if (0 === strpos($line, '### ')) {
+                self::assertTrue($wasEmptyLine, 'CHANGELOG line ' . ($index - 1) . ' MUST be empty');
+                self::assertTrue($inTitle2, 'CHANGELOG line ' . $index . ' MUST have title2 inside a title2');
+                self::assertFalse($title3Empty, 'CHANGELOG line ' . $index . ' MUST not have empty title3');
+                self::assertContains($line, $title3Choices, 'CHANGELOG line ' . $index . ' MUST be "' . implode('" or "', $title3Choices) . '"');
+                $newTitle3Index = array_search($line, $title3Choices, true);
+                self::assertGreaterThan($lastTitle3, $newTitle3Index, 'CHANGELOG line ' . $index . ' MUST respect the order "' . implode('" then "', $title3Choices) . '"');
+
+                $lastTitle3 = $newTitle3Index;
+                $title2Empty = false;
+                $inTitle3 = true;
+                $title3Empty = true;
+                $wasEmptyLine = false;
+
+                $needEmptyLine = true;
+
+                continue;
+            }
+
+            $wasEmptyLine = false;
+            if ($inTitle3) {
+                self::assertMatchesRegularExpression('/^[ -] /', $line, 'CHANGELOG entry at line ' . $index . ' MUST start with "- " or "  " for multiline content');
+                $title3Empty = false;
+
+                continue;
+            }
+
+            if ('- Empty release' === $line) {
+                $needEmptyLine = true;
+                $inTitle3 = false;
+                $title2Empty = false;
+
+                continue;
+            }
+
+            if ('First version' === $line) {
+                $finalWords = true;
+                $needEmptyLine = true;
+
+                continue;
+            }
+
+            self::assertFalse('CHANGELOG entry at line ' . $index . ' is not expected');
+        }
+
+        self::assertTrue($finalWords, 'CHANGELOG MUST contains "First version"');
+    }
+
+    /**
+     * @dataProvider provideChangedServicesWithoutChangelog
+     */
+    public function testChangelogEntryForService(string $service, string $base, $isCommentOnly)
+    {
+        if (!$isCommentOnly) {
+            self::fail('Missing CHANGELOG entry for package ' . $service);
+        }
+
+        $changelog = explode("\n", file_get_contents($base . '/CHANGELOG.md'));
+        $nrSection = false;
+
+        foreach ($changelog as $line) {
+            if ('## NOT RELEASED' === $line) {
+                $nrSection = true;
+
+                continue;
+            }
+            if (!$nrSection) {
+                continue;
+            }
+            if (0 === strpos($line, '## ')) {
+                break;
+            }
+
+            if ('- AWS enhancement: Documentation updates.' === $line) {
+                $this->expectNotToPerformAssertions();
+
+                return;
+            }
+        }
+
+        self::fail('Missing CHANGELOG entry for package ' . $service);
+    }
+
+    public static function provideChangedlogFiles(): iterable
+    {
+        $finder = (new Finder())
+            ->in(\dirname(__DIR__, 2) . '/src')
+            ->name('CHANGELOG.md');
+
+        /** @var \SplFileInfo $file */
+        foreach ($finder as $file) {
+            yield [$file->getRealPath()];
+        }
+    }
+
+    public static function provideChangedServicesWithoutChangelog(): iterable
+    {
+        $branches = array_filter(
+            array_map(static function ($line) {
+                return trim(substr($line, 1));
+            }, self::call('git branch -a --color=never')),
+            static function ($branch) {
+                return 'master' === $branch || '/master' === substr($branch, -7);
+            }
+        );
+
+        if (0 === \count($branches)) {
+            self::markTestSkipped('Cannot find the master branch');
+        }
+
+        usort($branches, static function ($a, $b) {
+            return \strlen($a) <=> \strlen($b);
+        });
+
+        $output = array_merge(
+            self::call('git diff --numstat HEAD src/'),
+            self::call('git diff --numstat ' . $branches[0] . '...HEAD src/')
+        );
+
+        $changedServices = [];
+        foreach ($output as $line) {
+            $file = explode("\t", $line)[2];
+            $parts = explode('/', $file);
+            if ('src' !== $parts[0]) {
+                continue;
+            }
+            if (!isset($parts[1])) {
+                continue;
+            }
+
+            if ('Service' === $parts[1]) {
+                $service = $parts[2];
+                $base = 'src/Service/' . $service;
+            } elseif ('Integration' === $parts[1]) {
+                $service = $parts[2] . '/' . $parts[3];
+                $base = 'src/Integration/' . $service;
+            } elseif ('CodeGenerator' === $parts[1] || 'Core' === $parts[1]) {
+                $service = $parts[1];
+                $base = 'src/' . $service;
+            } else {
+                continue;
+            }
+            if (!isset($changedServices[$service])) {
+                $changedServices[$service] = ['base' => $base, 'files' => []];
+            }
+            $changedServices[$service]['files'][] = substr($file, \strlen($base));
+        }
+
+        foreach ($changedServices as $service => $changesService) {
+            $changedFiles = $changesService['files'];
+            if (\in_array('/CHANGELOG.md', $changedFiles, true)) {
+                continue;
+            }
+
+            $isCommentOnly = true;
+            foreach ($changedFiles as $changedFile) {
+                $changedLines = self::call('git diff --no-color -U0 ' . escapeshellarg($changesService['base'] . $changedFile));
+                foreach ($changedLines as $changedLine) {
+                    if (!$changedLine) {
+                        continue;
+                    }
+                    if ('-' !== $changedLine[0] && '+' !== $changedLine[0]) {
+                        continue;
+                    }
+                    if (\in_array(substr($changedLine, 0, 3), ['---', '+++'], true)) {
+                        continue;
+                    }
+                    $changedLine = trim(substr($changedLine, 1));
+                    if ('' === $changedLine || '*' !== $changedLine[0] ?? null) {
+                        $isCommentOnly = false;
+
+                        break 2;
+                    }
+                }
+            }
+
+            yield [$service, $changesService['base'], $isCommentOnly];
+        }
+    }
+
+    private static function call(string $command): array
+    {
+        $output = [];
+        exec($command . ' 2>&1', $output, $return);
+        if (0 !== $return) {
+            throw new \Exception('Command "' . $command . '" failed: ' . "\n" . implode("\n", $output));
+        }
+
+        return $output;
+    }
+}


### PR DESCRIPTION
This PR adds 2 tests:
- Assert that a CHANGELOG entry is present
- Assert the CHANGELOG files content are consistent

all files MUST follow the following format (inspired by https://keepachangelog.com/en/1.1.0/)
```
# Change Log

## NOT RELEASED

## 1.2.0

### Added|Changed|Fixed|Deprecated|Removed|Security

- single line entry
- multiline
  entry

## 1.1.0

- Empty release

## 0.1

First version

```

It also fixes all previous change log files to make the baseline.