### PR TITLE
Fix SymfonyContainer when both Credential and Cache are defined

### DIFF
--- a/src/Integration/Symfony/Bundle/CHANGELOG.md
+++ b/src/Integration/Symfony/Bundle/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Enable compiler optimization for the `sprintf` function.
 
+### Fixed
+
+- Fix bundle configuration with both `credential_provider` and `credential_provider_cache`.
+
 ## 1.12.2
 
 ### Changed

--- a/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/issue-1758/cache.yaml
+++ b/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/issue-1758/cache.yaml
@@ -1,0 +1,8 @@
+framework:
+    cache:
+        pools:
+            test:
+                adapter: cache.adapter.apcu
+
+async_aws:
+    credential_provider_cache: test

--- a/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/issue-1758/empty.yaml
+++ b/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/issue-1758/empty.yaml
@@ -1,0 +1,1 @@
+async_aws:

--- a/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/issue-1758/provider.yaml
+++ b/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/issue-1758/provider.yaml
@@ -1,0 +1,5 @@
+async_aws:
+    credential_provider: AsyncAws\Core\Credentials\InstanceProvider
+    credential_provider_cache: null
+services:
+    AsyncAws\Core\Credentials\InstanceProvider: ~

--- a/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/issue-1758/provider_cache.yaml
+++ b/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/issue-1758/provider_cache.yaml
@@ -1,0 +1,10 @@
+framework:
+    cache:
+        pools:
+            test:
+                adapter: cache.adapter.apcu
+async_aws:
+    credential_provider: AsyncAws\Core\Credentials\InstanceProvider
+    credential_provider_cache: test
+services:
+    AsyncAws\Core\Credentials\InstanceProvider: ~


### PR DESCRIPTION
fix #1758