### PR TITLE
Add SQS AddPermission operation

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -623,6 +623,7 @@
             "example": "https://raw.githubusercontent.com/aws/aws-sdk-php/${LATEST}/src/data/sqs/2012-11-05/examples-1.json",
             "api-reference": "https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference",
             "methods": [
+                "AddPermission",
                 "ChangeMessageVisibility",
                 "ChangeMessageVisibilityBatch",
                 "CreateQueue",

--- a/src/Service/Sqs/CHANGELOG.md
+++ b/src/Service/Sqs/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 ## NOT RELEASED
 
-### Changed
-
-- Enable compiler optimization for the `sprintf` function.
-
 ### Added
 
 - Add AddPermission endpoint
+
+### Changed
+
+- Enable compiler optimization for the `sprintf` function.
 
 ## 2.1.1
 

--- a/src/Service/Sqs/CHANGELOG.md
+++ b/src/Service/Sqs/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Changed
 
 - Enable compiler optimization for the `sprintf` function.
+- Add AddPermission endpoint
 
 ## 2.1.1
 

--- a/src/Service/Sqs/CHANGELOG.md
+++ b/src/Service/Sqs/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Changed
 
 - Enable compiler optimization for the `sprintf` function.
+
+### Added
+
 - Add AddPermission endpoint
 
 ## 2.1.1

--- a/src/Service/Sqs/composer.json
+++ b/src/Service/Sqs/composer.json
@@ -28,7 +28,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.1-dev"
+            "dev-master": "2.2-dev"
         }
     }
 }

--- a/src/Service/Sqs/src/Input/AddPermissionRequest.php
+++ b/src/Service/Sqs/src/Input/AddPermissionRequest.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace AsyncAws\Sqs\Input;
+
+use AsyncAws\Core\Exception\InvalidArgument;
+use AsyncAws\Core\Input;
+use AsyncAws\Core\Request;
+use AsyncAws\Core\Stream\StreamFactory;
+
+final class AddPermissionRequest extends Input
+{
+    /**
+     * The URL of the Amazon SQS queue to which permissions are added.
+     *
+     * Queue URLs and names are case-sensitive.
+     *
+     * @required
+     *
+     * @var string|null
+     */
+    private $queueUrl;
+
+    /**
+     * The unique identification of the permission you're setting (for example, `AliceSendMessage`). Maximum 80 characters.
+     * Allowed characters include alphanumeric characters, hyphens (`-`), and underscores (`_`).
+     *
+     * @required
+     *
+     * @var string|null
+     */
+    private $label;
+
+    /**
+     * The Amazon Web Services account numbers of the principals [^1] who are to receive permission. For information about
+     * locating the Amazon Web Services account identification, see Your Amazon Web Services Identifiers [^2] in the *Amazon
+     * SQS Developer Guide*.
+     *
+     * [^1]: https://docs.aws.amazon.com/general/latest/gr/glos-chap.html#P
+     * [^2]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-making-api-requests.html#sqs-api-request-authentication
+     *
+     * @required
+     *
+     * @var string[]|null
+     */
+    private $awsAccountIds;
+
+    /**
+     * The action the client wants to allow for the specified principal. Valid values: the name of any action or `*`.
+     *
+     * For more information about these actions, see Overview of Managing Access Permissions to Your Amazon Simple Queue
+     * Service Resource [^1] in the *Amazon SQS Developer Guide*.
+     *
+     * Specifying `SendMessage`, `DeleteMessage`, or `ChangeMessageVisibility` for `ActionName.n` also grants permissions
+     * for the corresponding batch versions of those actions: `SendMessageBatch`, `DeleteMessageBatch`, and
+     * `ChangeMessageVisibilityBatch`.
+     *
+     * [^1]: https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-overview-of-managing-access.html
+     *
+     * @required
+     *
+     * @var string[]|null
+     */
+    private $actions;
+
+    /**
+     * @param array{
+     *   QueueUrl?: string,
+     *   Label?: string,
+     *   AWSAccountIds?: string[],
+     *   Actions?: string[],
+     *   '@region'?: string|null,
+     * } $input
+     */
+    public function __construct(array $input = [])
+    {
+        $this->queueUrl = $input['QueueUrl'] ?? null;
+        $this->label = $input['Label'] ?? null;
+        $this->awsAccountIds = $input['AWSAccountIds'] ?? null;
+        $this->actions = $input['Actions'] ?? null;
+        parent::__construct($input);
+    }
+
+    /**
+     * @param array{
+     *   QueueUrl?: string,
+     *   Label?: string,
+     *   AWSAccountIds?: string[],
+     *   Actions?: string[],
+     *   '@region'?: string|null,
+     * }|AddPermissionRequest $input
+     */
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getActions(): array
+    {
+        return $this->actions ?? [];
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getAwsAccountIds(): array
+    {
+        return $this->awsAccountIds ?? [];
+    }
+
+    public function getLabel(): ?string
+    {
+        return $this->label;
+    }
+
+    public function getQueueUrl(): ?string
+    {
+        return $this->queueUrl;
+    }
+
+    /**
+     * @internal
+     */
+    public function request(): Request
+    {
+        // Prepare headers
+        $headers = [
+            'Content-Type' => 'application/x-amz-json-1.0',
+            'X-Amz-Target' => 'AmazonSQS.AddPermission',
+            'Accept' => 'application/json',
+        ];
+
+        // Prepare query
+        $query = [];
+
+        // Prepare URI
+        $uriString = '/';
+
+        // Prepare Body
+        $bodyPayload = $this->requestBody();
+        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload, 4194304);
+
+        // Return the Request
+        return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));
+    }
+
+    /**
+     * @param string[] $value
+     */
+    public function setActions(array $value): self
+    {
+        $this->actions = $value;
+
+        return $this;
+    }
+
+    /**
+     * @param string[] $value
+     */
+    public function setAwsAccountIds(array $value): self
+    {
+        $this->awsAccountIds = $value;
+
+        return $this;
+    }
+
+    public function setLabel(?string $value): self
+    {
+        $this->label = $value;
+
+        return $this;
+    }
+
+    public function setQueueUrl(?string $value): self
+    {
+        $this->queueUrl = $value;
+
+        return $this;
+    }
+
+    private function requestBody(): array
+    {
+        $payload = [];
+        if (null === $v = $this->queueUrl) {
+            throw new InvalidArgument(\sprintf('Missing parameter "QueueUrl" for "%s". The value cannot be null.', __CLASS__));
+        }
+        $payload['QueueUrl'] = $v;
+        if (null === $v = $this->label) {
+            throw new InvalidArgument(\sprintf('Missing parameter "Label" for "%s". The value cannot be null.', __CLASS__));
+        }
+        $payload['Label'] = $v;
+        if (null === $v = $this->awsAccountIds) {
+            throw new InvalidArgument(\sprintf('Missing parameter "AWSAccountIds" for "%s". The value cannot be null.', __CLASS__));
+        }
+
+        $index = -1;
+        $payload['AWSAccountIds'] = [];
+        foreach ($v as $listValue) {
+            ++$index;
+            $payload['AWSAccountIds'][$index] = $listValue;
+        }
+
+        if (null === $v = $this->actions) {
+            throw new InvalidArgument(\sprintf('Missing parameter "Actions" for "%s". The value cannot be null.', __CLASS__));
+        }
+
+        $index = -1;
+        $payload['Actions'] = [];
+        foreach ($v as $listValue) {
+            ++$index;
+            $payload['Actions'][$index] = $listValue;
+        }
+
+        return $payload;
+    }
+}

