### PR TITLE
Add possibility to use locking with DynamoDB sessions

### DIFF
--- a/src/Integration/Aws/DynamoDbSession/CHANGELOG.md
+++ b/src/Integration/Aws/DynamoDbSession/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Added
 
 - Added support for `async-aws/dynamo-db` 2.0 and 3.0
+- Support locking by configuring `locking`, `max_lock_wait_time`, `min_lock_retry_microtime` & `max_lock_retry_microtime`
 
 ## 1.0.2
 

--- a/src/Integration/Aws/DynamoDbSession/composer.json
+++ b/src/Integration/Aws/DynamoDbSession/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "async-aws/dynamo-db": "^1.0 || ^2.0 || ^3.0"
+        "async-aws/dynamo-db": "^1.1 || ^2.0 || ^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Integration/Aws/DynamoDbSession/src/SessionHandler.php
+++ b/src/Integration/Aws/DynamoDbSession/src/SessionHandler.php
@@ -285,9 +285,9 @@ class SessionHandler implements \SessionHandlerInterface
                     'ReturnValues' => 'ALL_NEW',
                 ])->getAttributes();
             } catch (ConditionalCheckFailedException $e) {
-                // If we were to exceed the timeout after sleep, let's give up immediately.
-                $sleep = rand($this->options['min_lock_retry_microtime'], $this->options['max_lock_retry_microtime']);
-                if (microtime(true) + $sleep * 1e-6 > $timeout) {
+                $sleep = min((int) (($timeout - microtime(true)) * 1e6), random_int($this->options['min_lock_retry_microtime'], $this->options['max_lock_retry_microtime']));
+
+                if ($sleep < 0) {
                     throw $e;
                 }
 

--- a/src/Integration/Aws/DynamoDbSession/src/SessionHandler.php
+++ b/src/Integration/Aws/DynamoDbSession/src/SessionHandler.php
@@ -77,10 +77,10 @@ class SessionHandler implements \SessionHandlerInterface
         $options['session_lifetime_attribute'] = $options['session_lifetime_attribute'] ?? 'expires';
         $options['id_separator'] = $options['id_separator'] ?? '_';
         $options['consistent_read'] = $options['consistent_read'] ?? true;
-        $options['locking'] = (bool) ($options['locking'] ?? false);
-        $options['max_lock_wait_time'] = (float) ($options['max_lock_wait_time'] ?? 10.0);
-        $options['min_lock_retry_microtime'] = (int) ($options['min_lock_retry_microtime'] ?? 10000);
-        $options['max_lock_retry_microtime'] = (int) ($options['max_lock_retry_microtime'] ?? 50000);
+        $options['locking'] = $options['locking'] ?? false;
+        $options['max_lock_wait_time'] = $options['max_lock_wait_time'] ?? 10.0;
+        $options['min_lock_retry_microtime'] = $options['min_lock_retry_microtime'] ?? 10000;
+        $options['max_lock_retry_microtime'] = $options['max_lock_retry_microtime'] ?? 50000;
         $this->options = $options;
     }
 

--- a/src/Integration/Aws/DynamoDbSession/tests/SessionHandlerLockingTest.php
+++ b/src/Integration/Aws/DynamoDbSession/tests/SessionHandlerLockingTest.php
@@ -1,0 +1,215 @@
+<?php
+
+namespace AsyncAws\DynamoDbSession\Tests;
+
+use AsyncAws\Core\AwsError\AwsError;
+use AsyncAws\Core\Test\ResultMockFactory;
+use AsyncAws\DynamoDb\DynamoDbClient;
+use AsyncAws\DynamoDb\Exception\ConditionalCheckFailedException;
+use AsyncAws\DynamoDb\Result\UpdateItemOutput;
+use AsyncAws\DynamoDb\ValueObject\AttributeValue;
+use AsyncAws\DynamoDbSession\SessionHandler;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class SessionHandlerLockingTest extends TestCase
+{
+    /**
+     * @var \PHPUnit\Framework\MockObject\MockObject|DynamoDbClient
+     */
+    private $client;
+
+    /**
+     * @var SessionHandler
+     */
+    private $handler;
+
+    protected function setUp(): void
+    {
+        $this->client = $this->createMock(DynamoDbClient::class);
+
+        $this->handler = new SessionHandler($this->client, [
+            'table_name' => 'testTable',
+            'session_lifetime' => 86400,
+            'locking' => true,
+            'max_lock_wait_time' => 1.0,
+            'min_lock_retry_microtime' => 300000,
+            'max_lock_retry_microtime' => 300000,
+        ]);
+
+        $this->handler->open(null, 'PHPSESSID');
+    }
+
+    public function testRead(): void
+    {
+        $this->client
+            ->expects(self::once())
+            ->method('updateItem')
+            ->with(self::equalTo([
+                'TableName' => 'testTable',
+                'Key' => [
+                    'id' => [
+                        'S' => 'PHPSESSID_123456789',
+                    ],
+                ],
+                'ConsistentRead' => true,
+                'Expected' => ['lock' => ['Exists' => false]],
+                'AttributeUpdates' => ['lock' => ['Value' => ['N' => '1']]],
+                'ReturnValues' => 'ALL_NEW',
+            ]))
+            ->willReturn(ResultMockFactory::create(UpdateItemOutput::class, [
+                'Attributes' => [
+                    'data' => new AttributeValue(['S' => 'test data']),
+                    'expires' => new AttributeValue(['N' => (string) (time() + 86400)]),
+                ],
+            ]));
+
+        self::assertEquals('test data', $this->handler->read('123456789'));
+    }
+
+    public static function readLockProvider(): array
+    {
+        return [
+            'success' => [3, 2, true],
+            'timeout' => [4, 4, false],
+        ];
+    }
+
+    /**
+     * @dataProvider readLockProvider
+     */
+    public function testReadLock(int $attempts, int $failCount, bool $expectedSuccess): void
+    {
+        $this->client
+            ->expects($matcher = self::exactly($attempts))
+            ->method('updateItem')
+            ->with(self::equalTo([
+                'TableName' => 'testTable',
+                'Key' => [
+                    'id' => [
+                        'S' => 'PHPSESSID_123456789',
+                    ],
+                ],
+                'ConsistentRead' => true,
+                'Expected' => ['lock' => ['Exists' => false]],
+                'AttributeUpdates' => ['lock' => ['Value' => ['N' => '1']]],
+                'ReturnValues' => 'ALL_NEW',
+            ]))
+            ->willReturnCallback(function () use ($matcher, $failCount) {
+                if ($matcher->getInvocationCount() <= $failCount) {
+                    $mockResponse = self::createMock(ResponseInterface::class);
+                    $mockResponse->method('getInfo')->willReturnMap([['http_code', 400]]);
+
+                    throw new ConditionalCheckFailedException($mockResponse, new AwsError('a', 'b', 'c', 'd'));
+                }
+
+                return ResultMockFactory::create(UpdateItemOutput::class, [
+                    'Attributes' => [
+                        'data' => new AttributeValue(['S' => 'test data']),
+                        'expires' => new AttributeValue(['N' => (string) (time() + 86400)]),
+                    ],
+                ]);
+            });
+
+        if (!$expectedSuccess) {
+            self::expectException(ConditionalCheckFailedException::class);
+        }
+
+        self::assertEquals('test data', $this->handler->read('123456789'));
+    }
+
+    public function testWriteWithUnchangedData(): void
+    {
+        $this->client
+            ->method('updateItem')
+            ->willReturnMap([
+                [
+                    [
+                        'TableName' => 'testTable',
+                        'Key' => ['id' => ['S' => 'PHPSESSID_123456789']],
+                        'ConsistentRead' => true,
+                        'Expected' => ['lock' => ['Exists' => false]],
+                        'AttributeUpdates' => ['lock' => ['Value' => ['N' => '1']]],
+                        'ReturnValues' => 'ALL_NEW',
+                    ],
+                    ResultMockFactory::create(UpdateItemOutput::class, [
+                        'Attributes' => [
+                            'data' => new AttributeValue(['S' => 'previous data']),
+                            'expires' => new AttributeValue(['N' => (string) (time() + 86400)]),
+                        ],
+                    ]),
+                ],
+                [
+                    [
+                        'TableName' => 'testTable',
+                        'Key' => [
+                            'id' => ['S' => 'PHPSESSID_123456789'],
+                        ],
+                        'AttributeUpdates' => [
+                            'expires' => ['Value' => ['N' => (string) (time() + 86400)]],
+                            'lock' => ['Action' => 'DELETE'],
+                        ],
+                    ],
+                    ResultMockFactory::create(UpdateItemOutput::class, [
+                        'Attributes' => [
+                            'data' => new AttributeValue(['S' => 'previous data']),
+                            'expires' => new AttributeValue(['N' => (string) (time() + 86400)]),
+                        ],
+                    ]),
+                ],
+            ]);
+
+        $this->handler->read('123456789');
+
+        self::assertTrue($this->handler->write('123456789', 'previous data'));
+    }
+
+    public function testWriteWithChangedData(): void
+    {
+        $this->client
+            ->method('updateItem')
+            ->willReturnMap([
+                [
+                    [
+                        'TableName' => 'testTable',
+                        'Key' => ['id' => ['S' => 'PHPSESSID_123456789']],
+                        'ConsistentRead' => true,
+                        'Expected' => ['lock' => ['Exists' => false]],
+                        'AttributeUpdates' => [
+                            'lock' => ['Value' => ['N' => '1']],
+                        ],
+                        'ReturnValues' => 'ALL_NEW',
+                    ],
+                    ResultMockFactory::create(UpdateItemOutput::class, [
+                        'Attributes' => [
+                            'data' => new AttributeValue(['S' => 'previous data']),
+                            'expires' => new AttributeValue(['N' => (string) (time() + 86400)]),
+                        ],
+                    ]),
+                ],
+                [
+                    [
+                        'TableName' => 'testTable',
+                        'Key' => [
+                            'id' => ['S' => 'PHPSESSID_123456789'],
+                        ],
+                        'AttributeUpdates' => [
+                            'expires' => ['Value' => ['N' => (string) (time() + 86400)]],
+                            'lock' => ['Action' => 'DELETE'],
+                            'data' => ['Value' => ['S' => 'new data']],
+                        ],
+                    ],
+                    ResultMockFactory::create(UpdateItemOutput::class, [
+                        'Attributes' => [
+                            'data' => new AttributeValue(['S' => 'previous data']),
+                            'expires' => new AttributeValue(['N' => (string) (time() + 86400)]),
+                        ],
+                    ]),
+                ],
+            ]);
+
+        $this->handler->read('123456789');
+
+        self::assertTrue($this->handler->write('123456789', 'new data'));
+    }
+}

--- a/src/Integration/Aws/DynamoDbSession/tests/SessionHandlerLockingTest.php
+++ b/src/Integration/Aws/DynamoDbSession/tests/SessionHandlerLockingTest.php
@@ -33,8 +33,8 @@ class SessionHandlerLockingTest extends TestCase
             'session_lifetime' => 86400,
             'locking' => true,
             'max_lock_wait_time' => 1.0,
-            'min_lock_retry_microtime' => 300000,
-            'max_lock_retry_microtime' => 300000,
+            'min_lock_retry_microtime' => 350000,
+            'max_lock_retry_microtime' => 350000,
         ]);
 
         $this->handler->open(null, 'PHPSESSID');


### PR DESCRIPTION
DynamoDB session handler in this library not supporting session locking makes it really difficult to migrate applications using the official AWS SDK with locking (or default file handler with locking) to `async-aws/dynamo-db-session`.

Unless there are some valid arguments not to support locking, I'd propose let's add it.