### PR TITLE
Upgrade localstack

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ $(SUBINITIALIZE): %.initialize:
 
 start-docker: start-docker-s3 start-docker-kms start-docker-localstack
 start-docker-localstack:
-	docker pull localstack/localstack:0.14.2
+	docker pull localstack/localstack:2.3.2
 	docker start async_aws_localstack && exit 0 || \
-	docker run -d -p 4566:4566 -p 4567:4566 -p 4568:4566 -p 4571:4566 -p 4572:4566 -p 4573:4566 -p 4574:4566 -p 4575:4566 -p 4576:4566 -p 4577:4566 -p 4578:4566 -e SERVICES=sts,cloudformation,logs,events,iam,sns,ssm,dynamodb,route53,kinesis,secretsmanager -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack localstack/localstack:0.14.2 && \
+	docker run -d -p 4566:4566 -p 4567:4566 -p 4568:4566 -p 4571:4566 -p 4572:4566 -p 4573:4566 -p 4574:4566 -p 4575:4566 -p 4576:4566 -p 4577:4566 -p 4578:4566 -e SERVICES=sts,cloudformation,logs,events,iam,sns,ssm,dynamodb,route53,kinesis,secretsmanager -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack localstack/localstack:2.3.2 && \
 	docker run --rm --link async_aws_localstack:localstack martin/wait -c localstack:4566
 start-docker-s3:
 	docker pull asyncaws/testing-s3

--- a/src/Core/Makefile
+++ b/src/Core/Makefile
@@ -4,8 +4,8 @@ initialize: start-docker
 start-docker:
 	docker start async_aws_localstack && exit 0 || \
 	docker start async_aws_localstack-sts && exit 0 || \
-	docker pull localstack/localstack:0.14.2 && \
-	docker run -d -p 4566:4566 -e SERVICES=sts -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-sts localstack/localstack:0.14.2 && \
+	docker pull localstack/localstack:2.3.2 && \
+	docker run -d -p 4566:4566 -e SERVICES=sts -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-sts localstack/localstack:2.3.2 && \
 	docker run --rm --link async_aws_localstack-sts:localstack martin/wait -c localstack:4566
 
 test: initialize

--- a/src/Core/tests/Integration/StsClientTest.php
+++ b/src/Core/tests/Integration/StsClientTest.php
@@ -65,7 +65,7 @@ class StsClientTest extends TestCase
         self::assertNotNull($result->getCredentials());
         self::assertLessThanOrEqual(new \DateTime('+5min'), $result->getCredentials()->getExpiration());
         self::assertNotNull($result->getAssumedRoleUser());
-        self::assertSame('arn:aws:sts::000000000000:assumed-role/FederatedWebIdentityRole/app1', $result->getAssumedRoleUser()->getArn());
+        self::assertSame('arn:aws:sts::123456789012:assumed-role/FederatedWebIdentityRole/app1', $result->getAssumedRoleUser()->getArn());
         self::assertSame(6, $result->getPackedPolicySize());
     }
 
@@ -78,7 +78,7 @@ class StsClientTest extends TestCase
 
         self::assertNotNull($result->getUserId());
         self::assertStringContainsString('000000000000', $result->getAccount());
-        self::assertStringContainsString('arn:aws:sts::000000000000:user/localstack', $result->getArn());
+        self::assertStringContainsString('arn:aws:iam::000000000000:root', $result->getArn());
     }
 
     public function testNonAwsRegionWithCustomEndpoint(): void

--- a/src/Service/CloudFormation/Makefile
+++ b/src/Service/CloudFormation/Makefile
@@ -4,8 +4,8 @@ initialize: start-docker
 start-docker:
 	docker start async_aws_localstack && exit 0 || \
 	docker start async_aws_localstack-cloudformation && exit 0 || \
-	docker pull localstack/localstack:0.14.2 && \
-	docker run -d -p 4567:4566 -e SERVICES=cloudformation -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-cloudformation localstack/localstack:0.14.2 && \
+	docker pull localstack/localstack:2.3.2 && \
+	docker run -d -p 4567:4566 -e SERVICES=cloudformation -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-cloudformation localstack/localstack:2.3.2 && \
 	docker run --rm --link async_aws_localstack-cloudformation:localstack martin/wait -c localstack:4566
 
 test: initialize

--- a/src/Service/CloudWatchLogs/Makefile
+++ b/src/Service/CloudWatchLogs/Makefile
@@ -4,8 +4,8 @@ initialize: start-docker
 start-docker:
 	docker start async_aws_localstack && exit 0 || \
 	docker start async_aws_localstack-logs && exit 0 || \
