### PR TITLE
fix query params sorting to build correct canonical query string

### DIFF
--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Fixed
+- SignerV4: sort canonical query parameters **after** URI-encoding (per AWS SigV4). Fixes incorrect ordering for array-style keys (e.g., `transaction_ids[10]` vs `transaction_ids[1]`), which could cause `The request signature we calculated does not match the signature you provided`. See: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html
+
+
 ## 1.27.0
 
 ### Added

--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## NOT RELEASED
 
 ### Fixed
-- SignerV4: sort canonical query parameters **after** URI-encoding (per AWS SigV4). Fixes incorrect ordering for array-style keys (e.g., `transaction_ids[10]` vs `transaction_ids[1]`), which could cause `The request signature we calculated does not match the signature you provided`. See: https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html
 
+- SignerV4: fix sort of query parameters to build correct canoncal query string 
 
 ## 1.27.0
 

--- a/src/Core/phpunit.xml.dist
+++ b/src/Core/phpunit.xml.dist
@@ -1,17 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
-         failOnRisky="true"
-         failOnWarning="true"
->
-  <coverage>
-    <include>
-      <directory>./src</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php" failOnRisky="true" failOnWarning="true">
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +8,9 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory>./src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Core/src/Signer/SignerV4.php
+++ b/src/Core/src/Signer/SignerV4.php
@@ -321,7 +321,7 @@ class SignerV4 implements Signer
             return '';
         }
 
