### PR TITLE
Fix the generated code for enum-based map keys for json services

### DIFF
--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestJsonSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestJsonSerializer.php
@@ -227,8 +227,8 @@ class RestJsonSerializer implements Serializer
         $mapKeyShape = $shape->getKey()->getShape();
         if (!empty($mapKeyShape->getEnum())) {
             $enumClassName = $this->namespaceRegistry->getEnum($mapKeyShape);
-            $validateEnum = strtr('if (!ENUM_CLASS::exists($mapKey)) {
-                    throw new InvalidArgument(sprintf(\'Invalid key for "%s". The value "%s" is not a valid "ENUM_CLASS".\', __CLASS__, $mapKey));
+            $validateEnum = strtr('if (!ENUM_CLASS::exists($name)) {
+                    throw new InvalidArgument(sprintf(\'Invalid key for "%s". The value "%s" is not a valid "ENUM_CLASS".\', __CLASS__, $name));
                 }', [
                 'ENUM_CLASS' => $enumClassName->getName(),
             ]);

--- a/tests/Unit/ChangelogTest.php
+++ b/tests/Unit/ChangelogTest.php
@@ -219,7 +219,9 @@ class ChangelogTest extends TestCase
             } elseif ('Integration' === $parts[1]) {
                 $service = $parts[2] . '/' . $parts[3];
                 $base = 'src/Integration/' . $service;
-            } elseif ('CodeGenerator' === $parts[1] || 'Core' === $parts[1]) {
+            } elseif ('CodeGenerator' === $parts[1]) {
+                continue; // The code generator does not have a changelog as it has no releases
+            } elseif ('Core' === $parts[1]) {
                 $service = $parts[1];
                 $base = 'src/' . $service;
             } else {


### PR DESCRIPTION
This fixes the bug discovered in https://github.com/async-aws/aws/pull/1601#pullrequestreview-1722218379

Once merged, we will re-run the code generator for that PR.