-	docker pull localstack/localstack:0.14.2 && \
-	docker run -d -p 4568:4566 -e SERVICES=logs -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-logs localstack/localstack:0.14.2 && \
+	docker pull localstack/localstack:2.3.2 && \
+	docker run -d -p 4568:4566 -e SERVICES=logs -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-logs localstack/localstack:2.3.2 && \
 	docker run --rm --link async_aws_localstack-logs:localstack martin/wait -c localstack:4566
 
 test: initialize

--- a/src/Service/DynamoDb/Makefile
+++ b/src/Service/DynamoDb/Makefile
@@ -4,8 +4,8 @@ initialize: start-docker
 start-docker:
 	docker start async_aws_localstack && exit 0 || \
 	docker start async_aws_localstack-dynamodb && exit 0 || \
-	docker pull localstack/localstack:0.14.2 && \
-	docker run -d -p 4575:4566 -e SERVICES=dynamodb -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-dynamodb localstack/localstack:0.14.2 && \
+	docker pull localstack/localstack:2.3.2 && \
+	docker run -d -p 4575:4566 -e SERVICES=dynamodb -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-dynamodb localstack/localstack:2.3.2 && \
 	docker run --rm --link async_aws_localstack-dynamodb:localstack martin/wait -c localstack:4566
 
 test: initialize

--- a/src/Service/DynamoDb/tests/Integration/DynamoDbClientTest.php
+++ b/src/Service/DynamoDb/tests/Integration/DynamoDbClientTest.php
@@ -7,6 +7,7 @@ use AsyncAws\Core\Test\TestCase;
 use AsyncAws\DynamoDb\DynamoDbClient;
 use AsyncAws\DynamoDb\Enum\KeyType;
 use AsyncAws\DynamoDb\Enum\ProjectionType;
+use AsyncAws\DynamoDb\Enum\ReturnConsumedCapacity;
 use AsyncAws\DynamoDb\Input\BatchGetItemInput;
 use AsyncAws\DynamoDb\Input\BatchWriteItemInput;
 use AsyncAws\DynamoDb\Input\CreateTableInput;
@@ -348,9 +349,11 @@ class DynamoDbClientTest extends TestCase
                 'Subject' => ['S' => 'How do I update multiple items?'],
                 'LastPostedBy' => ['S' => 'fred@example.com'],
             ],
+            'ReturnConsumedCapacity' => ReturnConsumedCapacity::INDEXES,
         ]);
 
         $result = $client->putItem($input);
+        self::assertNotNull($result->getConsumedCapacity());
         self::assertSame(1.0, $result->getConsumedCapacity()->getCapacityUnits());
     }
 

--- a/src/Service/EventBridge/Makefile
+++ b/src/Service/EventBridge/Makefile
@@ -4,8 +4,8 @@ initialize: start-docker
 start-docker:
 	docker start async_aws_localstack && exit 0 || \
 	docker start async_aws_localstack-events && exit 0 || \
-	docker pull localstack/localstack:0.14.2 && \
-	docker run -d -p 4571:4566 -e SERVICES=events -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-events localstack/localstack:0.14.2 && \
+	docker pull localstack/localstack:2.3.2 && \
+	docker run -d -p 4571:4566 -e SERVICES=events -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-events localstack/localstack:2.3.2 && \
 	docker run --rm --link async_aws_localstack-events:localstack martin/wait -c localstack:4566
 
 test: initialize

--- a/src/Service/Iam/Makefile
+++ b/src/Service/Iam/Makefile
@@ -4,8 +4,8 @@ initialize: start-docker
 start-docker:
 	docker start async_aws_localstack && exit 0 || \
 	docker start async_aws_localstack-iam && exit 0 || \
-	docker pull localstack/localstack:0.14.2 && \
-	docker run -d -p 4572:4566 -e SERVICES=iam -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-iam localstack/localstack:0.14.2 && \
+	docker pull localstack/localstack:2.3.2 && \
+	docker run -d -p 4572:4566 -e SERVICES=iam -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-iam localstack/localstack:2.3.2 && \
 	docker run --rm --link async_aws_localstack-iam:localstack martin/wait -c localstack:4566
 
 test: initialize

--- a/src/Service/Kinesis/Makefile
+++ b/src/Service/Kinesis/Makefile
@@ -4,8 +4,8 @@ initialize: start-docker
 start-docker:
 	docker start async_aws_localstack && exit 0 || \
 	docker start async_aws_localstack-kinesis && exit 0 || \
-	docker pull localstack/localstack:0.14.2 && \
-	docker run -d -p 4578:4566 -e SERVICES=kinesis -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-kinesis localstack/localstack:0.14.2 && \
+	docker pull localstack/localstack:2.3.2 && \
+	docker run -d -p 4578:4566 -e SERVICES=kinesis -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-kinesis localstack/localstack:2.3.2 && \
 	docker run --rm --link async_aws_localstack-kinesis:localstack martin/wait -c localstack:4566
 
 test: initialize

