### PR TITLE
Add hint to the presign documentation how to upload a file

### DIFF
--- a/docs/features/presign.md
+++ b/docs/features/presign.md
@@ -23,10 +23,10 @@ $input = new GetObjectRequest([
     'Key' => 'test',
 ]);
 // To allow uploading a file use:
-$input = new PutObjectRequest([
-    'Bucket' => 'my-bucket',
-    'Key' => 'test',
-]);
+// $input = new PutObjectRequest([
+//     'Bucket' => 'my-bucket',
+//     'Key' => 'test',
+// ]);
 
 $url = $s3->presign($input, new \DateTimeImmutable('+60 min'));
 

--- a/docs/features/presign.md
+++ b/docs/features/presign.md
@@ -13,10 +13,17 @@ for a limited time.
 
 ```php
 use AsyncAws\S3\Input\GetObjectRequest;
+use AsyncAws\S3\Input\PutObjectRequest;
 use AsyncAws\S3\S3Client;
 
 $s3 = new S3Client();
+// To allow reading of a file use:
 $input = new GetObjectRequest([
+    'Bucket' => 'my-bucket',
+    'Key' => 'test',
+]);
+// To allow uploading a file use:
+$input = new PutObjectRequest([
     'Bucket' => 'my-bucket',
     'Key' => 'test',
 ]);


### PR DESCRIPTION
I was confused that I can not upload a file until I realized that the Request was explicitly "Get" and I had simply to switch it to "Put" to upload files via the presigned url.