### PR TITLE
Normalize the case of the SimpleXML requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,11 +5,11 @@
     "type": "project",
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "ext-SimpleXML": "*",
         "ext-dom": "*",
         "ext-filter": "*",
         "ext-hash": "*",
         "ext-json": "*",
+        "ext-simplexml": "*",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/http-client": "^4.4.16 || ^5.1.7 || ^6.0 || ^7.0",
         "symfony/http-client-contracts": "^1.0 || ^2.0 || ^3.0",

--- a/src/CodeGenerator/composer.json
+++ b/src/CodeGenerator/composer.json
@@ -5,9 +5,9 @@
     "type": "library",
     "require": {
         "php": "^8.2",
-        "ext-SimpleXML": "*",
         "ext-dom": "*",
         "ext-json": "*",
+        "ext-simplexml": "*",
         "friendsofphp/php-cs-fixer": "~3.60.0",
         "nette/php-generator": "^3.6 || ^4.1",
         "nette/utils": "^3.0 || ^4.0",

--- a/src/CodeGenerator/src/File/ComposerWriter.php
+++ b/src/CodeGenerator/src/File/ComposerWriter.php
@@ -36,7 +36,8 @@ class ComposerWriter
             unset(
                 $content['require']['ext-json'],
                 $content['require']['ext-dom'],
-                $content['require']['ext-SimpleXML'],
+                $content['require']['ext-SimpleXML'], // Older versions of the code generator were using that case. We keep cleaning it to avoid garbage.
+                $content['require']['ext-simplexml'],
                 $content['require']['ext-filter'],
                 $content['require']['async-aws/core'],
                 $content['require']['symfony/polyfill-uuid'],

--- a/src/CodeGenerator/src/Generator/ResponseParser/RestXmlParser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/RestXmlParser.php
@@ -97,7 +97,7 @@ class RestXmlParser implements Parser
             return new ParserResult('');
         }
 
-        $this->requirementsRegistry->addRequirement('ext-SimpleXML');
+        $this->requirementsRegistry->addRequirement('ext-simplexml');
 
         $body = '$data = new \SimpleXMLElement($response->getContent(' . ($throwOnError ? '' : 'false') . '));';
         if (!$throwOnError) {

--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Normalize the composer requirements
 - Sort exception alphabetically.
 
 ## 1.25.0

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -12,9 +12,9 @@
     ],
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "ext-SimpleXML": "*",
         "ext-hash": "*",
         "ext-json": "*",
+        "ext-simplexml": "*",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "symfony/deprecation-contracts": "^2.1 || ^3.0",

--- a/src/Service/CloudFormation/CHANGELOG.md
+++ b/src/Service/CloudFormation/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - AWS api-change: Added `eu-isoe-west-1` region
 
+### Changed
+
+- Normalize the composer requirements
+
 ## 1.8.1
 
 ### Changed

--- a/src/Service/CloudFormation/composer.json
+++ b/src/Service/CloudFormation/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "ext-SimpleXML": "*",
         "ext-filter": "*",
+        "ext-simplexml": "*",
         "async-aws/core": "^1.9"
     },
     "autoload": {

--- a/src/Service/CloudFront/CHANGELOG.md
+++ b/src/Service/CloudFront/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Normalize the composer requirements
 - Sort exception alphabetically.
 
 ## 1.0.3

--- a/src/Service/CloudFront/composer.json
+++ b/src/Service/CloudFront/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "ext-SimpleXML": "*",
         "ext-dom": "*",
+        "ext-simplexml": "*",
         "async-aws/core": "^1.9"
     },
     "autoload": {

--- a/src/Service/CloudWatch/CHANGELOG.md
+++ b/src/Service/CloudWatch/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Normalize the composer requirements
 - Sort exception alphabetically.
 
 ## 1.2.0

--- a/src/Service/CloudWatch/composer.json
+++ b/src/Service/CloudWatch/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "ext-SimpleXML": "*",
+        "ext-simplexml": "*",
         "async-aws/core": "^1.9"
     },
     "autoload": {

--- a/src/Service/ElastiCache/CHANGELOG.md
+++ b/src/Service/ElastiCache/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 
+- Normalize the composer requirements
 - Sort exception alphabetically.
 
 ## 1.3.0

--- a/src/Service/ElastiCache/composer.json
+++ b/src/Service/ElastiCache/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "ext-SimpleXML": "*",
         "ext-filter": "*",
+        "ext-simplexml": "*",
         "async-aws/core": "^1.9"
     },
     "autoload": {

--- a/src/Service/Iam/CHANGELOG.md
+++ b/src/Service/Iam/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Changed
 
+- Normalize the composer requirements
 - Sort exception alphabetically.
 
 ## 1.6.0

--- a/src/Service/Iam/composer.json
+++ b/src/Service/Iam/composer.json
@@ -15,8 +15,8 @@
     ],
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "ext-SimpleXML": "*",
         "ext-filter": "*",
+        "ext-simplexml": "*",
         "async-aws/core": "^1.9"
     },
     "autoload": {

--- a/src/Service/Route53/CHANGELOG.md
+++ b/src/Service/Route53/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Changed
 
+- Normalize the composer requirements
 - Sort exception alphabetically.
 
 ## 2.8.0

--- a/src/Service/Route53/composer.json
+++ b/src/Service/Route53/composer.json
@@ -12,9 +12,9 @@
     ],
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "ext-SimpleXML": "*",
         "ext-dom": "*",
         "ext-filter": "*",
+        "ext-simplexml": "*",
         "async-aws/core": "^1.9"
     },
     "autoload": {

--- a/src/Service/S3/CHANGELOG.md
+++ b/src/Service/S3/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Normalize the composer requirements
 - Sort exception alphabetically.
 - AWS enhancement: Documentation updates.
 

--- a/src/Service/S3/composer.json
+++ b/src/Service/S3/composer.json
@@ -12,10 +12,10 @@
     ],
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "ext-SimpleXML": "*",
         "ext-dom": "*",
         "ext-filter": "*",
         "ext-hash": "*",
+        "ext-simplexml": "*",
         "async-aws/core": "^1.22"
     },
     "autoload": {

--- a/src/Service/Sns/CHANGELOG.md
+++ b/src/Service/Sns/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Changed
 
+- Normalize the composer requirements
 - Sort exception alphabetically.
 
 ## 1.9.0

--- a/src/Service/Sns/composer.json
+++ b/src/Service/Sns/composer.json
@@ -12,8 +12,8 @@
     ],
     "require": {
         "php": "^7.2.5 || ^8.0",
-        "ext-SimpleXML": "*",
         "ext-filter": "*",
+        "ext-simplexml": "*",
         "async-aws/core": "^1.9"
     },
     "autoload": {


### PR DESCRIPTION
`ergebnis/composer-normalize` now enforces using lowercase for extension requirement (see https://github.com/ergebnis/composer-normalize/issues/1388)