### PR TITLE
Use named cases for the data provider for changelog tests

### DIFF
--- a/tests/Unit/ChangelogTest.php
+++ b/tests/Unit/ChangelogTest.php
@@ -172,9 +172,8 @@ class ChangelogTest extends TestCase
             ->in(\dirname(__DIR__, 2) . '/src')
             ->name('CHANGELOG.md');
 
-        /** @var \SplFileInfo $file */
         foreach ($finder as $file) {
-            yield [$file->getRealPath()];
+            yield $file->getRelativePath() => [$file->getRealPath()];
         }
     }
 


### PR DESCRIPTION
This makes it easier to identify which package has an invalid changelog as PHPUnit displays the name of the failing case in its output (which is easier to understand than figuring out which component has the index 23 in the data provider).

See https://github.com/async-aws/aws/actions/runs/14520270313/job/40739268792?pr=1879#step:8:137 for the output with the old test