-        ksort($query);
+        uksort($query, static fn($a, $b) => strcmp(rawurlencode($a), rawurlencode($b)));
         $encodedQuery = [];
         foreach ($query as $key => $values) {
             if (!\is_array($values)) {

--- a/src/Core/src/Signer/SignerV4.php
+++ b/src/Core/src/Signer/SignerV4.php
@@ -321,7 +321,9 @@ class SignerV4 implements Signer
             return '';
         }
 
-        uksort($query, static fn ($a, $b) => strcmp(rawurlencode($a), rawurlencode($b)));
+        uksort($query, static function (string $a, string $b): int {
+            return strcmp(rawurlencode($a), rawurlencode($b));
+        });
         $encodedQuery = [];
         foreach ($query as $key => $values) {
             if (!\is_array($values)) {

--- a/src/Core/src/Signer/SignerV4.php
+++ b/src/Core/src/Signer/SignerV4.php
@@ -321,7 +321,7 @@ class SignerV4 implements Signer
             return '';
         }
 
-        uksort($query, static fn($a, $b) => strcmp(rawurlencode($a), rawurlencode($b)));
+        uksort($query, static fn ($a, $b) => strcmp(rawurlencode($a), rawurlencode($b)));
         $encodedQuery = [];
         foreach ($query as $key => $values) {
             if (!\is_array($values)) {

--- a/src/Core/tests/Unit/Signer/SignerV4Test.php
+++ b/src/Core/tests/Unit/Signer/SignerV4Test.php
@@ -78,7 +78,7 @@ class SignerV4Test extends TestCase
         self::assertEquals($expected, $request);
     }
 
-    public function provideRequests()
+    public static function provideRequests()
     {
         return [
             // POST headers should be signed.
@@ -158,7 +158,7 @@ class SignerV4Test extends TestCase
         self::assertEquals($expected, $request);
     }
 
-    private function provideRequestsWithQueryParams()
+    public static function provideRequestsWithQueryParams()
     {
         return [
             // GET Case with array in query params

--- a/src/Core/tests/Unit/Signer/SignerV4Test.php
+++ b/src/Core/tests/Unit/Signer/SignerV4Test.php
@@ -140,7 +140,58 @@ class SignerV4Test extends TestCase
         ];
     }
 
-    private function parseRequest(string $req): Request
+    /**
+     * @dataProvider provideRequestsWithQueryParams
+     */
+    public function testSignsRequestsWithArrayInQueryParams($rawRequestWithoutQuery, $rawExpected, $queryParams)
+    {
+        $request = $this->parseRequest($rawRequestWithoutQuery, $queryParams);
+
+        $signer = new SignerV4('host', 'us-east-1');
+        $context = new RequestContext(['currentDate' => new \DateTimeImmutable('20110909T233600Z')]);
+        $credentials = new Credentials('AKIDEXAMPLE', 'wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY');
+
+        $signer->sign($request, $credentials, $context);
+
+        $expected = $this->parseRequest($rawExpected, $queryParams);
+
+        self::assertEquals($expected, $request);
+    }
+
+    private function provideRequestsWithQueryParams()
+    {
+        return [
+            // GET Case with array in query params
+            [
+                "GET / HTTP/1.1\r\nHost: host.foo.com:443\r\n\r\n",
+                "GET / HTTP/1.1\r\nHost: host.foo.com:443\r\nX-Amz-Date: 20110909T233600Z\r\nAuthorization: AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=host;x-amz-date, Signature=7bd9c6fed0473be1f7ea96ff34c7d79e71a92932054a24b4210b3a56e4ab46d3\r\n\r\n",
+                [
+                    'foos[0]' => '834127',
+                    'foos[1]' => '59',
+                    'foos[2]' => '90123',
+                    'foos[3]' => '4708',
+                    'foos[4]' => '120001',
+                    'foos[5]' => '333',
+                    'foos[6]' => '78005',
+                    'foos[7]' => '2',
+                    'foos[8]' => 'string value',
+                    'foos[9]' => '40617',
+                    'foos[10]' => '715',
+                ],
+            ],
+            // GET Simple case with query params (copy of one of the cases above from testSignsRequests)
+            [
+                "GET / HTTP/1.1\r\nHost: host.foo.com:443\r\n\r\n",
+                "GET / HTTP/1.1\r\nHost: host.foo.com:443\r\nX-Amz-Date: 20110909T233600Z\r\nAuthorization: AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20110909/us-east-1/host/aws4_request, SignedHeaders=host;x-amz-date, Signature=1c3274381ae12d8817336268d7da17672bd57e7348e39b7b9c567280f73742af\r\n\r\n",
+                [
+                    'a' => 'foo',
+                    'b' => 'foo',
+                ],
+            ],
+        ];
+    }
+
+    private function parseRequest(string $req, array $queryParams = []): Request
     {
         $lines = explode("\r\n", $req);
         [$method, $path] = explode(' ', array_shift($lines));
@@ -156,6 +207,12 @@ class SignerV4Test extends TestCase
 
         $req = new Request($method, '/', [], $headers, StringStream::create(implode("\n", $lines)));
         $req->setEndpoint('https://' . $headers['Host'] . $path);
+
+        // currently the library cannot properly parse query params if they contain arrays, so we need to set them manually
+        foreach ($queryParams as $k => $v) {
+            $req->setQueryAttribute($k, $v);
+        }
+
         // Ensure that the memoized property is filled, so that comparison works consistently.
         $req->getEndpoint();
 


### PR DESCRIPTION
Hello!

I found a bug while working with Async AWS , AWS sdk have the same one.

If one of the query params is an array with 10+ elements it causes an error:
"The request signature we calculated does not match the signature you provided".
The root of problem is sorting of query params for canonical string, cause params should be sorted by name AFTER url encoding.
You can read about this [here](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_sigv-create-signed-request.html)

quote:
" You must also sort the parameters in the canonical query string alphabetically by key name. The sorting occurs after encoding."
This [ksort](https://github.com/async-aws/aws/blob/cd16cff578cf6ff1fcfe79ef4c1424a175e9774f/src/Core/src/Signer/SignerV4.php#L324) is the reason of problem.

Example URL:
```
'https://example.com/service?transaction_ids[0]=1111&transaction_ids[1]=1111&transaction_ids[10]=1111&transaction_ids[2]=1111&transaction_ids[3]=1111&transaction_ids[4]=1111&transaction_ids[5]=1111&transaction_ids[6]=1111&transaction_ids[7]=1111&transaction_ids[8]=1111&transaction_ids[9]=1111'

```

The example of sorting result on current version:
```
array(11) {
  ["transaction_ids[0]"]=>
  string(4) "1111"
  ["transaction_ids[10]"]=>
  string(4) "1111"
  ["transaction_ids[1]"]=>
  string(4) "1111"
  ["transaction_ids[2]"]=>
  string(4) "1111"
  ["transaction_ids[3]"]=>
  string(4) "1111"
  ["transaction_ids[4]"]=>
  string(4) "1111"
  ["transaction_ids[5]"]=>
  string(4) "1111"
  ["transaction_ids[6]"]=>
  string(4) "1111"
  ["transaction_ids[7]"]=>
  string(4) "1111"
  ["transaction_ids[8]"]=>
  string(4) "1111"
  ["transaction_ids[9]"]=>
  string(4) "1111"
}
```

and the correct one after this fix:
```
array(11) {
  ["transaction_ids[0]"]=>
  string(7) "1111"
  ["transaction_ids[1]"]=>
  string(7) "1111"
  ["transaction_ids[10]"]=>
  string(7) "1111"
  ["transaction_ids[2]"]=>
  string(7) "1111"
  ["transaction_ids[3]"]=>
  string(7) "1111"
  ["transaction_ids[4]"]=>
  string(7) "1111"
  ["transaction_ids[5]"]=>
  string(7) "1111"
  ["transaction_ids[6]"]=>
  string(7) "1111"
  ["transaction_ids[7]"]=>
  string(7) "1111"
  ["transaction_ids[8]"]=>
  string(7) "1111"
  ["transaction_ids[9]"]=>
  string(7) "1111"
}
```

As you can see current sorting put 10 and 1 in wrong places. This not allowed signer to build correct canonical query string.
Also need to clarify that Query parameters are added to the request via:
```
AsyncAws\Core\Request::setQueryAttribute
```