### PR TITLE
Fix for Issue #1412: AWS SQS Long Polling Empty Response

### DIFF
--- a/src/Service/Sqs/src/Result/ReceiveMessageResult.php
+++ b/src/Service/Sqs/src/Result/ReceiveMessageResult.php
@@ -32,6 +32,12 @@ class ReceiveMessageResult extends Result
 
     protected function populateResult(Response $response): void
     {
+        if ('' === $response->getContent()) {
+            $this->messages = [];
+
+            return;
+        }
+
         $data = $response->toArray();
 
         $this->messages = empty($data['Messages']) ? [] : $this->populateResultMessageList($data['Messages']);

--- a/src/Service/Sqs/tests/Unit/Result/ReceiveMessageResultTest.php
+++ b/src/Service/Sqs/tests/Unit/Result/ReceiveMessageResultTest.php
@@ -48,4 +48,29 @@ JSON
         self::assertArrayHasKey('ApproximateFirstReceiveTimestamp', $message->getAttributes());
         self::assertEquals('1250700979248', $message->getAttributes()['ApproximateFirstReceiveTimestamp']);
     }
+
+    public function testReceiveMessageEmptyArray()
+    {
+        $response = new SimpleMockedResponse(<<<JSON
+{
+    "Messages": []
+}
+JSON
+        );
+
+        $client = new MockHttpClient($response);
+        $result = new ReceiveMessageResult(new Response($client->request('POST', 'http://localhost'), $client, new NullLogger()));
+
+        self::assertCount(0, $result->getMessages());
+    }
+
+    public function testReceiveMessageEmptyStringLongPolling()
+    {
+        $response = new SimpleMockedResponse('');
+
+        $client = new MockHttpClient($response);
+        $result = new ReceiveMessageResult(new Response($client->request('POST', 'http://localhost'), $client, new NullLogger()));
+
+        self::assertCount(0, $result->getMessages());
+    }
 }


### PR DESCRIPTION
The [SQS documentation](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-short-and-long-polling.html) says the following:

> With long polling, the ReceiveMessage request queries all of the servers for messages. Amazon SQS sends a response after it collects at least one available message, up to the maximum number of messages specified in the request. Amazon SQS sends an empty response only if the polling wait time expires.

Since AWS can send an empty response instead of calling `$response->toArray()` I suggest to check first if response content is not an empty string.