### PR TITLE
Work around where empty lists are missing from responses

### DIFF
--- a/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
@@ -336,7 +336,7 @@ class RestJsonParser implements Parser
         return strtr($required ? '$this->FUNCTION_NAME(INPUT)' : 'EMPTY_METHOD(INPUT) ? EMPTY : $this->FUNCTION_NAME(INPUT)', [
             'EMPTY_METHOD' => $inObject ? '!isset' : 'empty',
             'EMPTY' => !$inObject ? '[]' : 'null',
-            'INPUT' => $input,
+            'INPUT' => $required && !$inObject ? "$input ?? []" : $input,
             'FUNCTION_NAME' => $functionName,
         ]);
     }

--- a/src/Service/CognitoIdentityProvider/src/Result/GetUserResponse.php
+++ b/src/Service/CognitoIdentityProvider/src/Result/GetUserResponse.php
@@ -101,7 +101,7 @@ class GetUserResponse extends Result
         $data = $response->toArray();
 
         $this->username = (string) $data['Username'];
-        $this->userAttributes = $this->populateResultAttributeListType($data['UserAttributes']);
+        $this->userAttributes = $this->populateResultAttributeListType($data['UserAttributes'] ?? []);
         $this->mfaOptions = empty($data['MFAOptions']) ? [] : $this->populateResultMFAOptionListType($data['MFAOptions']);
         $this->preferredMfaSetting = isset($data['PreferredMfaSetting']) ? (string) $data['PreferredMfaSetting'] : null;
         $this->userMfaSettingList = empty($data['UserMFASettingList']) ? [] : $this->populateResultUserMFASettingListType($data['UserMFASettingList']);

