### PR TITLE
Update event-bridge.md

### DIFF
--- a/docs/clients/event-bridge.md
+++ b/docs/clients/event-bridge.md
@@ -19,7 +19,7 @@ $eventBridge = new EventBridgeClient();
 $events = $eventBridge->putEvents(new PutEventsRequest([
     'Entries' => [
         new PutEventsRequestEntry([
-            'EventBusName' => 'marketing',
+            'EventBusName' => 'arn:aws:events:region:account:event-bus/event-bus-name',
             'Source' => 'acme.newsletter.campaign',
             'DetailType' => 'UserSignUp',
             'Detail' => json_encode(['email' => $userEmail]),


### PR DESCRIPTION
Change eventbus name to ARN. EventBusName should have the arn of the eventbus else it will not work. In the source code of async-aws it also says it needs an ARN not a eventbus name