### PR TITLE
Update simple-s3 to use the new major version of the s3 package

### DIFF
--- a/src/Integration/Aws/SimpleS3/CHANGELOG.md
+++ b/src/Integration/Aws/SimpleS3/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### BC-BREAK
+
+- Upgrade to `async-aws/s3` 3.0
+
 ### Dependency bumped
 
 - Drop support for PHP versions lower than 8.2

--- a/src/Integration/Aws/SimpleS3/composer.json
+++ b/src/Integration/Aws/SimpleS3/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-json": "*",
-        "async-aws/s3": "^2.0"
+        "async-aws/s3": "^3.0"
     },
     "autoload": {
         "psr-4": {
@@ -27,7 +27,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.2-dev"
+            "dev-master": "3.0-dev"
         }
     }
 }

--- a/src/Integration/Symfony/Bundle/CHANGELOG.md
+++ b/src/Integration/Symfony/Bundle/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Add support for `async-aws` 3.0 in the testsuite
 
 ## 1.15.0
 

--- a/src/Integration/Symfony/Bundle/composer.json
+++ b/src/Integration/Symfony/Bundle/composer.json
@@ -19,7 +19,7 @@
         "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
     },
     "require-dev": {
-        "async-aws/s3": "^1.0 || ^2.0",
+        "async-aws/s3": "^1.0 || ^2.0 || ^3.0",
         "async-aws/ses": "^1.0",
         "async-aws/sqs": "^1.0 || ^2.0",
         "async-aws/ssm": "^1.0 || ^2.0",


### PR DESCRIPTION
As our `simple-s3` extends the `async-aws/s3` client, we cannot support multiple versions at the same time (as we inherit BC breaks). Thus, users might rely on the transitive dependency so being strict on the targeted version is also safer.

As the not-released changes for `async-aws/s3` are targeting a new major version, we need to upgrade `simple-s3` to also do the same.

For the Symfony bundle, I added support for the new major version in the dev dependency, to allow us to use the latest version of the package. This does not matter much in such case (it won't call the client anyway in those tests).