### PR TITLE
Remove discoverEndpoints when not used anymore

### DIFF
--- a/src/CodeGenerator/src/Definition/ServiceDefinition.php
+++ b/src/CodeGenerator/src/Definition/ServiceDefinition.php
@@ -65,6 +65,11 @@ class ServiceDefinition
      */
     private $apiReferenceUrl;
 
+    /**
+     * @var false|Operation|null
+     */
+    private $cachedEndpointOperation = false;
+
     public function __construct(string $name, array $endpoints, array $definition, array $documentation, array $pagination, array $waiter, array $example, array $hooks, string $apiReferenceUrl)
     {
         $this->name = $name;
@@ -108,15 +113,19 @@ class ServiceDefinition
         return null;
     }
 
-    public function findEndpointOperationName(): ?Operation
+    public function findEndpointOperation(): ?Operation
     {
+        if (false !== $this->cachedEndpointOperation) {
+            return $this->cachedEndpointOperation;
+        }
+
         foreach ($this->definition['operations'] as $name => $data) {
             if (isset($data['endpointoperation'])) {
-                return $this->getOperation($name);
+                return $this->cachedEndpointOperation = $this->getOperation($name);
             }
         }
 
-        return null;
+        return $this->cachedEndpointOperation = null;
     }
 
     public function getWaiter(string $name): ?Waiter

--- a/src/CodeGenerator/src/Generator/OperationGenerator.php
+++ b/src/CodeGenerator/src/Generator/OperationGenerator.php
@@ -203,29 +203,33 @@ class OperationGenerator
             $extra .= ", 'exceptionMapping' => [\n" . implode("\n", $mapping) . "\n]";
         }
 
-        if ($operation->requiresEndpointDiscovery()) {
-            if (0 !== strpos($classBuilder->getClassName()->getFqdn(), 'AsyncAws\Core\\')) {
-                $this->requirementsRegistry->addRequirement('async-aws/core', '^1.16');
-            }
-            $endpointOperation = $operation->getService()->findEndpointOperationName();
+        $endpointOperation = $operation->getService()->findEndpointOperation();
+        if ($endpointOperation) {
+            if ($operation->requiresEndpointDiscovery()) {
+                if (0 !== strpos($classBuilder->getClassName()->getFqdn(), 'AsyncAws\Core\\')) {
+                    $this->requirementsRegistry->addRequirement('async-aws/core', '^1.16');
+                }
 
-            if (null !== $endpointOperation) {
-                $this->generate($endpointOperation);
-            }
+                if (null !== $endpointOperation) {
+                    $this->generate($endpointOperation);
+                }
 
-            $extra .= ", 'requiresEndpointDiscovery' => true";
-        }
-        if ($operation->usesEndpointDiscovery()) {
-            if (0 !== strpos($classBuilder->getClassName()->getFqdn(), 'AsyncAws\Core\\')) {
-                $this->requirementsRegistry->addRequirement('async-aws/core', '^1.16');
+                $extra .= ", 'requiresEndpointDiscovery' => true";
             }
-            $endpointOperation = $operation->getService()->findEndpointOperationName();
+            if ($operation->usesEndpointDiscovery()) {
+                if (0 !== strpos($classBuilder->getClassName()->getFqdn(), 'AsyncAws\Core\\')) {
+                    $this->requirementsRegistry->addRequirement('async-aws/core', '^1.16');
+                }
+                $endpointOperation = $operation->getService()->findEndpointOperation();
 
-            if (null !== $endpointOperation) {
-                $this->generate($endpointOperation);
+                if (null !== $endpointOperation) {
+                    $this->generate($endpointOperation);
+                }
+
+                $extra .= ", 'usesEndpointDiscovery' => true";
             }
-
-            $extra .= ", 'usesEndpointDiscovery' => true";
+        } else {
+            $classBuilder->removeMethod('discoverEndpoints');
         }
 
         $method->setBody(strtr($body, [

--- a/src/CodeGenerator/src/Generator/PhpGenerator/ClassBuilder.php
+++ b/src/CodeGenerator/src/Generator/PhpGenerator/ClassBuilder.php
@@ -106,6 +106,13 @@ class ClassBuilder
         return $this->class->hasMethod($name);
     }
 
+    public function removeMethod(string $name): void
+    {
+        if ($this->class->hasMethod($name)) {
+            $this->class->removeMethod($name);
+        }
+    }
+
     /**
      * @param Method[] $methods
      */


### PR DESCRIPTION
The current logic of the `CodeGenerator` registers the operation when it is flagged `EndpointOperation` (the generator adds a new `discoverEndpoints` method that overrides the method from AbstractApi) 

The issue is, AWS removes the flag `EndpointOperation` on some service but our logic was not able to detect the removal of a flag.

This removes the `discoverEndpoints` method when there isn't operations flagged anymore

This should remove deprecations in https://github.com/async-aws/aws/pull/1657


I had to remove your custom patch @stof . Could you check that endpoint discovery is not needed anymore?