### PR TITLE
Fix the lowest bound for the symfony/polyfill-uuid requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "symfony/finder": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0 || ^7.0",
         "symfony/phpunit-bridge": "^5.3 || ^6.0 || ^7.0",
-        "symfony/polyfill-uuid": "^1.0"
+        "symfony/polyfill-uuid": "^1.13.1"
     },
     "conflict": {
         "symfony/http-client": "5.2.0"

--- a/src/CodeGenerator/src/Generator/RequestSerializer/QuerySerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/QuerySerializer.php
@@ -87,7 +87,7 @@ class QuerySerializer implements Serializer
             }
             $shape = $member->getShape();
             if ($member->isIdempotencyToken()) {
-                $this->requirementsRegistry->addRequirement('symfony/polyfill-uuid', '^1.0');
+                $this->requirementsRegistry->addRequirement('symfony/polyfill-uuid', '^1.13.1');
                 $body = 'if (null === $v = $this->PROPERTY) {
                     $v = uuid_create(UUID_TYPE_RANDOM);
                 }

--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestJsonSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestJsonSerializer.php
@@ -89,7 +89,7 @@ class RestJsonSerializer implements Serializer
             }
             $shape = $member->getShape();
             if ($member->isIdempotencyToken()) {
-                $this->requirementsRegistry->addRequirement('symfony/polyfill-uuid', '^1.0');
+                $this->requirementsRegistry->addRequirement('symfony/polyfill-uuid', '^1.13.1');
                 $body = 'if (null === $v = $this->PROPERTY) {
                     $v = uuid_create(UUID_TYPE_RANDOM);
                 }

--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
@@ -111,7 +111,7 @@ class RestXmlSerializer implements Serializer
             }
 
             if ($member->isIdempotencyToken()) {
-                $this->requirementsRegistry->addRequirement('symfony/polyfill-uuid', '^1.0');
+                $this->requirementsRegistry->addRequirement('symfony/polyfill-uuid', '^1.13.1');
                 $body = 'if (null === $v = $this->PROPERTY) {
                     $v = uuid_create(UUID_TYPE_RANDOM);
                 }

--- a/src/Service/Athena/CHANGELOG.md
+++ b/src/Service/Athena/CHANGELOG.md
@@ -7,6 +7,10 @@
 - AWS api-change: Added `eu-isoe-west-1` region
 - AWS api-change: rewrite declaration of regions
 
+### Fixed
+
+- Fix the lowest bound for the `symfony/polyfill-uuid` requirement
+
 ## 3.2.0
 
 ### Added

--- a/src/Service/Athena/composer.json
+++ b/src/Service/Athena/composer.json
@@ -15,7 +15,7 @@
         "ext-filter": "*",
         "ext-json": "*",
         "async-aws/core": "^1.9",
-        "symfony/polyfill-uuid": "^1.0"
+        "symfony/polyfill-uuid": "^1.13.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Service/DynamoDb/CHANGELOG.md
+++ b/src/Service/DynamoDb/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Sort exception alphabetically.
 - AWS enhancement: Documentation updates.
 
+### Fixed
+
+- Fix the lowest bound for the `symfony/polyfill-uuid` requirement
+
 ## 3.5.0
 
 ### Added

--- a/src/Service/DynamoDb/composer.json
+++ b/src/Service/DynamoDb/composer.json
@@ -15,7 +15,7 @@
         "ext-filter": "*",
         "ext-json": "*",
         "async-aws/core": "^1.16",
-        "symfony/polyfill-uuid": "^1.0"
+        "symfony/polyfill-uuid": "^1.13.1"
     },
     "conflict": {
         "symfony/http-client": "<4.4.16 <5.1.7"

--- a/src/Service/MediaConvert/CHANGELOG.md
+++ b/src/Service/MediaConvert/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Sort exception alphabetically.
 
+### Fixed
+
+- Fix the lowest bound for the `symfony/polyfill-uuid` requirement
+
 ## 1.7.0
 
 ### Added

--- a/src/Service/MediaConvert/composer.json
+++ b/src/Service/MediaConvert/composer.json
@@ -14,7 +14,7 @@
         "php": "^7.2.5 || ^8.0",
         "ext-json": "*",
         "async-aws/core": "^1.9",
-        "symfony/polyfill-uuid": "^1.0"
+        "symfony/polyfill-uuid": "^1.13.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Service/Scheduler/CHANGELOG.md
+++ b/src/Service/Scheduler/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Sort exception alphabetically.
 
+### Fixed
+
+- Fix the lowest bound for the `symfony/polyfill-uuid` requirement
+
 ## 1.3.0
 
 ### Added

--- a/src/Service/Scheduler/composer.json
+++ b/src/Service/Scheduler/composer.json
@@ -15,7 +15,7 @@
         "ext-filter": "*",
         "ext-json": "*",
         "async-aws/core": "^1.9",
-        "symfony/polyfill-uuid": "^1.0"
+        "symfony/polyfill-uuid": "^1.13.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Service/SecretsManager/CHANGELOG.md
+++ b/src/Service/SecretsManager/CHANGELOG.md
@@ -10,6 +10,10 @@
 
 - Sort exception alphabetically.
 
+### Fixed
+
+- Fix the lowest bound for the `symfony/polyfill-uuid` requirement
+
 ## 2.7.0
 
 ### Added

--- a/src/Service/SecretsManager/composer.json
+++ b/src/Service/SecretsManager/composer.json
@@ -15,7 +15,7 @@
         "ext-filter": "*",
         "ext-json": "*",
         "async-aws/core": "^1.9",
-        "symfony/polyfill-uuid": "^1.0"
+        "symfony/polyfill-uuid": "^1.13.1"
     },
     "autoload": {
         "psr-4": {

--- a/src/Service/TimestreamQuery/CHANGELOG.md
+++ b/src/Service/TimestreamQuery/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Sort exception alphabetically.
 
+### Fixed
+
+- Fix the lowest bound for the `symfony/polyfill-uuid` requirement
+
 ## 2.1.1
 
 ### Changed

--- a/src/Service/TimestreamQuery/composer.json
+++ b/src/Service/TimestreamQuery/composer.json
@@ -15,7 +15,7 @@
         "ext-filter": "*",
         "ext-json": "*",
         "async-aws/core": "^1.16",
-        "symfony/polyfill-uuid": "^1.0"
+        "symfony/polyfill-uuid": "^1.13.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
The 1.13.0 release (the first release of that package) is unusable due to a bug triggering an error when loading the autoload file.
Defining 1.13.1 as our lowest bound for the requirement (the first working release) makes it easier for projects testing with `--prefer-lowest`.