--- a/src/Service/Route53/Makefile
+++ b/src/Service/Route53/Makefile
@@ -4,8 +4,8 @@ initialize: start-docker
 start-docker:
 	docker start async_aws_localstack && exit 0 || \
 	docker start async_aws_localstack-route53 && exit 0 || \
-	docker pull localstack/localstack:0.14.2 && \
-	docker run -d -p 4576:4566 -e SERVICES=route53 -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-route53 localstack/localstack:0.14.2 && \
+	docker pull localstack/localstack:2.3.2 && \
+	docker run -d -p 4576:4566 -e SERVICES=route53 -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-route53 localstack/localstack:2.3.2 && \
 	docker run --rm --link async_aws_localstack-route53:localstack martin/wait -c localstack:4566
 
 test: initialize

--- a/src/Service/Route53/tests/Integration/Route53ClientTest.php
+++ b/src/Service/Route53/tests/Integration/Route53ClientTest.php
@@ -221,7 +221,8 @@ class Route53ClientTest extends TestCase
 
         $result->resolve();
 
-        self::assertCount(2, iterator_to_array($result->getResourceRecordSets()));
+        // Creating a zone automatically creates NS and SOA records, and we added 2 records above.
+        self::assertCount(4, iterator_to_array($result->getResourceRecordSets()));
         self::assertFalse($result->getIsTruncated());
         self::assertNull($result->getNextRecordName());
     }

--- a/src/Service/SecretsManager/Makefile
+++ b/src/Service/SecretsManager/Makefile
@@ -4,8 +4,8 @@ initialize: start-docker
 start-docker:
 	docker start async_aws_localstack && exit 0 || \
 	docker start async_aws_localstack-secretsmanager && exit 0 || \
-	docker pull localstack/localstack:0.14.2 && \
-	docker run -d -p 4577:4566 -e SERVICES=secretsmanager -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-secretsmanager localstack/localstack:0.14.2 && \
+	docker pull localstack/localstack:2.3.2 && \
+	docker run -d -p 4577:4566 -e SERVICES=secretsmanager -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-secretsmanager localstack/localstack:2.3.2 && \
 	docker run --rm --link async_aws_localstack-secretsmanager:localstack martin/wait -c localstack:4566
 
 test: initialize

--- a/src/Service/Sns/Makefile
+++ b/src/Service/Sns/Makefile
@@ -4,8 +4,8 @@ initialize: start-docker
 start-docker:
 	docker start async_aws_localstack && exit 0 || \
 	docker start async_aws_localstack-sns && exit 0 || \
-	docker pull localstack/localstack:0.14.2 && \
-	docker run -d -p 4573:4566 -e SERVICES=sns -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-sns localstack/localstack:0.14.2 && \
+	docker pull localstack/localstack:2.3.2 && \
+	docker run -d -p 4573:4566 -e SERVICES=sns -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-sns localstack/localstack:2.3.2 && \
 	docker run --rm --link async_aws_localstack-sns:localstack martin/wait -c localstack:4566
 
 test: initialize

--- a/src/Service/Ssm/Makefile
+++ b/src/Service/Ssm/Makefile
@@ -4,8 +4,8 @@ initialize: start-docker
 start-docker:
 	docker start async_aws_localstack && exit 0 || \
 	docker start async_aws_localstack-ssm && exit 0 || \
-	docker pull localstack/localstack:0.14.2 && \
-	docker run -d -p 4574:4566 -e SERVICES=ssm -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-ssm localstack/localstack:0.14.2 && \
+	docker pull localstack/localstack:2.3.2 && \
+	docker run -d -p 4574:4566 -e SERVICES=ssm -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-ssm localstack/localstack:2.3.2 && \
 	docker run --rm --link async_aws_localstack-ssm:localstack martin/wait -c localstack:4566
 
 test: initialize


### PR DESCRIPTION
This upgrades the localstack image used for integration test to the current latest version instead of a very old version.

The goal is to try fixing https://github.com/async-aws/aws/pull/1489 which had a failed CI due to a parity mismatch between localstack and AWS for Route53. The bug has been fixed in moto (used by localstack) and I don't know yet whether this is enough to fix the issue entirely in localstack or whether it requires additional changes there (the latest localstack version already uses a version of moto that includes the fix).

Future changes might involve investigating whether our S3 and SQS clients might rely on localstack to run integration tests instead of the testing-s3 and testing-sqs docker images for which we (don't) maintain a fork in this organization (and which rely on tools that have no activity since 2019)