### PR TITLE
[Symfony Bundle] Fix the usage of a deprecated class

### DIFF
--- a/src/Integration/Symfony/Bundle/src/DependencyInjection/AsyncAwsExtension.php
+++ b/src/Integration/Symfony/Bundle/src/DependencyInjection/AsyncAwsExtension.php
@@ -15,8 +15,8 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Contracts\Cache\CacheInterface;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 


### PR DESCRIPTION
Fixes this issue spotted while updating some app to Symfony 7.1:

```
The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered
internal since Symfony 7.1, to be deprecated in 8.1;
use Symfony\Component\DependencyInjection\Extension\Extension instead.
It may change without further notice. You should not use it from 
"AsyncAws\Symfony\Bundle\DependencyInjection\AsyncAwsExtension".
```