### PR TITLE
Resolve dependencies with phpunit version installed by simple-phpunit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,6 +168,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability ${{ matrix.minimum_stability }}
+          composer require --dev --no-update "phpunit/phpunit=9.6.*"
           composer update --no-interaction --prefer-dist --optimize-autoloader
 
       - name: Run tests


### PR DESCRIPTION
SimplePhpunit downloads the version 9.6 of PhpUnit, bug some dependencies might requires another version of PHPUnit.
As a result, we have 2 differents version of the library installed in the vendors and the autoloader might load the classes in a different order.

Leading to errors like:

> PHP Fatal error:  Declaration of PHPUnit\Framework\TestSuite::run(): void must be compatible with PHPUnit\Framework\Test::run(?PHPUnit\Framework\TestResult $result = null): PHPUnit\Framework\TestResult in /home/runner/work/aws/aws/vendor/phpunit/phpunit/src/Framework/TestSuite.php on line 328