### PR TITLE
Event bridge - Optimization of Connection Persistence in HTTP Client

### DIFF
--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## NOT RELEASED
 
+## 1.20.2
+
+### Fixed
+
+- Optimization of Connection Persistence in HTTP Client
+
 ## 1.20.1
 
 ### Changed

--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -145,13 +145,11 @@ final class Response
         try {
             if (null === $timeout) {
                 $this->httpResponse->getStatusCode();
+                $this->httpResponse->getContent(false);
             } else {
                 foreach ($this->httpClient->stream($this->httpResponse, $timeout) as $chunk) {
                     if ($chunk->isTimeout()) {
                         return false;
-                    }
-                    if ($chunk->isFirst()) {
-                        break;
                     }
                 }
             }

--- a/src/Core/tests/Unit/Credentials/DateFromResultTest.php
+++ b/src/Core/tests/Unit/Credentials/DateFromResultTest.php
@@ -5,24 +5,17 @@ namespace AsyncAws\Core\Tests\Unit\Credentials;
 use AsyncAws\Core\Credentials\DateFromResult;
 use AsyncAws\Core\Response;
 use AsyncAws\Core\Result;
+use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
-use Symfony\Component\HttpClient\Response\MockResponse;
 
 class DateFromResultTest extends TestCase
 {
     public function testWithValidDate()
     {
-        $httpResponse = $this->getMockBuilder(MockResponse::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getHeaders'])
-            ->getMock();
         $time = '2020-10-29 17:42:00';
-        $httpResponse->expects(self::once())
-            ->method('getHeaders')
-            ->with(false)
-            ->willReturn(['date' => [$time]]);
+        $httpResponse = new SimpleMockedResponse('{"foo":"bar"}', ['date' => $time], 200);
 
         $response = new Response($httpResponse, new MockHttpClient(), new NullLogger());
         $result = new DummyResult($response);
@@ -34,15 +27,7 @@ class DateFromResultTest extends TestCase
 
     public function testWithNoDate()
     {
-        $httpResponse = $this->getMockBuilder(MockResponse::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getHeaders'])
-            ->getMock();
-
-        $httpResponse->expects(self::once())
-            ->method('getHeaders')
-            ->with(false)
-            ->willReturn([]);
+        $httpResponse = new SimpleMockedResponse('{"foo":"bar"}', [], 200);
 
         $response = new Response($httpResponse, new MockHttpClient(), new NullLogger());
         $result = new DummyResult($response);


### PR DESCRIPTION
This merge request addresses a significant performance issue in the HTTP client, specifically relating to the management of keep-alive connections. Previously, when only the status code of the HTTP response was retrieved without accessing the content, it inadvertently led to the termination of keep-alive connections on the client side (particularly noticeable with curl). This behavior resulted in the need for re-establishing connections and performing a new handshake for subsequent requests. Such a process introduced a considerable delay ranging between 30-80 ms for each request, substantially impacting the overall efficiency.

The proposed changes in this merge request aim to optimize this behavior. By ensuring that the content of the HTTP response is accessed ($this->httpResponse->getContent(false)) even when a timeout is not specified (null === $timeout), we maintain the persistence of the keep-alive connection. This approach effectively avoids the overhead of re-establishing connections and performing handshakes for subsequent requests, thereby enhancing the performance of the HTTP client.

These changes are crucial for scenarios where high-frequency requests are made, as it significantly reduces the cumulative latency. This optimization is particularly beneficial for applications requiring fast and efficient communication with AWS services.

Included is the updated code snippet for the resolve function, which now ensures that the content of the HTTP response is accessed irrespective of the timeout condition, thereby maintaining the keep-alive connection state effectively.