### PR TITLE
Add support for document shapes in the code generator

### DIFF
--- a/src/CodeGenerator/src/Definition/DocumentShape.php
+++ b/src/CodeGenerator/src/Definition/DocumentShape.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\CodeGenerator\Definition;
+
+/**
+ * @internal
+ */
+final class DocumentShape extends Shape
+{
+}

--- a/src/CodeGenerator/src/Definition/Shape.php
+++ b/src/CodeGenerator/src/Definition/Shape.php
@@ -41,7 +41,13 @@ class Shape
     {
         switch ($data['type']) {
             case 'structure':
-                $shape = ($data['exception'] ?? false) ? new ExceptionShape() : new StructureShape();
+                if ($data['exception'] ?? false) {
+                    $shape = new ExceptionShape();
+                } elseif ($data['document'] ?? false) {
+                    $shape = new DocumentShape();
+                } else {
+                    $shape = new StructureShape();
+                }
 
                 break;
             case 'list':

--- a/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Generator\CodeGenerator;
 
+use AsyncAws\CodeGenerator\Definition\DocumentShape;
 use AsyncAws\CodeGenerator\Definition\ListShape;
 use AsyncAws\CodeGenerator\Definition\MapShape;
 use AsyncAws\CodeGenerator\Definition\Operation;
@@ -127,6 +128,8 @@ class PopulatorGenerator
                 }
 
                 $nullable = false;
+            } elseif ($memberShape instanceof DocumentShape) {
+                $nullable = false; // the type is already nullable, not need to add an extra union
             } elseif ($member->isStreaming()) {
                 $returnType = ResultStream::class;
                 $parameterType = 'ResultStream';

--- a/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Generator\CodeGenerator;
 
+use AsyncAws\CodeGenerator\Definition\DocumentShape;
 use AsyncAws\CodeGenerator\Definition\ListShape;
 use AsyncAws\CodeGenerator\Definition\MapShape;
 use AsyncAws\CodeGenerator\Definition\Shape;
@@ -90,6 +91,8 @@ class TypeGenerator
                 } else {
                     $param = 'array<string, ' . $param . '>';
                 }
+            } elseif ($memberShape instanceof DocumentShape) {
+                $param = 'bool|string|int|float|null|list<mixed>|array<string, mixed>';
             } elseif ($member->isStreaming()) {
                 $param = 'string|resource|(callable(int): string)|iterable<string>';
             } elseif ('timestamp' === $param = $memberShape->getType()) {
@@ -166,6 +169,10 @@ class TypeGenerator
             }
 
             return ['array', $doc, $memberClassNames];
+        }
+
+        if ($shape instanceof DocumentShape) {
+            return ['bool|string|int|float|null|array', 'bool|string|int|float|null|list<mixed>|array<string, mixed>', []];
         }
 
         $type = $doc = $this->getNativePhpType($shape->getType());

--- a/src/CodeGenerator/src/Generator/InputGenerator.php
+++ b/src/CodeGenerator/src/Generator/InputGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Generator;
 
+use AsyncAws\CodeGenerator\Definition\DocumentShape;
 use AsyncAws\CodeGenerator\Definition\ListShape;
 use AsyncAws\CodeGenerator\Definition\MapShape;
 use AsyncAws\CodeGenerator\Definition\Member;
@@ -210,6 +211,8 @@ class InputGenerator
                     // It is a scalar, like a string
                     $constructorBody .= strtr('$this->PROPERTY = $input["NAME"] ?? null;' . "\n", ['PROPERTY' => GeneratorHelper::normalizeName($member->getName()), 'NAME' => $member->getName()]);
                 }
+            } elseif ($memberShape instanceof DocumentShape) {
+                $getterSetterNullable = false; // The type itself is already nullable
             } elseif ($member->isStreaming()) {
                 $parameterType = 'string|resource|(callable(int): string)|iterable<string>';
                 $returnType = null;

--- a/src/CodeGenerator/src/Generator/ObjectGenerator.php
+++ b/src/CodeGenerator/src/Generator/ObjectGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Generator;
 
+use AsyncAws\CodeGenerator\Definition\DocumentShape;
 use AsyncAws\CodeGenerator\Definition\ListShape;
 use AsyncAws\CodeGenerator\Definition\MapShape;
 use AsyncAws\CodeGenerator\Definition\Shape;
@@ -307,6 +308,8 @@ class ObjectGenerator
                     $enumClassName = $this->enumGenerator->generate($memberShape);
                     $classBuilder->addUse($enumClassName->getFqdn());
                 }
