### PR TITLE
Fix the version update for BC breaking changes

### DIFF
--- a/.github/workflows/bin/refresh
+++ b/.github/workflows/bin/refresh
@@ -265,7 +265,6 @@ foreach ($services as $service => $hasChange) {
             exit(1);
         }
         $parts = explode('.', $lastPackageVersion);
-        $level = 1;
         if (0 === (int) $parts[0]) {
             $level = min(2, $level + 1);
         }


### PR DESCRIPTION
The refresh script was computing the level variable based on the kind of changes in the changelog of the unreleased version, and was later reinitializing the variable, losing that info.

This fixes the issue detected in https://github.com/async-aws/aws/pull/1964