### PR TITLE
Add the ability to manually run the workflow updating the SDK

### DIFF
--- a/.github/workflows/watch.yml
+++ b/.github/workflows/watch.yml
@@ -3,6 +3,7 @@ name: Watch for changes
 on:
   schedule:
     - cron: "0 6 * * *"
+  workflow_dispatch: ~
 
 jobs:
   generated-code:


### PR DESCRIPTION
This avoids waiting for the scheduled run on the next day when we make fixes in the code generator to fix an update.