### PR TITLE
gitignore `.idea` folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ composer.lock
 /website/package-lock.json
 /website/template/assets/*
 !/website/template/assets/.gitignore
+.idea


### PR DESCRIPTION
This is a folder which is automatically created by PhpStorm/Webstorm and can be safely ignored for Git.