### PR TITLE
Fix the local test setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
         "symfony/polyfill-uuid": "^1.13.1"
     },
     "conflict": {
+        "phpunit/phpunit": ">=10",
         "symfony/http-client": "5.2.0"
     },
     "autoload": {


### PR DESCRIPTION
When installing dependencies in the root project, the bundle tests are installing phpunit as a transitive dependency. This causes issue when the installed version is incompatible with the version installed by the simple-phpunit script.
CI was not impacted because it injects such conflict rule in component-level files to prevent this issue already.