### PR TITLE
Force 'now' to be in UTC for signing requests

### DIFF
--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -19,6 +19,7 @@
 ### Fixed
 
 - Buffer the response in temporary file to avoid issues when stream is used by another request's body
+- SignerV4: Fix signing request during DST change
 
 
 ## 1.27.1

--- a/src/Core/src/Signer/SignerV4.php
+++ b/src/Core/src/Signer/SignerV4.php
@@ -62,7 +62,7 @@ class SignerV4 implements Signer
 
     public function presign(Request $request, Credentials $credentials, RequestContext $context): void
     {
-        $now = $context->getCurrentDate() ?? new \DateTimeImmutable();
+        $now = $context->getCurrentDate() ?? new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
 
         // Signer date have to be UTC https://docs.aws.amazon.com/general/latest/gr/sigv4-date-handling.html
         $now = $now->setTimezone(new \DateTimeZone('UTC'));
@@ -73,7 +73,7 @@ class SignerV4 implements Signer
 
     public function sign(Request $request, Credentials $credentials, RequestContext $context): void
     {
-        $now = $context->getCurrentDate() ?? new \DateTimeImmutable();
+        $now = $context->getCurrentDate() ?? new \DateTimeImmutable('now', new \DateTimeZone('UTC'));
 
         // Signer date have to be UTC https://docs.aws.amazon.com/general/latest/gr/sigv4-date-handling.html
         $now = $now->setTimezone(new \DateTimeZone('UTC'));


### PR DESCRIPTION
Our server is running in `Europe/London`, at `26 OCT 2025 UTC 00:01:00`, we had a load of errors for 1 hour:
```
AsyncAws\Core\Exception\Http\ClientException: HTTP 403 returned for "https://sqs.eu-west-1.amazonaws.com/".

Code:    InvalidSignatureException
Message: Signature not yet current: 20251026T010057Z is still later than 20251026T001557Z (20251026T000057Z + 15 min.)
```
We understand the culprit to be at these lines: https://github.com/async-aws/aws/blob/87fd89ecc0806cf8b2c4faf635ff5920729bb755/src/Core/src/Signer/SignerV4.php#L76-L79

At `26 OCT 2025 UTC 00:01:00`, on a server set to `Europe/London`, DateTimeImmutable yields:
```php
$date = new DateTimeImmutable();
var_dump($date);
class DateTimeImmutable#1 (3) {
  public $date =>
  string(26) "2025-10-26 01:01:03.078020"
  public $timezone_type =>
  int(3)
  public $timezone =>
  string(13) "Europe/London"
}
```
Then when the timezone is updated as seen in the code:
```php
$updated = $date->setTimezone(new \DateTimeZone('UTC'));
var_dump($updated);
class DateTimeImmutable#3 (3) {
  public $date =>
  string(26) "2025-10-26 01:01:03.078020"
  public $timezone_type =>
  int(3)
  public $timezone =>
  string(3) "UTC"
}
```
The time is inconsistent with the real UTC time at that given moment, hence the error.

If we force the instantiation of the date to include UTC which is covered in this PR, at `26 OCT 2025 UTC 00:01:00` the DateTime is instantiated as expected.
```php
$dateUtc = new DateTimeImmutable('now', new DateTimeZone('UTC'));
var_dump($dateUtc);
class DateTimeImmutable#2 (3) {
  public $date =>
  string(26) "2025-10-26 00:01:03.078122"
  public $timezone_type =>
  int(3)
  public $timezone =>
  string(3) "UTC"
}
```
Then if the timezone is set to UTC, as seen in the code, it has no effect.
```php
$updated = $dateUtc->setTimezone(new \DateTimeZone('UTC'));
var_dump($updated);
class DateTimeImmutable#5 (3) {
  public $date =>
  string(26) "2025-10-26 00:01:03.078122"
  public $timezone_type =>
  int(3)
  public $timezone =>
  string(3) "UTC"
}
```

We believe this would prevent the error. Unfortunately, as this relies on the system time being modified, it is very difficult to set up a unit test case to prove this behaviour.

Closes #1658