+            } elseif ($memberShape instanceof DocumentShape) {
+                $nullable = false;
             } elseif ($member->isStreaming()) {
                 $returnType = ResultStream::class;
                 $parameterType = ResultStream::class;

--- a/src/CodeGenerator/src/Generator/RequestSerializer/QuerySerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/QuerySerializer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Generator\RequestSerializer;
 
+use AsyncAws\CodeGenerator\Definition\DocumentShape;
 use AsyncAws\CodeGenerator\Definition\ListShape;
 use AsyncAws\CodeGenerator\Definition\MapShape;
 use AsyncAws\CodeGenerator\Definition\Member;
@@ -183,6 +184,8 @@ class QuerySerializer implements Serializer
                 return $this->dumpArrayList($output, $input, $contextProperty, $shape);
             case $shape instanceof MapShape:
                 return $this->dumpArrayMap($output, $input, $contextProperty, $shape);
+            case $shape instanceof DocumentShape:
+                throw new \LogicException('Document shapes are not supported in the query serializer for now.');
         }
 
         switch ($shape->getType()) {

--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestJsonSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestJsonSerializer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Generator\RequestSerializer;
 
+use AsyncAws\CodeGenerator\Definition\DocumentShape;
 use AsyncAws\CodeGenerator\Definition\ListShape;
 use AsyncAws\CodeGenerator\Definition\MapShape;
 use AsyncAws\CodeGenerator\Definition\Member;
@@ -180,6 +181,8 @@ class RestJsonSerializer implements Serializer
                 return $this->dumpArrayList($output, $input, $contextProperty, $shape);
             case $shape instanceof MapShape:
                 return $this->dumpArrayMap($output, $input, $contextProperty, $shape);
+            case $shape instanceof DocumentShape:
+                return $this->dumpArrayScalar($output, $input, $contextProperty, $shape);
         }
 
         switch ($shape->getType()) {

--- a/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
+++ b/src/CodeGenerator/src/Generator/RequestSerializer/RestXmlSerializer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Generator\RequestSerializer;
 
+use AsyncAws\CodeGenerator\Definition\DocumentShape;
 use AsyncAws\CodeGenerator\Definition\ListShape;
 use AsyncAws\CodeGenerator\Definition\Member;
 use AsyncAws\CodeGenerator\Definition\Operation;
@@ -158,6 +159,8 @@ class RestXmlSerializer implements Serializer
                 return $this->dumpXmlShapeStructure($member, $shape, $output, $input);
             case $shape instanceof ListShape:
                 return $this->dumpXmlShapeList($member, $shape, $output, $input);
+            case $shape instanceof DocumentShape:
+                throw new \LogicException('Document shapes are not supported in the XML serializer for now.');
         }
 
         switch ($shape->getType()) {

--- a/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/RestJsonParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Generator\ResponseParser;
 
+use AsyncAws\CodeGenerator\Definition\DocumentShape;
 use AsyncAws\CodeGenerator\Definition\ListShape;
 use AsyncAws\CodeGenerator\Definition\MapShape;
 use AsyncAws\CodeGenerator\Definition\Member;
@@ -193,6 +194,8 @@ class RestJsonParser implements Parser
                 return $this->parseResponseStructure($shape, $input, $required);
             case $shape instanceof MapShape:
                 return $this->parseResponseMap($shape, $input, $required, $inObject);
+            case $shape instanceof DocumentShape:
+                return $this->parseResponseDocument($input, $required);
         }
 
         switch ($shape->getType()) {
@@ -294,6 +297,15 @@ class RestJsonParser implements Parser
         }
 
         return strtr('isset(INPUT) ? base64_decode((string) INPUT) : null', ['INPUT' => $input]);
+    }
+
+    private function parseResponseDocument(string $input, bool $required): string
+    {
+        if ($required) {
+            return strtr('INPUT', ['INPUT' => $input]);
+        }
+
+        return strtr('INPUT ?? null', ['INPUT' => $input]);
     }
 
     private function parseResponseList(ListShape $shape, string $input, bool $required, bool $inObject): string

--- a/src/CodeGenerator/src/Generator/ResponseParser/RestXmlParser.php
+++ b/src/CodeGenerator/src/Generator/ResponseParser/RestXmlParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Generator\ResponseParser;
 
+use AsyncAws\CodeGenerator\Definition\DocumentShape;
 use AsyncAws\CodeGenerator\Definition\ListShape;
 use AsyncAws\CodeGenerator\Definition\MapShape;
 use AsyncAws\CodeGenerator\Definition\Member;
@@ -177,6 +178,8 @@ class RestXmlParser implements Parser
                 return $this->parseXmlResponseStructure($shape, $input, $required);
             case $shape instanceof MapShape:
                 return $this->parseXmlResponseMap($shape, $input, $required, $inObject);
+            case $shape instanceof DocumentShape:
+                throw new \LogicException('Document shapes are not supported in the XML parser for now.');
         }
 
         switch ($shape->getType()) {

--- a/src/CodeGenerator/src/Generator/TestGenerator.php
+++ b/src/CodeGenerator/src/Generator/TestGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\CodeGenerator\Generator;
 
+use AsyncAws\CodeGenerator\Definition\DocumentShape;
 use AsyncAws\CodeGenerator\Definition\ListShape;
 use AsyncAws\CodeGenerator\Definition\MapShape;
 use AsyncAws\CodeGenerator\Definition\Operation;
@@ -292,6 +293,8 @@ class TestGenerator
                 return strtr('["change me" => INPUT_ARGUMENTS]', [
                     'INPUT_ARGUMENTS' => $this->getInputCode($classBuilder, $shape->getValue()->getShape(), $includeOptionalParameters, $recursion),
                 ]);
+            case $shape instanceof DocumentShape:
+                return '"change me"';
         }
 
         switch ($shape->getType()) {


### PR DESCRIPTION
Such shape accept a raw JSON value. It is supported only in the JSON format.

Closes #1882

this will be used in #1861 (but it needs more)