### PR TITLE
Fix the branch alias for the location-service package

### DIFF
--- a/src/Service/LocationService/composer.json
+++ b/src/Service/LocationService/composer.json
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.1-dev"
+            "dev-master": "1.0-dev"
         }
     }
 }


### PR DESCRIPTION
#1722 broke the root tests by having a branch alias that does not match the changelog (probably due to the second commit doing manual changes to the changelog) and was merged with the failing CI jobs. this is meant to fix those jobs (this PR does not fix the PHP 8.4 job, which is failing for a different reason)