### PR TITLE
Add endpoint URL env variable to fallback options

### DIFF
--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Added
+
+- Support for AWS_ENDPOINT_URL environment variable
+
 ## 1.20.1
 
 ### Changed

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -38,7 +38,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.20-dev"
+            "dev-master": "1.21-dev"
         }
     }
 }

--- a/src/Core/src/Configuration.php
+++ b/src/Core/src/Configuration.php
@@ -66,6 +66,7 @@ final class Configuration
         ],
         [self::OPTION_SHARED_CREDENTIALS_FILE => 'AWS_SHARED_CREDENTIALS_FILE'],
         [self::OPTION_SHARED_CONFIG_FILE => 'AWS_CONFIG_FILE'],
+        [self::OPTION_ENDPOINT => 'AWS_ENDPOINT_URL'],
         [
             self::OPTION_ROLE_ARN => 'AWS_ROLE_ARN',
             self::OPTION_WEB_IDENTITY_TOKEN_FILE => 'AWS_WEB_IDENTITY_TOKEN_FILE',

--- a/src/Core/tests/Unit/ConfigurationTest.php
+++ b/src/Core/tests/Unit/ConfigurationTest.php
@@ -70,6 +70,7 @@ class ConfigurationTest extends TestCase
 
         yield 'default when env missing' => [[], [], ['profile' => 'default']];
         yield 'fallback env' => [[], ['AWS_PROFILE' => 'foo'], ['profile' => 'foo']];
+        yield 'fallback endpoint env' => [[], ['AWS_ENDPOINT_URL' => 'http://localhost:4566'], ['endpoint' => 'http://localhost:4566']];
         yield 'config priority on env' => [['profile' => 'bar'], ['AWS_PROFILE' => 'foo'], ['profile' => 'bar']];
 
         yield 'config with env group' => [['accessKeyId' => 'key'], [], ['accessKeyId' => 'key', 'sessionToken' => null]];
@@ -92,18 +93,5 @@ class ConfigurationTest extends TestCase
 
         self::assertFalse($config->isDefault('region'));
         self::assertEquals('eu-central-1', $config->get('region'));
-    }
-
-    public function testEndpointFromEnv()
-    {
-        $_SERVER['AWS_ENDPOINT_URL'] = 'http://localhost:4566';
-
-        try {
-            $config = Configuration::create([]);
-
-            self::assertEquals('http://localhost:4566', $config->get('endpoint'));
-        } finally {
-            unset($_SERVER['AWS_ENDPOINT_URL']);
-        }
     }
 }

--- a/src/Core/tests/Unit/ConfigurationTest.php
+++ b/src/Core/tests/Unit/ConfigurationTest.php
@@ -93,4 +93,17 @@ class ConfigurationTest extends TestCase
         self::assertFalse($config->isDefault('region'));
         self::assertEquals('eu-central-1', $config->get('region'));
     }
+
+    public function testEndpointFromEnv()
+    {
+        $_SERVER['AWS_ENDPOINT_URL'] = 'http://localhost:4566';
+
+        try {
+            $config = Configuration::create([]);
+
+            self::assertEquals('http://localhost:4566', $config->get('endpoint'));
+        } finally {
+            unset($_SERVER['AWS_ENDPOINT_URL']);
+        }
+    }
 }


### PR DESCRIPTION
Currently, Async AWS supports almost all environment variables from the official SDK (list is published [here](https://docs.aws.amazon.com/sdkref/latest/guide/settings-reference.html#EVarSettings)). `AWS_ENDPOINT_URL` is currently not supported but can be very useful for local development with LocalStack or a similar service by just providing it to the `.env` file. Here I added it to the list of fallback options. 

Future improvements can include `AWS_ENDPOINT_URL_<SERVICE>` as well.

