### PR TITLE
Add simple mocked response object to httpResponse property on ResultMockFactory

### DIFF
--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Enable compiler optimization for the `sprintf` function.
 - Avoid calls to spl_object_ methods when computing cache key.
+- Added SimpleMockedResponse to response of ResultMockFactory.
 
 ## 1.22.0
 

--- a/src/Core/src/Test/ResultMockFactory.php
+++ b/src/Core/src/Test/ResultMockFactory.php
@@ -285,6 +285,10 @@ class ResultMockFactory
         $property->setAccessible(true);
         $property->setValue($response, true);
 
+        $property = $reflectionClass->getProperty('httpResponse');
+        $property->setAccessible(true);
+        $property->setValue($response, new SimpleMockedResponse());
+
         return $response;
     }
 }


### PR DESCRIPTION
Hello,

I am writing some tests using the `ResultMockFactory` on the `SsmClient`. This all works great but as part of the application code we are calling the following method on the result mock class.

```php
$parameterResult->info()['response']->getStatusCode()
```

This goes through to the `info()` method on the `AsyncAws\Core\Response` class where the `httpResponse` property is null, so the test then attempts to call `getInfo()` on null.

I have been following https://async-aws.com/features/tests.html and I have tried to figure out if I can add the response data in any other way but I can't see this being possible.

So I have set the `SimpleMockedResponse` object as the `httpResponse` property on the class and it now returns 200 as expected. I felt this was the most appropriate class to use, but I may be wrong.