--- a/src/Service/DynamoDb/src/Result/BatchGetItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/BatchGetItemOutput.php
@@ -206,7 +206,7 @@ class BatchGetItemOutput extends Result implements \IteratorAggregate
     {
         $items = [];
         foreach ($json as $name => $value) {
-            $items[(string) $name] = $this->populateResultItemList($value);
+            $items[(string) $name] = $this->populateResultItemList($value ?? []);
         }
 
         return $items;

--- a/src/Service/DynamoDb/src/Result/BatchWriteItemOutput.php
+++ b/src/Service/DynamoDb/src/Result/BatchWriteItemOutput.php
@@ -142,7 +142,7 @@ class BatchWriteItemOutput extends Result
     {
         $items = [];
         foreach ($json as $name => $value) {
-            $items[(string) $name] = $this->populateResultWriteRequests($value);
+            $items[(string) $name] = $this->populateResultWriteRequests($value ?? []);
         }
 
         return $items;
@@ -247,7 +247,7 @@ class BatchWriteItemOutput extends Result
     {
         $items = [];
         foreach ($json as $name => $value) {
-            $items[(string) $name] = $this->populateResultItemCollectionMetricsMultiple($value);
+            $items[(string) $name] = $this->populateResultItemCollectionMetricsMultiple($value ?? []);
         }
 
         return $items;

--- a/src/Service/DynamoDb/src/Result/DescribeEndpointsResponse.php
+++ b/src/Service/DynamoDb/src/Result/DescribeEndpointsResponse.php
@@ -29,7 +29,7 @@ class DescribeEndpointsResponse extends Result
     {
         $data = $response->toArray();
 
-        $this->endpoints = $this->populateResultEndpoints($data['Endpoints']);
+        $this->endpoints = $this->populateResultEndpoints($data['Endpoints'] ?? []);
     }
 
     private function populateResultEndpoint(array $json): Endpoint

--- a/src/Service/DynamoDb/src/Result/TransactWriteItemsOutput.php
+++ b/src/Service/DynamoDb/src/Result/TransactWriteItemsOutput.php
@@ -163,7 +163,7 @@ class TransactWriteItemsOutput extends Result
     {
         $items = [];
         foreach ($json as $name => $value) {
-            $items[(string) $name] = $this->populateResultItemCollectionMetricsMultiple($value);
+            $items[(string) $name] = $this->populateResultItemCollectionMetricsMultiple($value ?? []);
         }
 
         return $items;

--- a/src/Service/Firehose/src/Result/PutRecordBatchOutput.php
+++ b/src/Service/Firehose/src/Result/PutRecordBatchOutput.php
@@ -61,7 +61,7 @@ class PutRecordBatchOutput extends Result
 
         $this->failedPutCount = (int) $data['FailedPutCount'];
         $this->encrypted = isset($data['Encrypted']) ? filter_var($data['Encrypted'], \FILTER_VALIDATE_BOOLEAN) : null;
-        $this->requestResponses = $this->populateResultPutRecordBatchResponseEntryList($data['RequestResponses']);
+        $this->requestResponses = $this->populateResultPutRecordBatchResponseEntryList($data['RequestResponses'] ?? []);
     }
 
     private function populateResultPutRecordBatchResponseEntry(array $json): PutRecordBatchResponseEntry

--- a/src/Service/Kinesis/src/Result/GetRecordsOutput.php
+++ b/src/Service/Kinesis/src/Result/GetRecordsOutput.php
@@ -83,7 +83,7 @@ class GetRecordsOutput extends Result
     {
         $data = $response->toArray();
 
-        $this->records = $this->populateResultRecordList($data['Records']);
+        $this->records = $this->populateResultRecordList($data['Records'] ?? []);
         $this->nextShardIterator = isset($data['NextShardIterator']) ? (string) $data['NextShardIterator'] : null;
         $this->millisBehindLatest = isset($data['MillisBehindLatest']) ? (int) $data['MillisBehindLatest'] : null;
         $this->childShards = empty($data['ChildShards']) ? [] : $this->populateResultChildShardList($data['ChildShards']);

--- a/src/Service/Kinesis/src/Result/ListStreamsOutput.php
+++ b/src/Service/Kinesis/src/Result/ListStreamsOutput.php
@@ -185,7 +185,7 @@ class ListStreamsOutput extends Result implements \IteratorAggregate
     {
         $data = $response->toArray();
 
-        $this->streamNames = $this->populateResultStreamNameList($data['StreamNames']);
+        $this->streamNames = $this->populateResultStreamNameList($data['StreamNames'] ?? []);
         $this->hasMoreStreams = filter_var($data['HasMoreStreams'], \FILTER_VALIDATE_BOOLEAN);
         $this->nextToken = isset($data['NextToken']) ? (string) $data['NextToken'] : null;
         $this->streamSummaries = empty($data['StreamSummaries']) ? [] : $this->populateResultStreamSummaryList($data['StreamSummaries']);

--- a/src/Service/Kinesis/src/Result/ListTagsForStreamOutput.php
+++ b/src/Service/Kinesis/src/Result/ListTagsForStreamOutput.php
@@ -48,7 +48,7 @@ class ListTagsForStreamOutput extends Result
     {
         $data = $response->toArray();
 
-        $this->tags = $this->populateResultTagList($data['Tags']);
+        $this->tags = $this->populateResultTagList($data['Tags'] ?? []);
         $this->hasMoreTags = filter_var($data['HasMoreTags'], \FILTER_VALIDATE_BOOLEAN);
     }
 

--- a/src/Service/Kinesis/src/Result/PutRecordsOutput.php
+++ b/src/Service/Kinesis/src/Result/PutRecordsOutput.php
@@ -70,7 +70,7 @@ class PutRecordsOutput extends Result
         $data = $response->toArray();
 
         $this->failedRecordCount = isset($data['FailedRecordCount']) ? (int) $data['FailedRecordCount'] : null;
-        $this->records = $this->populateResultPutRecordsResultEntryList($data['Records']);
+        $this->records = $this->populateResultPutRecordsResultEntryList($data['Records'] ?? []);
         $this->encryptionType = isset($data['EncryptionType']) ? (string) $data['EncryptionType'] : null;
     }
 

--- a/src/Service/LocationService/src/Exception/ValidationException.php
+++ b/src/Service/LocationService/src/Exception/ValidationException.php
@@ -46,7 +46,7 @@ final class ValidationException extends ClientException
     {
         $data = $response->toArray(false);
 
-        $this->fieldList = $this->populateResultValidationExceptionFieldList($data['fieldList']);
+        $this->fieldList = $this->populateResultValidationExceptionFieldList($data['fieldList'] ?? []);
         $this->reason = (string) $data['reason'];
     }
 

--- a/src/Service/LocationService/src/Result/CalculateRouteMatrixResponse.php
+++ b/src/Service/LocationService/src/Result/CalculateRouteMatrixResponse.php
@@ -87,7 +87,7 @@ class CalculateRouteMatrixResponse extends Result
     {
         $data = $response->toArray();
 
-        $this->routeMatrix = $this->populateResultRouteMatrix($data['RouteMatrix']);
+        $this->routeMatrix = $this->populateResultRouteMatrix($data['RouteMatrix'] ?? []);
         $this->snappedDeparturePositions = empty($data['SnappedDeparturePositions']) ? [] : $this->populateResultCalculateRouteMatrixResponseSnappedDeparturePositionsList($data['SnappedDeparturePositions']);
         $this->snappedDestinationPositions = empty($data['SnappedDestinationPositions']) ? [] : $this->populateResultCalculateRouteMatrixResponseSnappedDestinationPositionsList($data['SnappedDestinationPositions']);
         $this->summary = $this->populateResultCalculateRouteMatrixSummary($data['Summary']);
@@ -100,7 +100,7 @@ class CalculateRouteMatrixResponse extends Result
     {
         $items = [];
         foreach ($json as $item) {
-            $items[] = $this->populateResultPosition($item);
+            $items[] = $this->populateResultPosition($item ?? []);
         }
 
         return $items;
@@ -113,7 +113,7 @@ class CalculateRouteMatrixResponse extends Result
     {
         $items = [];
         foreach ($json as $item) {
-            $items[] = $this->populateResultPosition($item);
+            $items[] = $this->populateResultPosition($item ?? []);
         }
 
         return $items;
@@ -152,7 +152,7 @@ class CalculateRouteMatrixResponse extends Result
     {
         $items = [];
         foreach ($json as $item) {
-            $items[] = $this->populateResultRouteMatrixRow($item);
+            $items[] = $this->populateResultRouteMatrixRow($item ?? []);
         }
 
         return $items;

--- a/src/Service/LocationService/src/Result/CalculateRouteResponse.php
+++ b/src/Service/LocationService/src/Result/CalculateRouteResponse.php
@@ -67,7 +67,7 @@ class CalculateRouteResponse extends Result
     {
         $data = $response->toArray();
 
-        $this->legs = $this->populateResultLegList($data['Legs']);
+        $this->legs = $this->populateResultLegList($data['Legs'] ?? []);
         $this->summary = $this->populateResultCalculateRouteSummary($data['Summary']);
     }
 

--- a/src/Service/LocationService/src/Result/SearchPlaceIndexForPositionResponse.php
+++ b/src/Service/LocationService/src/Result/SearchPlaceIndexForPositionResponse.php
@@ -49,7 +49,7 @@ class SearchPlaceIndexForPositionResponse extends Result
     {
         $data = $response->toArray();
 
-        $this->results = $this->populateResultSearchForPositionResultList($data['Results']);
+        $this->results = $this->populateResultSearchForPositionResultList($data['Results'] ?? []);
         $this->summary = $this->populateResultSearchPlaceIndexForPositionSummary($data['Summary']);
     }
 

--- a/src/Service/LocationService/src/Result/SearchPlaceIndexForTextResponse.php
+++ b/src/Service/LocationService/src/Result/SearchPlaceIndexForTextResponse.php
@@ -53,7 +53,7 @@ class SearchPlaceIndexForTextResponse extends Result
     {
         $data = $response->toArray();
 
-        $this->results = $this->populateResultSearchForTextResultList($data['Results']);
+        $this->results = $this->populateResultSearchForTextResultList($data['Results'] ?? []);
         $this->summary = $this->populateResultSearchPlaceIndexForTextSummary($data['Summary']);
     }
 

--- a/src/Service/RdsDataService/src/Result/ExecuteStatementResponse.php
+++ b/src/Service/RdsDataService/src/Result/ExecuteStatementResponse.php
@@ -251,7 +251,7 @@ class ExecuteStatementResponse extends Result
     {
         $items = [];
         foreach ($json as $item) {
-            $items[] = $this->populateResultFieldList($item);
+            $items[] = $this->populateResultFieldList($item ?? []);
         }
 
         return $items;

--- a/src/Service/Scheduler/src/Result/ListScheduleGroupsOutput.php
+++ b/src/Service/Scheduler/src/Result/ListScheduleGroupsOutput.php
@@ -94,7 +94,7 @@ class ListScheduleGroupsOutput extends Result implements \IteratorAggregate
         $data = $response->toArray();
 
         $this->nextToken = isset($data['NextToken']) ? (string) $data['NextToken'] : null;
-        $this->scheduleGroups = $this->populateResultScheduleGroupList($data['ScheduleGroups']);
+        $this->scheduleGroups = $this->populateResultScheduleGroupList($data['ScheduleGroups'] ?? []);
     }
 
     /**

--- a/src/Service/Scheduler/src/Result/ListSchedulesOutput.php
+++ b/src/Service/Scheduler/src/Result/ListSchedulesOutput.php
@@ -95,7 +95,7 @@ class ListSchedulesOutput extends Result implements \IteratorAggregate
         $data = $response->toArray();
 
         $this->nextToken = isset($data['NextToken']) ? (string) $data['NextToken'] : null;
-        $this->schedules = $this->populateResultScheduleList($data['Schedules']);
+        $this->schedules = $this->populateResultScheduleList($data['Schedules'] ?? []);
     }
 
     /**

--- a/src/Service/Sqs/src/Result/ChangeMessageVisibilityBatchResult.php
+++ b/src/Service/Sqs/src/Result/ChangeMessageVisibilityBatchResult.php
@@ -51,8 +51,8 @@ class ChangeMessageVisibilityBatchResult extends Result
     {
         $data = $response->toArray();
 
-        $this->successful = $this->populateResultChangeMessageVisibilityBatchResultEntryList($data['Successful']);
-        $this->failed = $this->populateResultBatchResultErrorEntryList($data['Failed']);
+        $this->successful = $this->populateResultChangeMessageVisibilityBatchResultEntryList($data['Successful'] ?? []);
+        $this->failed = $this->populateResultBatchResultErrorEntryList($data['Failed'] ?? []);
     }
 
     private function populateResultBatchResultErrorEntry(array $json): BatchResultErrorEntry

--- a/src/Service/Sqs/src/Result/DeleteMessageBatchResult.php
+++ b/src/Service/Sqs/src/Result/DeleteMessageBatchResult.php
@@ -51,8 +51,8 @@ class DeleteMessageBatchResult extends Result
     {
         $data = $response->toArray();
 
-        $this->successful = $this->populateResultDeleteMessageBatchResultEntryList($data['Successful']);
-        $this->failed = $this->populateResultBatchResultErrorEntryList($data['Failed']);
+        $this->successful = $this->populateResultDeleteMessageBatchResultEntryList($data['Successful'] ?? []);
+        $this->failed = $this->populateResultBatchResultErrorEntryList($data['Failed'] ?? []);
     }
 
     private function populateResultBatchResultErrorEntry(array $json): BatchResultErrorEntry

--- a/src/Service/Sqs/src/Result/SendMessageBatchResult.php
+++ b/src/Service/Sqs/src/Result/SendMessageBatchResult.php
@@ -51,8 +51,8 @@ class SendMessageBatchResult extends Result
     {
         $data = $response->toArray();
 
-        $this->successful = $this->populateResultSendMessageBatchResultEntryList($data['Successful']);
-        $this->failed = $this->populateResultBatchResultErrorEntryList($data['Failed']);
+        $this->successful = $this->populateResultSendMessageBatchResultEntryList($data['Successful'] ?? []);
+        $this->failed = $this->populateResultBatchResultErrorEntryList($data['Failed'] ?? []);
     }
 
     private function populateResultBatchResultErrorEntry(array $json): BatchResultErrorEntry

--- a/src/Service/TimestreamQuery/src/Result/DescribeEndpointsResponse.php
+++ b/src/Service/TimestreamQuery/src/Result/DescribeEndpointsResponse.php
@@ -29,7 +29,7 @@ class DescribeEndpointsResponse extends Result
     {
         $data = $response->toArray();
 
-        $this->endpoints = $this->populateResultEndpoints($data['Endpoints']);
+        $this->endpoints = $this->populateResultEndpoints($data['Endpoints'] ?? []);
     }
 
     private function populateResultEndpoint(array $json): Endpoint

--- a/src/Service/TimestreamQuery/src/Result/PrepareQueryResponse.php
+++ b/src/Service/TimestreamQuery/src/Result/PrepareQueryResponse.php
@@ -64,8 +64,8 @@ class PrepareQueryResponse extends Result
         $data = $response->toArray();
 
         $this->queryString = (string) $data['QueryString'];
-        $this->columns = $this->populateResultSelectColumnList($data['Columns']);
-        $this->parameters = $this->populateResultParameterMappingList($data['Parameters']);
+        $this->columns = $this->populateResultSelectColumnList($data['Columns'] ?? []);
+        $this->parameters = $this->populateResultParameterMappingList($data['Parameters'] ?? []);
     }
 
     private function populateResultColumnInfo(array $json): ColumnInfo

--- a/src/Service/TimestreamQuery/src/Result/QueryResponse.php
+++ b/src/Service/TimestreamQuery/src/Result/QueryResponse.php
@@ -145,8 +145,8 @@ class QueryResponse extends Result implements \IteratorAggregate
 
         $this->queryId = (string) $data['QueryId'];
         $this->nextToken = isset($data['NextToken']) ? (string) $data['NextToken'] : null;
-        $this->rows = $this->populateResultRowList($data['Rows']);
-        $this->columnInfo = $this->populateResultColumnInfoList($data['ColumnInfo']);
+        $this->rows = $this->populateResultRowList($data['Rows'] ?? []);
+        $this->columnInfo = $this->populateResultColumnInfoList($data['ColumnInfo'] ?? []);
         $this->queryStatus = empty($data['QueryStatus']) ? null : $this->populateResultQueryStatus($data['QueryStatus']);
     }
 

--- a/src/Service/TimestreamWrite/src/Result/DescribeEndpointsResponse.php
+++ b/src/Service/TimestreamWrite/src/Result/DescribeEndpointsResponse.php
@@ -29,7 +29,7 @@ class DescribeEndpointsResponse extends Result
     {
         $data = $response->toArray();
 
-        $this->endpoints = $this->populateResultEndpoints($data['Endpoints']);
+        $this->endpoints = $this->populateResultEndpoints($data['Endpoints'] ?? []);
     }
 
     private function populateResultEndpoint(array $json): Endpoint


### PR DESCRIPTION
This is a bug on the AWS server side, but I don't know anyone on the SQS service team to report this to, and basic support ain't gonna allow me to do that. We must thus mitigate on the client side. Fixes #1620.