### PR TITLE
Fix exception not created from HEAD requests

### DIFF
--- a/src/CodeGenerator/src/Generator/OperationGenerator.php
+++ b/src/CodeGenerator/src/Generator/OperationGenerator.php
@@ -198,6 +198,10 @@ class OperationGenerator
             $classBuilder->addUse($errorClass->getFqdn());
 
             $mapping[] = sprintf('%s => %s::class,', var_export($error->getCode() ?? $error->getName(), true), $errorClass->getName());
+            if ('HEAD' === $operation->getHttpMethod() && ($statusCode = $error->getStatusCode()) >= 400) {
+                $this->requirementsRegistry->addRequirement('async-aws/core', '^1.22');
+                $mapping[] = sprintf('%s => %s::class,', var_export('http_status_code_' . $statusCode, true), $errorClass->getName());
+            }
         }
         if ($mapping) {
             $extra .= ", 'exceptionMapping' => [\n" . implode("\n", $mapping) . "\n]";

--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Added
+
+- Added support for exception based on response http status code only.
+
 ## 1.21.0
 
 ### Added

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -38,7 +38,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.21-dev"
+            "dev-master": "1.22-dev"
         }
     }
 }

--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -417,6 +417,8 @@ final class Response
 
             if ((null !== $awsCode = ($awsError ? $awsError->getCode() : null)) && isset($this->exceptionMapping[$awsCode])) {
                 $exceptionClass = $this->exceptionMapping[$awsCode];
+            } elseif (isset($this->exceptionMapping['http_status_code_' . $statusCode])) {
+                $exceptionClass = $this->exceptionMapping['http_status_code_' . $statusCode];
             } elseif (500 <= $statusCode) {
                 $exceptionClass = ServerException::class;
             } elseif (400 <= $statusCode) {

--- a/src/Service/S3/CHANGELOG.md
+++ b/src/Service/S3/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Fixed
+
+- Exception NoSuchKeyException not fired for `HeadObject` request.
+
 ## 2.2.1
 
 ### Changed

--- a/src/Service/S3/composer.json
+++ b/src/Service/S3/composer.json
@@ -16,7 +16,7 @@
         "ext-dom": "*",
         "ext-filter": "*",
         "ext-hash": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.22"
     },
     "autoload": {
         "psr-4": {

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -1630,6 +1630,7 @@ class S3Client extends AbstractApi
         $input = HeadObjectRequest::create($input);
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'HeadObject', 'region' => $input->getRegion(), 'exceptionMapping' => [
             'NoSuchKey' => NoSuchKeyException::class,
+            'http_status_code_404' => NoSuchKeyException::class,
         ]]));
 
         return new HeadObjectOutput($response);


### PR DESCRIPTION
fix #1723

IIUC the manifest, all errors are "linked" to a `httpStatusCode`, but we don't check it.

We might need a deep refactor that:
- check for the list of exceptions by HTTP status
- if the response doesn't have a body, and we have a single exception available for the httpStatus code, then we can use it.

any opinion?