### PR TITLE
Fix test suite for latest version of Symfony

### DIFF
--- a/src/Integration/Symfony/Bundle/tests/Functional/BundleInitializationTest.php
+++ b/src/Integration/Symfony/Bundle/tests/Functional/BundleInitializationTest.php
@@ -20,6 +20,7 @@ use Symfony\Bundle\FrameworkBundle\EventListener\ConsoleProfilerListener;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Cache\Adapter\ApcuAdapter;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\DependencyInjection\Attribute\WhenNot;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 class BundleInitializationTest extends KernelTestCase
@@ -279,6 +280,9 @@ class BundleInitializationTest extends KernelTestCase
             }
 
             // hack to assert the version of the bundle
+            if (class_exists(WhenNot::class)) {
+                $kernel->addTestConfig(__DIR__ . '/Resources/config/base_sf72.yaml');
+            }
             if (class_exists(ConsoleProfilerListener::class)) {
                 $kernel->addTestConfig(__DIR__ . '/Resources/config/base_sf64.yaml');
             }

--- a/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/base_sf72.yaml
+++ b/src/Integration/Symfony/Bundle/tests/Functional/Resources/config/base_sf72.yaml
@@ -1,0 +1,6 @@
+framework:
+    trusted_hosts: ''
+    trusted_proxies: ''
+    trusted_headers: ''
+    trust_x_sendfile_type_header: true
+


### PR DESCRIPTION
Since https://github.com/symfony/symfony/pull/58161 the framework bundle tries to resolve new env variables at boot time, and fallbacks, at some points, to the SSMVault EnvVariableLoader. This loader tries to connect to Aws SSM, but it has no credentials configured.

see https://github.com/async-aws/aws/actions/runs/11066455304/job/30747723805


This PR overrides the fwb parameters to avoid to have to load env variables.

/cc @nicolas-grekas 