### PR TITLE
Stop using HttpResponse::stream method

### DIFF
--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -2,11 +2,15 @@
 
 ## NOT RELEASED
 
+### Fixed
+
+- Buffer the response in temporary file to avoid issues when stream is used by another request's body
+
 ## 1.27.1
 
 ### Fixed
 
-- SignerV4: fix sort of query parameters to build correct canoncal query string 
+- SignerV4: fix sort of query parameters to build correct canoncal query string
 
 ## 1.27.0
 

--- a/src/Core/Makefile
+++ b/src/Core/Makefile
@@ -1,12 +1,17 @@
 .EXPORT_ALL_VARIABLES:
 
 initialize: start-docker
-start-docker:
+start-docker: start-docker-s3 start-docker-localstack
+start-docker-localstack:
 	docker start async_aws_localstack && exit 0 || \
 	docker start async_aws_localstack-sts && exit 0 || \
 	docker pull localstack/localstack:3.0.0 && \
 	docker run -d -p 4566:4566 -e SERVICES=sts -v /var/run/docker.sock:/var/run/docker.sock --name async_aws_localstack-sts localstack/localstack:3.0.0 && \
 	docker run --rm --link async_aws_localstack-sts:localstack martin/wait -c localstack:4566
+start-docker-s3:
+	docker pull asyncaws/testing-s3
+	docker start async_aws_s3 && exit 0 || \
+	docker run -d -p 4569:4569 -p 4570:4569 --name async_aws_s3 asyncaws/testing-s3
 
 test: initialize
 	./vendor/bin/simple-phpunit

--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -17,7 +17,6 @@ use AsyncAws\Core\Exception\InvalidArgument;
 use AsyncAws\Core\Exception\LogicException;
 use AsyncAws\Core\Exception\RuntimeException;
 use AsyncAws\Core\Exception\UnparsableResponse;
-use AsyncAws\Core\Stream\ResponseBodyResourceStream;
 use AsyncAws\Core\Stream\ResponseBodyStream;
 use AsyncAws\Core\Stream\ResultStream;
 use Psr\Log\LoggerInterface;
@@ -288,7 +287,7 @@ final class Response
      * @return array{
      *                resolved: bool,
      *                body_downloaded: bool,
-     *                response: \Symfony\Contracts\HttpClient\ResponseInterface,
+     *                response: ResponseInterface,
      *                status: int,
      *                }
      */
@@ -368,10 +367,6 @@ final class Response
     public function toStream(): ResultStream
     {
         $this->resolve();
-
-        if (\is_callable([$this->httpResponse, 'toStream'])) {
-            return new ResponseBodyResourceStream($this->httpResponse->toStream());
-        }
 
         if ($this->streamStarted) {
             throw new RuntimeException('Can not create a ResultStream because the body started being downloaded. The body was started to be downloaded in Response::wait()');

--- a/src/Core/tests/Integration/ClientTest.php
+++ b/src/Core/tests/Integration/ClientTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core\Tests\Integration;
+
+use AsyncAws\Core\Credentials\NullProvider;
+use AsyncAws\S3\S3Client;
+use PHPUnit\Framework\TestCase;
+
+class ClientTest extends TestCase
+{
+    public function testStreamToStream(): void
+    {
+        if (!class_exists(S3Client::class)) {
+            self::markTestSkipped('This test needs a client with waiter endpoints');
+        }
+
+        $client = new S3Client([
+            'endpoint' => 'http://localhost:4569',
+            'pathStyleEndpoint' => true,
+        ], new NullProvider());
+
+        $client->createBucket(['Bucket' => 'foo'])->resolve();
+        $client->putObject([
+            'Bucket' => 'foo',
+            'Key' => 'bar',
+            'Body' => 'content',
+        ])->resolve();
+
+        $client->putObject([
+            'Bucket' => 'foo',
+            'Key' => 'bar2',
+            'Body' => $client->getObject(['Bucket' => 'foo', 'Key' => 'bar'])->getBody()->getContentAsResource(),
+        ])->resolve();
+
+        self::expectNotToPerformAssertions();
+    }
+}


### PR DESCRIPTION
cURL does not allows to stream a response when performing another request.

Therefore, the current implementation that leverages the symfony's `HttpResponse::stream` method might trigger exception if the stream is used in another request. (ie. copying file using `client->upload('2', client->download('1'))`).

This PR removes the use of `HttpResponse::stream` and fallbacks to the generic `ResponseBodyStream` that buffers the entire response in a temporary file, which consumes the entire stream before processing the request and avoid the issue.

fix #1944 