### PR TITLE
fix git diff commands

### DIFF
--- a/.github/workflows/bin/refresh
+++ b/.github/workflows/bin/refresh
@@ -65,7 +65,7 @@ if ($return !== 0) {
 /**
  * Check if something changed
  */
-$output = call('git diff --numstat  src/');
+$output = call('git diff --numstat  -- src/');
 
 if (empty($output)) {
     console_log('Nothing changed.');
@@ -98,7 +98,7 @@ foreach ($output as $line) {
         continue;
     }
 
-    $fileChanges = call('git diff --no-color -U0 '.escapeshellarg($file));
+    $fileChanges = call('git diff --no-color -U0 -- '.escapeshellarg($file));
     foreach ($fileChanges as $lineChange) {
         if (!$lineChange) {
             continue;

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -97,7 +97,7 @@ jobs:
             echo "###################################################"
             echo ""
 
-            git diff src
+            git diff -- src
 
             exit 1
           fi

--- a/tests/Unit/ChangelogTest.php
+++ b/tests/Unit/ChangelogTest.php
@@ -198,8 +198,8 @@ class ChangelogTest extends TestCase
         });
 
         $output = array_merge(
-            self::call('git diff --numstat HEAD src/'),
-            self::call('git diff --numstat ' . $branches[0] . '...HEAD src/')
+            self::call('git diff --numstat HEAD -- src/'),
+            self::call('git diff --numstat ' . $branches[0] . '...HEAD -- src/')
         );
 
         $changedServices = [];
@@ -250,7 +250,7 @@ class ChangelogTest extends TestCase
 
             $isCommentOnly = true;
             foreach ($changedFiles as $changedFile) {
-                $changedLines = self::call('git diff --no-color -U0 ' . escapeshellarg($changesService['base'] . $changedFile));
+                $changedLines = self::call('git diff --no-color -U0 -- ' . escapeshellarg($changesService['base'] . $changedFile));
                 foreach ($changedLines as $changedLine) {
                     if (!$changedLine) {
                         continue;


### PR DESCRIPTION
fixes:
```
fatal: ambiguous argument 'src/Service/Athena/src/Enum/ConnectionType.php': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
Command "git diff --no-color -U0 'src/Service/Athena/src/Enum/ConnectionType.php'" failed.
```

in https://github.com/async-aws/aws/actions/runs/11415307262/job/31765218101#step:8:62