--- a/src/Service/Sqs/tests/Integration/SqsClientTest.php
+++ b/src/Service/Sqs/tests/Integration/SqsClientTest.php
@@ -5,6 +5,7 @@ namespace AsyncAws\Sqs\Tests\Integration;
 use AsyncAws\Core\Credentials\NullProvider;
 use AsyncAws\Core\Test\TestCase;
 use AsyncAws\Sqs\Enum\QueueAttributeName;
+use AsyncAws\Sqs\Input\AddPermissionRequest;
 use AsyncAws\Sqs\Input\ChangeMessageVisibilityBatchRequest;
 use AsyncAws\Sqs\Input\ChangeMessageVisibilityRequest;
 use AsyncAws\Sqs\Input\CreateQueueRequest;
@@ -25,6 +26,21 @@ use AsyncAws\Sqs\ValueObject\SendMessageBatchRequestEntry;
 
 class SqsClientTest extends TestCase
 {
+    public function testAddPermission(): void
+    {
+        $client = $this->getClient();
+
+        $input = new AddPermissionRequest([
+            'QueueUrl' => 'change me',
+            'Label' => 'change me',
+            'AWSAccountIds' => ['change me'],
+            'Actions' => ['change me'],
+        ]);
+        $result = $client->addPermission($input);
+
+        $result->resolve();
+    }
+
     public function testChangeMessageVisibility()
     {
         $sqs = $this->getClient();

--- a/src/Service/Sqs/tests/Unit/Input/AddPermissionRequestTest.php
+++ b/src/Service/Sqs/tests/Unit/Input/AddPermissionRequestTest.php
@@ -9,24 +9,26 @@ class AddPermissionRequestTest extends TestCase
 {
     public function testRequest(): void
     {
-        self::fail('Not implemented');
-
         $input = new AddPermissionRequest([
-            'QueueUrl' => 'change me',
-            'Label' => 'change me',
-            'AWSAccountIds' => ['change me'],
-            'Actions' => ['change me'],
+            'QueueUrl' => 'https://sqs.us-east-1.amazonaws.com/177715257436/MyQueue/',
+            'Label' => 'MyLabel',
+            'AWSAccountIds' => ["177715257436", "111111111111"],
+            'Actions' => ["SendMessage", "ReceiveMessage"],
         ]);
 
         // see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_AddPermission.html
         $expected = '
             POST / HTTP/1.0
             Content-Type: application/x-amz-json-1.0
+            x-amz-target: AmazonSQS.AddPermission
+            Accept: application/json
 
             {
-            "change": "it"
-        }
-                ';
+                "QueueUrl": "https://sqs.us-east-1.amazonaws.com/177715257436/MyQueue/",
+                "Label": "MyLabel",
+                "Actions": ["SendMessage", "ReceiveMessage"],
+                "AWSAccountIds": ["177715257436", "111111111111"]
+            }';
 
         self::assertRequestEqualsHttpRequest($expected, $input->request());
     }

--- a/src/Service/Sqs/tests/Unit/Input/AddPermissionRequestTest.php
+++ b/src/Service/Sqs/tests/Unit/Input/AddPermissionRequestTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace AsyncAws\Sqs\Tests\Unit\Input;
+
+use AsyncAws\Core\Test\TestCase;
+use AsyncAws\Sqs\Input\AddPermissionRequest;
+
+class AddPermissionRequestTest extends TestCase
+{
+    public function testRequest(): void
+    {
+        self::fail('Not implemented');
+
+        $input = new AddPermissionRequest([
+            'QueueUrl' => 'change me',
+            'Label' => 'change me',
+            'AWSAccountIds' => ['change me'],
+            'Actions' => ['change me'],
+        ]);
+
+        // see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_AddPermission.html
+        $expected = '
+            POST / HTTP/1.0
+            Content-Type: application/x-amz-json-1.0
+
+            {
+            "change": "it"
+        }
+                ';
+
+        self::assertRequestEqualsHttpRequest($expected, $input->request());
+    }
+}

--- a/src/Service/Sqs/tests/Unit/Input/AddPermissionRequestTest.php
+++ b/src/Service/Sqs/tests/Unit/Input/AddPermissionRequestTest.php
@@ -12,8 +12,8 @@ class AddPermissionRequestTest extends TestCase
         $input = new AddPermissionRequest([
             'QueueUrl' => 'https://sqs.us-east-1.amazonaws.com/177715257436/MyQueue/',
             'Label' => 'MyLabel',
-            'AWSAccountIds' => ["177715257436", "111111111111"],
-            'Actions' => ["SendMessage", "ReceiveMessage"],
+            'AWSAccountIds' => ['177715257436', '111111111111'],
+            'Actions' => ['SendMessage', 'ReceiveMessage'],
         ]);
 
         // see https://docs.aws.amazon.com/AWSSimpleQueueService/latest/APIReference/API_AddPermission.html

--- a/src/Service/Sqs/tests/Unit/SqsClientTest.php
+++ b/src/Service/Sqs/tests/Unit/SqsClientTest.php
@@ -5,6 +5,7 @@ namespace AsyncAws\Sqs\Tests\Unit;
 use AsyncAws\Core\Credentials\NullProvider;
 use AsyncAws\Core\Result;
 use AsyncAws\Core\Test\TestCase;
+use AsyncAws\Sqs\Input\AddPermissionRequest;
 use AsyncAws\Sqs\Input\ChangeMessageVisibilityBatchRequest;
 use AsyncAws\Sqs\Input\ChangeMessageVisibilityRequest;
 use AsyncAws\Sqs\Input\CreateQueueRequest;
@@ -35,6 +36,22 @@ use Symfony\Component\HttpClient\MockHttpClient;
 
 class SqsClientTest extends TestCase
 {
+    public function testAddPermission(): void
+    {
+        $client = new SqsClient([], new NullProvider(), new MockHttpClient());
+
+        $input = new AddPermissionRequest([
+            'QueueUrl' => 'change me',
+            'Label' => 'change me',
+            'AWSAccountIds' => ['change me'],
+            'Actions' => ['change me'],
+        ]);
+        $result = $client->addPermission($input);
+
+        self::assertInstanceOf(Result::class, $result);
+        self::assertFalse($result->info()['resolved']);
+    }
+
     public function testChangeMessageVisibility(): void
     {
         $client = new SqsClient([], new NullProvider(), new MockHttpClient());


### PR DESCRIPTION
New SQS AddPermission operation, required to allow 3rd parties the permission to send messages to queues created using the createQueue endpoint.  

I didn't seem to need to do anything after using the generate script - very cool.  Let me know if I've missed anything.

As it looks like you are using a monorepo how would I go about using my fork of that in my code while the PR is reviewed and hopefully accepted.

Thanks

Steve