### PR TITLE
Avoid requiring changelog entry when updating the service template

### DIFF
--- a/tests/Unit/ChangelogTest.php
+++ b/tests/Unit/ChangelogTest.php
@@ -215,6 +215,10 @@ class ChangelogTest extends TestCase
             if ('Service' === $parts[1]) {
                 $service = $parts[2];
                 $base = 'src/Service/' . $service;
+
+                if ('.template' === $service) {
+                    continue; // The service template does not have an actual changelog
+                }
             } elseif ('Integration' === $parts[1]) {
                 $service = $parts[2] . '/' . $parts[3];
                 $base = 'src/Integration/' . $service;


### PR DESCRIPTION
This avoids making the CI fail when doing a change in `src/Service/.template`.
We don't update that template very often, which is probably why we never got this failure since the introduction of that test (but I got it in https://github.com/async-aws/aws/pull/1967)