### PR TITLE
Improve the makefile setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,10 @@ start-docker-kms:
 stop-docker: clean
 	docker stop async_aws_localstack || true
 	docker rm async_aws_localstack || true
+	docker stop async_aws_s3 || true
+	docker rm async_aws_s3 || true
+	docker stop async_aws_kms || true
+	docker rm async_aws_kms || true
 
 test: initialize
 	./vendor/bin/simple-phpunit

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ start-docker-kms:
 
 stop-docker: clean
 	docker stop async_aws_localstack || true
+	docker rm async_aws_localstack || true
 
 test: initialize
 	./vendor/bin/simple-phpunit

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SUBCLEAN = $(addsuffix .clean,$(COMPONENTS))
 SUBINITIALIZE = $(addsuffix .initialize,$(COMPONENTS))
 
 .PHONY: clean $(SUBCLEAN)
-clean: $(SUBCLEAN)
+clean: stop-docker $(SUBCLEAN)
 $(SUBCLEAN): %.clean:
 	$(MAKE) -C $* clean
 
@@ -30,7 +30,7 @@ start-docker-kms:
 	docker start async_aws_kms && exit 0 || \
 	docker run -d -p 4579:8080 --name async_aws_kms nsmithuk/local-kms
 
-stop-docker: clean
+stop-docker:
 	docker stop async_aws_localstack || true
 	docker rm async_aws_localstack || true
 	docker stop async_aws_s3 || true

--- a/src/Core/Makefile
+++ b/src/Core/Makefile
@@ -14,3 +14,4 @@ test: initialize
 clean: stop-docker
 stop-docker:
 	docker stop async_aws_localstack-sts || true
+	docker rm async_aws_localstack-sts || true

--- a/src/Service/CloudFormation/Makefile
+++ b/src/Service/CloudFormation/Makefile
@@ -14,3 +14,4 @@ test: initialize
 clean: stop-docker
 stop-docker:
 	docker stop async_aws_localstack-cloudformation || true
+	docker rm async_aws_localstack-cloudformation || true

--- a/src/Service/CloudWatchLogs/Makefile
+++ b/src/Service/CloudWatchLogs/Makefile
@@ -14,3 +14,4 @@ test: initialize
 clean: stop-docker
 stop-docker:
 	docker stop async_aws_localstack-logs || true
+	docker rm async_aws_localstack-logs || true

--- a/src/Service/DynamoDb/Makefile
+++ b/src/Service/DynamoDb/Makefile
@@ -14,3 +14,4 @@ test: initialize
 clean: stop-docker
 stop-docker:
 	docker stop async_aws_localstack-dynamodb || true
+	docker rm async_aws_localstack-dynamodb || true

--- a/src/Service/EventBridge/Makefile
+++ b/src/Service/EventBridge/Makefile
@@ -14,3 +14,4 @@ test: initialize
 clean: stop-docker
 stop-docker:
 	docker stop async_aws_localstack-events || true
+	docker rm async_aws_localstack-events || true

--- a/src/Service/Iam/Makefile
+++ b/src/Service/Iam/Makefile
@@ -14,3 +14,4 @@ test: initialize
 clean: stop-docker
 stop-docker:
 	docker stop async_aws_localstack-iam || true
+	docker rm async_aws_localstack-iam || true

--- a/src/Service/Kinesis/Makefile
+++ b/src/Service/Kinesis/Makefile
@@ -14,3 +14,4 @@ test: initialize
 clean: stop-docker
 stop-docker:
 	docker stop async_aws_localstack-kinesis || true
+	docker rm async_aws_localstack-kinesis || true

--- a/src/Service/Kms/Makefile
+++ b/src/Service/Kms/Makefile
@@ -14,3 +14,4 @@ test: initialize
 clean: stop-docker
 stop-docker:
 	docker stop async_aws_localstack-kms || true
+	docker rm async_aws_localstack-kms || true

--- a/src/Service/Kms/Makefile
+++ b/src/Service/Kms/Makefile
@@ -2,9 +2,9 @@
 
 initialize: start-docker
 start-docker:
-	docker start async_aws_localstack && exit 0 || \
+	docker start async_aws_kms && exit 0 || \
 	docker start async_aws_localstack-kms && exit 0 || \
-	docker pull localstack/localstack:0.14.2 && \
+	docker pull nsmithuk/local-kms && \
 	docker run -d -p 4579:8080 --name async_aws_localstack-kms nsmithuk/local-kms && \
 	docker run --rm --link async_aws_localstack-kms:localstack martin/wait -c localstack:8080
 

--- a/src/Service/Lambda/Makefile
+++ b/src/Service/Lambda/Makefile
@@ -5,7 +5,7 @@ ROOT_DIR:=$(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 initialize: start-docker
 start-docker:
 	docker start async_aws_lambda && exit 0 || \
-	docker pull lambci/lambda && \
+	docker pull lambci/lambda:nodejs12.x && \
 	docker run -d -p 9001:9001 -e DOCKER_LAMBDA_STAY_OPEN=1 -v "$(ROOT_DIR)/tests/fixtures/lambda":/var/task:ro,delegated --name async_aws_lambda lambci/lambda:nodejs12.x index.handler
 
 test: initialize

--- a/src/Service/Lambda/Makefile
+++ b/src/Service/Lambda/Makefile
@@ -14,3 +14,4 @@ test: initialize
 clean: stop-docker
 stop-docker:
 	docker stop async_aws_lambda || true
+	docker rm async_aws_lambda || true

--- a/src/Service/Route53/Makefile
+++ b/src/Service/Route53/Makefile
@@ -14,3 +14,4 @@ test: initialize
 clean: stop-docker
 stop-docker:
 	docker stop async_aws_localstack-route53 || true
+	docker rm async_aws_localstack-route53 || true

--- a/src/Service/S3/Makefile
+++ b/src/Service/S3/Makefile
@@ -13,3 +13,4 @@ test: initialize
 clean: stop-docker
 stop-docker:
 	docker stop async_aws_s3-client || true
+	docker rm async_aws_s3-client || true

--- a/src/Service/SecretsManager/Makefile
+++ b/src/Service/SecretsManager/Makefile
@@ -14,4 +14,4 @@ test: initialize
 clean: stop-docker
 stop-docker:
 	docker stop async_aws_localstack-secretsmanager || true
-
+	docker rm async_aws_localstack-secretsmanager || true

--- a/src/Service/Sns/Makefile
+++ b/src/Service/Sns/Makefile
@@ -14,3 +14,4 @@ test: initialize
 clean: stop-docker
 stop-docker:
 	docker stop async_aws_localstack-sns || true
+	docker rm async_aws_localstack-sns || true

--- a/src/Service/Sqs/Makefile
+++ b/src/Service/Sqs/Makefile
@@ -12,3 +12,4 @@ test: initialize
 clean: stop-docker
 stop-docker:
 	docker stop async_aws_sqs || true
+	docker rm async_aws_sqs || true

--- a/src/Service/Ssm/Makefile
+++ b/src/Service/Ssm/Makefile
@@ -14,3 +14,4 @@ test: initialize
 clean: stop-docker
 stop-docker:
 	docker stop async_aws_localstack-ssm || true
+	docker rm async_aws_localstack-ssm || true


### PR DESCRIPTION
When working on #1596, I discovered that our makefile setups were not properly cleaning containers. So once you run the initialization once, any update of the image would not be taken into account unless containers are cleaned manually.

I also found some inconsistencies between which image was pulled and which image was actually used in some services, which I cleaned in this PR.