### PR TITLE
Migrate the testsuite to PHPUnit 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,6 @@ jobs:
             sed -i -re 's/"require": \{/"repositories": [{"type": "path","url": "..\/..\/Core", "options": {"versions": {"async-aws\/core": "dev-master"}}, "canonical": ${{matrix.strategy != 'lowest' && 'true' || 'false'}} }],"require": \{/' composer.json
             composer config minimum-stability dev
             composer config prefer-stable true
-            composer require --dev --no-update symfony/phpunit-bridge:^7.3.2
             cat composer.json
 
             echo ::endgroup::
@@ -71,7 +70,6 @@ jobs:
             echo "$CURRENT_DIR/$COMPONENT"
             cd "$CURRENT_DIR/$COMPONENT"
 
-            sed -i -re 's/"require": \{/"conflict": \{"phpunit\/phpunit": ">=10.0"\},"require": \{/' composer.json
             composer config minimum-stability dev
             composer config prefer-stable true
             cat composer.json
@@ -93,9 +91,7 @@ jobs:
             cd "$CURRENT_DIR/$COMPONENT"
 
             localExit=0
-            composer require symfony/phpunit-bridge:^7.3.2@dev --dev --no-update --no-install
             composer update --no-interaction --no-scripts --prefer-dist --optimize-autoloader ${{ matrix.strategy == 'lowest' && '--prefer-lowest' || '' }} $COMPOSER_OPTIONS || localExit=1
-            ./vendor/bin/simple-phpunit install
             echo ::endgroup::
             if [ $localExit -ne 0 ]; then
               echo "::error::$COMPONENT error"
@@ -105,19 +101,16 @@ jobs:
 
       - name: Run tests
         env:
-          OVERRIDE_SYMFONY_DEPRECATIONS_HELPER: ${{ matrix.strategy == 'lowest' && 'max[self]=9999' || '' }}
+          PHPUNIT_FLAGS: ${{ matrix.strategy == 'lowest' && '--do-not-fail-on-deprecation' || '' }}
         run: |
           ok=0
-          if [ -n "$OVERRIDE_SYMFONY_DEPRECATIONS_HELPER" ]; then
-            export SYMFONY_DEPRECATIONS_HELPER=$OVERRIDE_SYMFONY_DEPRECATIONS_HELPER
-          fi
           CURRENT_DIR=$(pwd)
           for COMPONENT in $(find src -maxdepth 4 -type f -name phpunit.xml.dist -printf '%h\n' | sort)
           do
             echo ::group::$COMPONENT
             localExit=0
             cd "$CURRENT_DIR/$COMPONENT"
-            ./vendor/bin/simple-phpunit 2>&1 || localExit=1
+            ./vendor/bin/phpunit $PHPUNIT_FLAGS 2>&1 || localExit=1
             ok=$(( $localExit || $ok ))
             echo ::endgroup::
             if [ $localExit -ne 0 ]; then
@@ -163,12 +156,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability ${{ matrix.minimum_stability }}
-          composer require --dev --no-update "phpunit/phpunit=9.6.*"
           composer update --no-interaction --prefer-dist --optimize-autoloader
 
       - name: Run tests
-        run: |
-          echo ::group::Install
-          ./vendor/bin/simple-phpunit install
-          echo ::endgroup::
-          ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -40,9 +40,7 @@ jobs:
           restore-keys: phpstan-
 
       - name: Download dependencies
-        run: |
-          composer update --no-interaction --prefer-dist --optimize-autoloader
-          ./vendor/bin/simple-phpunit install
+        run: composer update --no-interaction --prefer-dist --optimize-autoloader
 
       - name: PHPStan
         run: vendor/bin/phpstan analyze --no-progress
@@ -104,9 +102,7 @@ jobs:
           restore-keys: composer-
 
       - name: Download dependencies
-        run: |
-          composer update --no-interaction --prefer-dist --optimize-autoloader
-          ./vendor/bin/simple-phpunit install
+        run: composer update --no-interaction --prefer-dist --optimize-autoloader
 
       - name: Psalm
         run: vendor/bin/psalm.phar --no-progress --show-info=false --stats

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ stop-docker:
 	docker rm async_aws_kms || true
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 website-assets: website/template/assets/app.css
 website/template/assets/app.css: website/node_modules website/assets/*

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
         "illuminate/cache": "^6.18.13 || ^7.10 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
         "illuminate/queue": "^6.18.11 || ^7.10 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
         "illuminate/support": "^6.18.13 || ^7.10 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
-        "matthiasnoback/symfony-config-test": "^4.1 || ^5.0",
+        "matthiasnoback/symfony-config-test": "^6.1",
         "monolog/monolog": "^1.1 || ^2.0 || ^3.0",
         "nette/php-generator": "^3.6 || ^4.1",
         "nette/utils": "^3.0 || ^4.0",
-        "nikic/php-parser": "^4.0",
         "nyholm/symfony-bundle-test": "^3.0",
         "phpstan/phpstan": "~2.0.0",
+        "phpunit/phpunit": "^11.5.42",
         "psalm/phar": "~6.13.1",
         "psr/cache": "^1.0 || ^2.0 || ^3.0",
         "swaggest/json-diff": "^3.7",
@@ -36,14 +36,16 @@
         "symfony/console": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
         "symfony/dependency-injection": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
         "symfony/deprecation-contracts": "^2.1 || ^3.0",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
         "symfony/filesystem": "^5.0 || ^6.0 || ^7.0 || ^8.0",
         "symfony/finder": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/framework-bundle": "^5.4.45 || ^6.4.13 || ^7.1.6",
         "symfony/http-kernel": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
-        "symfony/phpunit-bridge": "^5.3 || ^6.0 || ^7.0 || ^8.0",
-        "symfony/polyfill-uuid": "^1.13.1"
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0",
+        "symfony/polyfill-uuid": "^1.13.1",
+        "symfony/runtime": "^7.3.2 || ^8.0"
     },
     "conflict": {
-        "phpunit/phpunit": ">=10",
         "symfony/http-client": "5.2.0"
     },
     "autoload": {
@@ -156,7 +158,8 @@
     },
     "config": {
         "allow-plugins": {
-            "ergebnis/composer-normalize": true
+            "ergebnis/composer-normalize": true,
+            "symfony/runtime": false
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
+  <source ignoreSuppressionOfDeprecations="true" ignoreIndirectDeprecations="true">
+    <include>
+      <directory>./src</directory>
+    </include>
+    <exclude>
+      <directory>./src/Core/tests/</directory>
+      <directory>./src/Service/*/tests/</directory>
+      <directory>./src/Integration/*/tests/</directory>
+      <directory>./src/Integration/*/*/tests/</directory>
+    </exclude>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
     <env name="AWS_SHARED_CREDENTIALS_FILE" value="/dev/null" />
     <env name="AWS_CONFIG_FILE" value="/dev/null" />
-    <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[self]=0&amp;quiet[]=indirect" />
   </php>
   <testsuites>
     <testsuite name="Test Suite">

--- a/psalm.xml
+++ b/psalm.xml
@@ -22,10 +22,6 @@
         </ignoreFiles>
     </projectFiles>
 
-    <extraFiles>
-        <directory name="vendor/bin/.phpunit" />
-    </extraFiles>
-
     <issueHandlers>
         <LessSpecificReturnType errorLevel="info" />
 

--- a/src/CodeGenerator/.github/workflows/ci.yml
+++ b/src/CodeGenerator/.github/workflows/ci.yml
@@ -28,8 +28,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/CodeGenerator/composer.json
+++ b/src/CodeGenerator/composer.json
@@ -19,6 +19,11 @@
         "symfony/process": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
         "symfony/service-contracts": "^2.0 || ^3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\CodeGenerator\\": "src"

--- a/src/Core/.github/workflows/ci.yml
+++ b/src/Core/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Core/Makefile
+++ b/src/Core/Makefile
@@ -14,7 +14,7 @@ start-docker-s3:
 	docker run -d -p 4569:4569 -p 4570:4569 --name async_aws_s3 asyncaws/testing-s3
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Core/composer.json
+++ b/src/Core/composer.json
@@ -22,6 +22,11 @@
         "symfony/http-client-contracts": "^1.1.8 || ^2.0 || ^3.0",
         "symfony/service-contracts": "^1.0 || ^2.0 || ^3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "conflict": {
         "async-aws/s3": "<1.1",
         "symfony/http-client": "5.2.0"

--- a/src/Core/phpunit.xml.dist
+++ b/src/Core/phpunit.xml.dist
@@ -1,5 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" backupGlobals="false" colors="true" bootstrap="vendor/autoload.php" failOnRisky="true" failOnWarning="true">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="vendor/autoload.php"
+         failOnRisky="true"
+         failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
+>
+  <source ignoreSuppressionOfDeprecations="true">
+    <include>
+      <directory>./src</directory>
+    </include>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -8,9 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
-  <source>
-    <include>
-      <directory>./src</directory>
-    </include>
-  </source>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Core/tests/HttpClient/AwsRetryStrategyTest.php
+++ b/src/Core/tests/HttpClient/AwsRetryStrategyTest.php
@@ -4,6 +4,7 @@ namespace AsyncAws\Core\Tests\HttpClient;
 
 use AsyncAws\Core\HttpClient\AwsRetryStrategy;
 use AsyncAws\Core\Test\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\AsyncContext;
 use Symfony\Component\HttpClient\Response\MockResponse;
@@ -11,10 +12,8 @@ use Symfony\Component\HttpClient\Retry\GenericRetryStrategy;
 
 class AwsRetryStrategyTest extends TestCase
 {
-    /**
-     * @dataProvider provideRetries
-     */
-    public function testShoudRetry(?bool $expected, int $statusCode, ?string $response): void
+    #[DataProvider('provideRetries')]
+    public function testShouldRetry(?bool $expected, int $statusCode, ?string $response): void
     {
         if (!class_exists(GenericRetryStrategy::class)) {
             self::markTestSkipped('AwsRetryStrategy requires symfony/http-client 5.2');
@@ -25,7 +24,7 @@ class AwsRetryStrategyTest extends TestCase
         self::assertSame($expected, $strategy->shouldRetry($context, $response, null));
     }
 
-    public function provideRetries(): iterable
+    public static function provideRetries(): iterable
     {
         yield [false, 200, null];
         yield [true, 429, null];

--- a/src/Core/tests/Unit/ConfigurationTest.php
+++ b/src/Core/tests/Unit/ConfigurationTest.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace AsyncAws\Core\Tests\Unit;
 
 use AsyncAws\Core\Configuration;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ConfigurationTest extends TestCase
 {
-    /**
-     * @dataProvider provideConfiguration
-     */
+    #[DataProvider('provideConfiguration')]
     public function testCreate($config, $env, $expected)
     {
         foreach ($env as $key => $value) {
@@ -61,7 +60,7 @@ class ConfigurationTest extends TestCase
         self::assertNull($config->get('accessKeySecret'));
     }
 
-    public function provideConfiguration(): iterable
+    public static function provideConfiguration(): iterable
     {
         yield 'simple config' => [['endpoint' => 'foo'], [], ['endpoint' => 'foo']];
         yield 'empty config' => [['endpoint' => ''], [], ['endpoint' => '']];

--- a/src/Core/tests/Unit/Signer/SignerV4Test.php
+++ b/src/Core/tests/Unit/Signer/SignerV4Test.php
@@ -9,6 +9,7 @@ use AsyncAws\Core\Request;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Signer\SignerV4;
 use AsyncAws\Core\Stream\StringStream;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class SignerV4Test extends TestCase
@@ -60,9 +61,7 @@ class SignerV4Test extends TestCase
         self::assertEqualsCanonicalizing($expectedQuery, $request->getQuery());
     }
 
-    /**
-     * @dataProvider provideRequests
-     */
+    #[DataProvider('provideRequests')]
     public function testSignsRequests($rawRequest, $rawExpected)
     {
         $request = $this->parseRequest($rawRequest);
@@ -140,9 +139,7 @@ class SignerV4Test extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider provideRequestsWithQueryParams
-     */
+    #[DataProvider('provideRequestsWithQueryParams')]
     public function testSignsRequestsWithArrayInQueryParams($rawRequestWithoutQuery, $rawExpected, $queryParams)
     {
         $request = $this->parseRequest($rawRequestWithoutQuery, $queryParams);

--- a/src/Core/tests/Unit/Stream/CallableStreamTest.php
+++ b/src/Core/tests/Unit/Stream/CallableStreamTest.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace AsyncAws\Core\Tests\Unit\Stream;
 
 use AsyncAws\Core\Stream\CallableStream;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class CallableStreamTest extends TestCase
 {
-    /**
-     * @dataProvider provideLengths
-     */
+    #[DataProvider('provideLengths')]
     public function testLength(callable $content, ?int $expected): void
     {
         $stream = CallableStream::create($content);
@@ -19,9 +18,7 @@ class CallableStreamTest extends TestCase
         self::assertSame($expected, $stream->length());
     }
 
-    /**
-     * @dataProvider provideStrings
-     */
+    #[DataProvider('provideStrings')]
     public function testStringify(callable $content, string $expected): void
     {
         $stream = CallableStream::create($content);
@@ -29,9 +26,7 @@ class CallableStreamTest extends TestCase
         self::assertSame($expected, $stream->stringify());
     }
 
-    /**
-     * @dataProvider provideChunks
-     */
+    #[DataProvider('provideChunks')]
     public function testChunk(callable $content, array $expected): void
     {
         $stream = CallableStream::create($content);
@@ -39,14 +34,14 @@ class CallableStreamTest extends TestCase
         self::assertSame($expected, iterator_to_array($stream));
     }
 
-    public function provideLengths(): iterable
+    public static function provideLengths(): iterable
     {
         yield [function () {
             return 'Hello world';
         }, null];
     }
 
-    public function provideStrings(): iterable
+    public static function provideStrings(): iterable
     {
         $f = static function (string ...$items) {
             return static function () use (&$items) {
@@ -58,7 +53,7 @@ class CallableStreamTest extends TestCase
         yield [$f('Hello', ' ', '', 'world'), 'Hello '];
     }
 
-    public function provideChunks(): iterable
+    public static function provideChunks(): iterable
     {
         $f = static function (string ...$items) {
             return static function () use (&$items) {

--- a/src/Core/tests/Unit/Stream/FixedSizeStreamTest.php
+++ b/src/Core/tests/Unit/Stream/FixedSizeStreamTest.php
@@ -9,13 +9,12 @@ use AsyncAws\Core\Stream\FixedSizeStream;
 use AsyncAws\Core\Stream\IterableStream;
 use AsyncAws\Core\Stream\RequestStream;
 use AsyncAws\Core\Stream\StringStream;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class FixedSizeStreamTest extends TestCase
 {
-    /**
-     * @dataProvider provideLengths
-     */
+    #[DataProvider('provideLengths')]
     public function testLength(RequestStream $content, ?int $expected): void
     {
         $stream = FixedSizeStream::create($content);
@@ -23,9 +22,7 @@ class FixedSizeStreamTest extends TestCase
         self::assertSame($expected, $stream->length());
     }
 
-    /**
-     * @dataProvider provideStrings
-     */
+    #[DataProvider('provideStrings')]
     public function testStringify(RequestStream $content, string $expected): void
     {
         $stream = FixedSizeStream::create($content);
@@ -33,9 +30,7 @@ class FixedSizeStreamTest extends TestCase
         self::assertSame($expected, $stream->stringify());
     }
 
-    /**
-     * @dataProvider provideChunks
-     */
+    #[DataProvider('provideChunks')]
     public function testChunk(RequestStream $content, int $size, array $expected): void
     {
         $stream = FixedSizeStream::create($content, $size);
@@ -43,9 +38,7 @@ class FixedSizeStreamTest extends TestCase
         self::assertSame($expected, iterator_to_array($stream));
     }
 
-    /**
-     * @dataProvider provideChunks
-     */
+    #[DataProvider('provideChunks')]
     public function testDecoratingFixedSize(RequestStream $content, int $size, array $expected): void
     {
         $stream = FixedSizeStream::create(FixedSizeStream::create($content, 5), $size);
@@ -53,19 +46,19 @@ class FixedSizeStreamTest extends TestCase
         self::assertSame($expected, iterator_to_array($stream));
     }
 
-    public function provideLengths(): iterable
+    public static function provideLengths(): iterable
     {
         yield [StringStream::create('Hello world'), 11];
         yield [CallableStream::create(function () {}), null];
     }
 
-    public function provideStrings(): iterable
+    public static function provideStrings(): iterable
     {
         yield [StringStream::create('Hello world'), 'Hello world'];
         yield [IterableStream::create((function () { yield 'Hello world'; })()), 'Hello world'];
     }
 
-    public function provideChunks(): iterable
+    public static function provideChunks(): iterable
     {
         yield [StringStream::create('Hello world'), 3, ['Hel', 'lo ', 'wor', 'ld']];
         yield [IterableStream::create((function () {

--- a/src/Core/tests/Unit/Stream/IterableStreamTest.php
+++ b/src/Core/tests/Unit/Stream/IterableStreamTest.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace AsyncAws\Core\Tests\Unit\Stream;
 
 use AsyncAws\Core\Stream\IterableStream;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class IterableStreamTest extends TestCase
 {
-    /**
-     * @dataProvider provideLengths
-     */
+    #[DataProvider('provideLengths')]
     public function testLength(iterable $content, ?int $expected): void
     {
         $stream = IterableStream::create($content);
@@ -19,9 +18,7 @@ class IterableStreamTest extends TestCase
         self::assertSame($expected, $stream->length());
     }
 
-    /**
-     * @dataProvider provideStrings
-     */
+    #[DataProvider('provideStrings')]
     public function testStringify(iterable $content, string $expected): void
     {
         $stream = IterableStream::create($content);
@@ -29,9 +26,7 @@ class IterableStreamTest extends TestCase
         self::assertSame($expected, $stream->stringify());
     }
 
-    /**
-     * @dataProvider provideChunks
-     */
+    #[DataProvider('provideChunks')]
     public function testChunk(iterable $content, array $expected): void
     {
         $stream = IterableStream::create($content);
@@ -39,14 +34,14 @@ class IterableStreamTest extends TestCase
         self::assertSame($expected, iterator_to_array($stream));
     }
 
-    public function provideLengths(): iterable
+    public static function provideLengths(): iterable
     {
         yield [(function () {
             yield 'Hello world';
         })(), null];
     }
 
-    public function provideStrings(): iterable
+    public static function provideStrings(): iterable
     {
         yield [(function () {
             yield 'Hello world';
@@ -65,7 +60,7 @@ class IterableStreamTest extends TestCase
         })(), 'Hello world'];
     }
 
-    public function provideChunks(): iterable
+    public static function provideChunks(): iterable
     {
         yield [(function () {
             yield 'Hello world';

--- a/src/Core/tests/Unit/Stream/ResourceStreamTest.php
+++ b/src/Core/tests/Unit/Stream/ResourceStreamTest.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace AsyncAws\Core\Tests\Unit\Stream;
 
 use AsyncAws\Core\Stream\ResourceStream;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class ResourceStreamTest extends TestCase
 {
-    /**
-     * @dataProvider provideLengths
-     */
+    #[DataProvider('provideLengths')]
     public function testLength($content, ?int $expected): void
     {
         $stream = ResourceStream::create($content);
@@ -19,9 +18,7 @@ class ResourceStreamTest extends TestCase
         self::assertSame($expected, $stream->length());
     }
 
-    /**
-     * @dataProvider provideStrings
-     */
+    #[DataProvider('provideStrings')]
     public function testStringify($content, string $expected): void
     {
         $stream = ResourceStream::create($content);
@@ -29,16 +26,14 @@ class ResourceStreamTest extends TestCase
         self::assertSame($expected, $stream->stringify());
     }
 
-    /**
-     * @dataProvider provideChunks
-     */
+    #[DataProvider('provideChunks')]
     public function testChunk($content, int $size, array $expected): void
     {
         $stream = ResourceStream::create($content, $size);
         self::assertSame($expected, iterator_to_array($stream));
     }
 
-    public function provideLengths(): iterable
+    public static function provideLengths(): iterable
     {
         $resource = fopen(__DIR__ . '/../../../LICENSE', 'r');
         yield [$resource, 1099];
@@ -53,7 +48,7 @@ class ResourceStreamTest extends TestCase
         yield [$resource, 11];
     }
 
-    public function provideStrings(): iterable
+    public static function provideStrings(): iterable
     {
         $resource = fopen('php://temp', 'rw+');
         fwrite($resource, 'Hello World');
@@ -65,7 +60,7 @@ class ResourceStreamTest extends TestCase
         yield [$resource, 'Hello World'];
     }
 
-    public function provideChunks(): iterable
+    public static function provideChunks(): iterable
     {
         $resource = fopen('php://temp', 'rw+');
         fwrite($resource, 'Hello World');

--- a/src/Core/tests/Unit/Stream/RewindableStreamTest.php
+++ b/src/Core/tests/Unit/Stream/RewindableStreamTest.php
@@ -9,13 +9,12 @@ use AsyncAws\Core\Stream\IterableStream;
 use AsyncAws\Core\Stream\RequestStream;
 use AsyncAws\Core\Stream\RewindableStream;
 use AsyncAws\Core\Stream\StringStream;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class RewindableStreamTest extends TestCase
 {
-    /**
-     * @dataProvider provideLengths
-     */
+    #[DataProvider('provideLengths')]
     public function testLength(RequestStream $content, ?int $expected): void
     {
         $stream = RewindableStream::create($content);
@@ -23,9 +22,7 @@ class RewindableStreamTest extends TestCase
         self::assertSame($expected, $stream->length());
     }
 
-    /**
-     * @dataProvider provideStrings
-     */
+    #[DataProvider('provideStrings')]
     public function testStringify(RequestStream $content, string $expected): void
     {
         $stream = RewindableStream::create($content);
@@ -33,9 +30,7 @@ class RewindableStreamTest extends TestCase
         self::assertSame($expected, $stream->stringify());
     }
 
-    /**
-     * @dataProvider provideChunks
-     */
+    #[DataProvider('provideChunks')]
     public function testChunk(RequestStream $content, array $expected): void
     {
         $stream = RewindableStream::create($content);
@@ -46,7 +41,7 @@ class RewindableStreamTest extends TestCase
     /**
      * Asserts the streams returns always the same value, but calls the closure once.
      */
-    public function testNoRewind(): void
+    public static function testNoRewind(): void
     {
         $count = 0;
         $stream = RewindableStream::create(CallableStream::create(function () use (&$count) {
@@ -60,19 +55,19 @@ class RewindableStreamTest extends TestCase
         self::assertSame(2, $count);
     }
 
-    public function provideLengths(): iterable
+    public static function provideLengths(): iterable
     {
         yield [StringStream::create('Hello world'), 11];
         yield [CallableStream::create(function () {}), null];
     }
 
-    public function provideStrings(): iterable
+    public static function provideStrings(): iterable
     {
         yield [StringStream::create('Hello world'), 'Hello world'];
         yield [IterableStream::create((function () { yield 'Hello world'; })()), 'Hello world'];
     }
 
-    public function provideChunks(): iterable
+    public static function provideChunks(): iterable
     {
         yield [StringStream::create('Hello world'), ['Hello world']];
     }

--- a/src/Core/tests/Unit/Stream/StringStreamTest.php
+++ b/src/Core/tests/Unit/Stream/StringStreamTest.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace AsyncAws\Core\Tests\Unit\Stream;
 
 use AsyncAws\Core\Stream\StringStream;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class StringStreamTest extends TestCase
 {
-    /**
-     * @dataProvider provideLengths
-     */
+    #[DataProvider('provideLengths')]
     public function testLength(string $content, ?int $expected): void
     {
         $stream = StringStream::create($content);
@@ -19,9 +18,7 @@ class StringStreamTest extends TestCase
         self::assertSame($expected, $stream->length());
     }
 
-    /**
-     * @dataProvider provideStrings
-     */
+    #[DataProvider('provideStrings')]
     public function testStringify(string $content, string $expected): void
     {
         $stream = StringStream::create($content);
@@ -29,9 +26,7 @@ class StringStreamTest extends TestCase
         self::assertSame($expected, $stream->stringify());
     }
 
-    /**
-     * @dataProvider provideChunks
-     */
+    #[DataProvider('provideChunks')]
     public function testChunk(string $content, array $expected): void
     {
         $stream = StringStream::create($content);
@@ -39,19 +34,19 @@ class StringStreamTest extends TestCase
         self::assertSame($expected, iterator_to_array($stream));
     }
 
-    public function provideLengths(): iterable
+    public static function provideLengths(): iterable
     {
         yield ['Hello world', 11];
         yield ['H', 1];
         yield ['é', 2];
     }
 
-    public function provideStrings(): iterable
+    public static function provideStrings(): iterable
     {
         yield ['Hello world', 'Hello world'];
     }
 
-    public function provideChunks(): iterable
+    public static function provideChunks(): iterable
     {
         yield ['Hello world', ['Hello world']];
     }

--- a/src/Integration/Aws/DynamoDbSession/.github/workflows/ci.yml
+++ b/src/Integration/Aws/DynamoDbSession/.github/workflows/ci.yml
@@ -28,8 +28,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Integration/Aws/DynamoDbSession/composer.json
+++ b/src/Integration/Aws/DynamoDbSession/composer.json
@@ -15,6 +15,11 @@
         "php": "^8.2",
         "async-aws/dynamo-db": "^1.0 || ^2.0 || ^3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\DynamoDbSession\\": "src"

--- a/src/Integration/Aws/DynamoDbSession/phpunit.xml.dist
+++ b/src/Integration/Aws/DynamoDbSession/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Integration/Aws/SimpleS3/.github/workflows/ci.yml
+++ b/src/Integration/Aws/SimpleS3/.github/workflows/ci.yml
@@ -28,8 +28,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Integration/Aws/SimpleS3/composer.json
+++ b/src/Integration/Aws/SimpleS3/composer.json
@@ -15,6 +15,11 @@
         "ext-json": "*",
         "async-aws/s3": "^3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\SimpleS3\\": "src"

--- a/src/Integration/Aws/SimpleS3/phpunit.xml.dist
+++ b/src/Integration/Aws/SimpleS3/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Integration/Laravel/Cache/.github/workflows/ci.yml
+++ b/src/Integration/Laravel/Cache/.github/workflows/ci.yml
@@ -28,8 +28,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Integration/Laravel/Cache/composer.json
+++ b/src/Integration/Laravel/Cache/composer.json
@@ -16,6 +16,11 @@
         "illuminate/cache": "^6.18.13 || ^7.10 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
         "illuminate/support": "^6.18.13 || ^7.10 || ^8.0 || ^9.0 || ^10.0 || ^11.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Illuminate\\Cache\\": "src"

--- a/src/Integration/Laravel/Cache/phpunit.xml.dist
+++ b/src/Integration/Laravel/Cache/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Integration/Laravel/Queue/.github/workflows/ci.yml
+++ b/src/Integration/Laravel/Queue/.github/workflows/ci.yml
@@ -28,8 +28,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Integration/Laravel/Queue/composer.json
+++ b/src/Integration/Laravel/Queue/composer.json
@@ -17,6 +17,11 @@
         "illuminate/queue": "^6.18.11 || ^7.10 || ^8.0 || ^9.0 || ^10.0 || ^11.0",
         "illuminate/support": "^6.18.13 || ^7.10 || ^8.0 || ^9.0 || ^10.0 || ^11.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Illuminate\\Queue\\": "src"

--- a/src/Integration/Laravel/Queue/phpunit.xml.dist
+++ b/src/Integration/Laravel/Queue/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true" ignoreIndirectDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Integration/Monolog/CloudWatch/.github/workflows/ci.yml
+++ b/src/Integration/Monolog/CloudWatch/.github/workflows/ci.yml
@@ -28,8 +28,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Integration/Monolog/CloudWatch/composer.json
+++ b/src/Integration/Monolog/CloudWatch/composer.json
@@ -15,6 +15,11 @@
         "async-aws/cloud-watch-logs": "^1.0 || ^2.0",
         "monolog/monolog": "^1.1 || ^2.0 || ^3.0"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Monolog\\CloudWatch\\": "src"

--- a/src/Integration/Monolog/CloudWatch/phpunit.xml.dist
+++ b/src/Integration/Monolog/CloudWatch/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Integration/Symfony/Bundle/.github/workflows/ci.yml
+++ b/src/Integration/Symfony/Bundle/.github/workflows/ci.yml
@@ -28,9 +28,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer require "phpunit/phpunit=9.6.*" --dev --no-update
-          composer require "symfony/phpunit-bridge" --dev --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Integration/Symfony/Bundle/composer.json
+++ b/src/Integration/Symfony/Bundle/composer.json
@@ -23,9 +23,14 @@
         "async-aws/ses": "^1.0",
         "async-aws/sqs": "^1.0 || ^2.0",
         "async-aws/ssm": "^1.0 || ^2.0",
-        "matthiasnoback/symfony-config-test": "^4.1 || ^5.0",
+        "matthiasnoback/symfony-config-test": "^6.1",
         "nyholm/symfony-bundle-test": "^3.0",
-        "symfony/cache": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0"
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/cache": "^4.4 || ^5.0 || ^6.0 || ^7.0 || ^8.0",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/framework-bundle": "^5.4.45 || ^6.4.13 || ^7.1.6",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0",
+        "symfony/runtime": "^7.3.2 || ^8.0"
     },
     "autoload": {
         "psr-4": {
@@ -35,6 +40,11 @@
     "autoload-dev": {
         "psr-4": {
             "AsyncAws\\Symfony\\Bundle\\Tests\\": "tests/"
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "symfony/runtime": false
         }
     },
     "extra": {

--- a/src/Integration/Symfony/Bundle/phpunit.xml.dist
+++ b/src/Integration/Symfony/Bundle/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Integration/Symfony/Bundle/tests/Unit/Secrets/SsmVaultTest.php
+++ b/src/Integration/Symfony/Bundle/tests/Unit/Secrets/SsmVaultTest.php
@@ -7,13 +7,12 @@ use AsyncAws\Ssm\Result\GetParametersByPathResult;
 use AsyncAws\Ssm\SsmClient;
 use AsyncAws\Ssm\ValueObject\Parameter;
 use AsyncAws\Symfony\Bundle\Secrets\SsmVault;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 class SsmVaultTest extends TestCase
 {
-    /**
-     * @dataProvider provideParameters
-     */
+    #[DataProvider('provideParameters')]
     public function testLoadEnvVars($path, $parameterName, $expected)
     {
         $client = $this->createMock(SsmClient::class);
@@ -28,7 +27,7 @@ class SsmVaultTest extends TestCase
         self::assertEquals($expected, $actual);
     }
 
-    public function provideParameters(): iterable
+    public static function provideParameters(): iterable
     {
         yield 'simple' => [null, '/FOO', ['FOO' => 'value']];
         yield 'case insensitive' => [null, '/fOo', ['FOO' => 'value']];

--- a/src/Service/.template/.github/workflows/ci.yml
+++ b/src/Service/.template/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/.template/Makefile
+++ b/src/Service/.template/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/.template/composer.json
+++ b/src/Service/.template/composer.json
@@ -13,6 +13,11 @@
     "require": {
         "php": "^8.2"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Foobar\\": "src"

--- a/src/Service/.template/phpunit.xml.dist
+++ b/src/Service/.template/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/AppSync/.github/workflows/ci.yml
+++ b/src/Service/AppSync/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/AppSync/Makefile
+++ b/src/Service/AppSync/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/AppSync/composer.json
+++ b/src/Service/AppSync/composer.json
@@ -16,6 +16,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\AppSync\\": "src"

--- a/src/Service/AppSync/phpunit.xml.dist
+++ b/src/Service/AppSync/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Athena/.github/workflows/ci.yml
+++ b/src/Service/Athena/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Athena/Makefile
+++ b/src/Service/Athena/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Athena/composer.json
+++ b/src/Service/Athena/composer.json
@@ -17,6 +17,11 @@
         "async-aws/core": "^1.9",
         "symfony/polyfill-uuid": "^1.13.1"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Athena\\": "src"

--- a/src/Service/Athena/phpunit.xml.dist
+++ b/src/Service/Athena/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Athena/tests/Unit/Input/StartCalculationExecutionRequestTest.php
+++ b/src/Service/Athena/tests/Unit/Input/StartCalculationExecutionRequestTest.php
@@ -5,14 +5,11 @@ namespace AsyncAws\Athena\Tests\Unit\Input;
 use AsyncAws\Athena\Input\StartCalculationExecutionRequest;
 use AsyncAws\Athena\ValueObject\CalculationConfiguration;
 use AsyncAws\Core\Test\TestCase;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 
 class StartCalculationExecutionRequestTest extends TestCase
 {
-    /**
-     * @group legacy
-     *
-     * @expectedDeprecation The property "CalculationConfiguration" of "%s" is deprecated by AWS.
-     */
+    #[IgnoreDeprecations]
     public function testRequest(): void
     {
         $input = new StartCalculationExecutionRequest([
@@ -42,6 +39,8 @@ Accept: application/json
     "ClientRequestToken": "i@d-2023"
 }
                 ';
+
+        $this->expectUserDeprecationMessage('The property "CalculationConfiguration" of "AsyncAws\Athena\Input\StartCalculationExecutionRequest" is deprecated by AWS.');
 
         self::assertRequestEqualsHttpRequest($expected, $input->request());
     }

--- a/src/Service/BedrockRuntime/.github/workflows/ci.yml
+++ b/src/Service/BedrockRuntime/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/BedrockRuntime/Makefile
+++ b/src/Service/BedrockRuntime/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/BedrockRuntime/composer.json
+++ b/src/Service/BedrockRuntime/composer.json
@@ -14,6 +14,11 @@
         "php": "^8.2",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\BedrockRuntime\\": "src"

--- a/src/Service/BedrockRuntime/phpunit.xml.dist
+++ b/src/Service/BedrockRuntime/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/CloudFormation/.github/workflows/ci.yml
+++ b/src/Service/CloudFormation/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/CloudFormation/Makefile
+++ b/src/Service/CloudFormation/Makefile
@@ -9,7 +9,7 @@ start-docker:
 	docker run --rm --link async_aws_localstack-cloudformation:localstack martin/wait -c localstack:4566
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/CloudFormation/composer.json
+++ b/src/Service/CloudFormation/composer.json
@@ -16,6 +16,11 @@
         "ext-simplexml": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\CloudFormation\\": "src"

--- a/src/Service/CloudFormation/phpunit.xml.dist
+++ b/src/Service/CloudFormation/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/CloudFront/.github/workflows/ci.yml
+++ b/src/Service/CloudFront/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/CloudFront/Makefile
+++ b/src/Service/CloudFront/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/CloudFront/composer.json
+++ b/src/Service/CloudFront/composer.json
@@ -16,6 +16,11 @@
         "ext-simplexml": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\CloudFront\\": "src"

--- a/src/Service/CloudFront/phpunit.xml.dist
+++ b/src/Service/CloudFront/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/CloudWatch/.github/workflows/ci.yml
+++ b/src/Service/CloudWatch/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/CloudWatch/Makefile
+++ b/src/Service/CloudWatch/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/CloudWatch/composer.json
+++ b/src/Service/CloudWatch/composer.json
@@ -15,6 +15,11 @@
         "ext-simplexml": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\CloudWatch\\": "src"

--- a/src/Service/CloudWatch/phpunit.xml.dist
+++ b/src/Service/CloudWatch/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/CloudWatchLogs/.github/workflows/ci.yml
+++ b/src/Service/CloudWatchLogs/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/CloudWatchLogs/Makefile
+++ b/src/Service/CloudWatchLogs/Makefile
@@ -9,7 +9,7 @@ start-docker:
 	docker run --rm --link async_aws_localstack-logs:localstack martin/wait -c localstack:4566
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/CloudWatchLogs/composer.json
+++ b/src/Service/CloudWatchLogs/composer.json
@@ -17,6 +17,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\CloudWatchLogs\\": "src"

--- a/src/Service/CloudWatchLogs/phpunit.xml.dist
+++ b/src/Service/CloudWatchLogs/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/CloudWatchLogs/tests/Unit/Result/DescribeLogStreamsResponseTest.php
+++ b/src/Service/CloudWatchLogs/tests/Unit/Result/DescribeLogStreamsResponseTest.php
@@ -7,6 +7,7 @@ use AsyncAws\CloudWatchLogs\ValueObject\LogStream;
 use AsyncAws\Core\Response;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\Core\Test\TestCase;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use Psr\Log\NullLogger;
 use Symfony\Component\HttpClient\MockHttpClient;
 
@@ -56,11 +57,7 @@ class DescribeLogStreamsResponseTest extends TestCase
         self::assertSame('88602967394531410094953670125156212707622379445839968487', $logStreams[0]->getUploadSequenceToken());
     }
 
-    /**
-     * @group legacy
-     *
-     * @expectedDeprecation The property "storedBytes" of "%s" is deprecated by AWS.
-     */
+    #[IgnoreDeprecations]
     public function testDescribeLogStreamsResponseDeprecatedAttribute(): void
     {
         // see https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_DescribeLogStreams.html
@@ -84,6 +81,8 @@ class DescribeLogStreamsResponseTest extends TestCase
 
         /** @var LogStream[] $logStreams */
         $logStreams = iterator_to_array($result->getLogStreams(true));
+
+        $this->expectUserDeprecationMessage('The property "storedBytes" of "AsyncAws\CloudWatchLogs\ValueObject\LogStream" is deprecated by AWS.');
 
         self::assertSame(0, $logStreams[0]->getStoredBytes());
     }

--- a/src/Service/CodeBuild/.github/workflows/ci.yml
+++ b/src/Service/CodeBuild/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/CodeBuild/Makefile
+++ b/src/Service/CodeBuild/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/CodeBuild/composer.json
+++ b/src/Service/CodeBuild/composer.json
@@ -16,6 +16,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\CodeBuild\\": "src"

--- a/src/Service/CodeBuild/phpunit.xml.dist
+++ b/src/Service/CodeBuild/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/CodeCommit/.github/workflows/ci.yml
+++ b/src/Service/CodeCommit/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/CodeCommit/Makefile
+++ b/src/Service/CodeCommit/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/CodeCommit/composer.json
+++ b/src/Service/CodeCommit/composer.json
@@ -15,6 +15,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\CodeCommit\\": "src"

--- a/src/Service/CodeCommit/phpunit.xml.dist
+++ b/src/Service/CodeCommit/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/CodeDeploy/.github/workflows/ci.yml
+++ b/src/Service/CodeDeploy/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/CodeDeploy/Makefile
+++ b/src/Service/CodeDeploy/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/CodeDeploy/composer.json
+++ b/src/Service/CodeDeploy/composer.json
@@ -16,6 +16,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\CodeDeploy\\": "src"

--- a/src/Service/CodeDeploy/phpunit.xml.dist
+++ b/src/Service/CodeDeploy/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/CognitoIdentityProvider/.github/workflows/ci.yml
+++ b/src/Service/CognitoIdentityProvider/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/CognitoIdentityProvider/Makefile
+++ b/src/Service/CognitoIdentityProvider/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/CognitoIdentityProvider/composer.json
+++ b/src/Service/CognitoIdentityProvider/composer.json
@@ -16,6 +16,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\CognitoIdentityProvider\\": "src"

--- a/src/Service/CognitoIdentityProvider/phpunit.xml.dist
+++ b/src/Service/CognitoIdentityProvider/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Comprehend/.github/workflows/ci.yml
+++ b/src/Service/Comprehend/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Comprehend/Makefile
+++ b/src/Service/Comprehend/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Comprehend/composer.json
+++ b/src/Service/Comprehend/composer.json
@@ -15,6 +15,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Comprehend\\": "src"

--- a/src/Service/Comprehend/phpunit.xml.dist
+++ b/src/Service/Comprehend/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/DynamoDb/.github/workflows/ci.yml
+++ b/src/Service/DynamoDb/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/DynamoDb/Makefile
+++ b/src/Service/DynamoDb/Makefile
@@ -9,7 +9,7 @@ start-docker:
 	docker run --rm --link async_aws_localstack-dynamodb:localstack martin/wait -c localstack:4566
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/DynamoDb/composer.json
+++ b/src/Service/DynamoDb/composer.json
@@ -17,6 +17,11 @@
         "async-aws/core": "^1.16",
         "symfony/polyfill-uuid": "^1.13.1"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "conflict": {
         "symfony/http-client": "<4.4.16 <5.1.7"
     },

--- a/src/Service/DynamoDb/phpunit.xml.dist
+++ b/src/Service/DynamoDb/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Ecr/.github/workflows/ci.yml
+++ b/src/Service/Ecr/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Ecr/Makefile
+++ b/src/Service/Ecr/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Ecr/composer.json
+++ b/src/Service/Ecr/composer.json
@@ -17,6 +17,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Ecr\\": "src"

--- a/src/Service/Ecr/phpunit.xml.dist
+++ b/src/Service/Ecr/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/ElastiCache/.github/workflows/ci.yml
+++ b/src/Service/ElastiCache/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/ElastiCache/Makefile
+++ b/src/Service/ElastiCache/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/ElastiCache/composer.json
+++ b/src/Service/ElastiCache/composer.json
@@ -16,6 +16,11 @@
         "ext-simplexml": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\ElastiCache\\": "src"

--- a/src/Service/ElastiCache/phpunit.xml.dist
+++ b/src/Service/ElastiCache/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/EventBridge/.github/workflows/ci.yml
+++ b/src/Service/EventBridge/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/EventBridge/Makefile
+++ b/src/Service/EventBridge/Makefile
@@ -9,7 +9,7 @@ start-docker:
 	docker run --rm --link async_aws_localstack-events:localstack martin/wait -c localstack:4566
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/EventBridge/composer.json
+++ b/src/Service/EventBridge/composer.json
@@ -15,6 +15,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\EventBridge\\": "src"

--- a/src/Service/EventBridge/phpunit.xml.dist
+++ b/src/Service/EventBridge/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Firehose/.github/workflows/ci.yml
+++ b/src/Service/Firehose/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Firehose/Makefile
+++ b/src/Service/Firehose/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Firehose/composer.json
+++ b/src/Service/Firehose/composer.json
@@ -16,6 +16,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Firehose\\": "src"

--- a/src/Service/Firehose/phpunit.xml.dist
+++ b/src/Service/Firehose/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Iam/.github/workflows/ci.yml
+++ b/src/Service/Iam/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Iam/Makefile
+++ b/src/Service/Iam/Makefile
@@ -9,7 +9,7 @@ start-docker:
 	docker run --rm --link async_aws_localstack-iam:localstack martin/wait -c localstack:4566
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Iam/composer.json
+++ b/src/Service/Iam/composer.json
@@ -19,6 +19,11 @@
         "ext-simplexml": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Iam\\": "src"

--- a/src/Service/Iam/phpunit.xml.dist
+++ b/src/Service/Iam/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Iot/.github/workflows/ci.yml
+++ b/src/Service/Iot/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Iot/Makefile
+++ b/src/Service/Iot/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Iot/composer.json
+++ b/src/Service/Iot/composer.json
@@ -16,6 +16,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Iot\\": "src"

--- a/src/Service/Iot/phpunit.xml.dist
+++ b/src/Service/Iot/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/IotData/.github/workflows/ci.yml
+++ b/src/Service/IotData/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/IotData/Makefile
+++ b/src/Service/IotData/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/IotData/composer.json
+++ b/src/Service/IotData/composer.json
@@ -14,6 +14,11 @@
         "php": "^8.2",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\IotData\\": "src"

--- a/src/Service/IotData/phpunit.xml.dist
+++ b/src/Service/IotData/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Kinesis/.github/workflows/ci.yml
+++ b/src/Service/Kinesis/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Kinesis/Makefile
+++ b/src/Service/Kinesis/Makefile
@@ -9,7 +9,7 @@ start-docker:
 	docker run --rm --link async_aws_localstack-kinesis:localstack martin/wait -c localstack:4566
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Kinesis/composer.json
+++ b/src/Service/Kinesis/composer.json
@@ -16,6 +16,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Kinesis\\": "src"

--- a/src/Service/Kinesis/phpunit.xml.dist
+++ b/src/Service/Kinesis/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Kms/.github/workflows/ci.yml
+++ b/src/Service/Kms/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Kms/Makefile
+++ b/src/Service/Kms/Makefile
@@ -9,7 +9,7 @@ start-docker:
 	docker run --rm --link async_aws_localstack-kms:localstack martin/wait -c localstack:8080
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Kms/composer.json
+++ b/src/Service/Kms/composer.json
@@ -16,6 +16,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Kms\\": "src"

--- a/src/Service/Kms/phpunit.xml.dist
+++ b/src/Service/Kms/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Kms/tests/Integration/KmsClientTest.php
+++ b/src/Service/Kms/tests/Integration/KmsClientTest.php
@@ -147,6 +147,7 @@ class KmsClientTest extends TestCase
         ]);
 
         $result = $client->listAliases($input);
+        $result = iterator_to_array($result);
         self::assertCount(0, $result);
 
         $client->createAlias([
@@ -155,8 +156,9 @@ class KmsClientTest extends TestCase
         ]);
 
         $result = $client->listAliases($input);
+        $result = iterator_to_array($result);
         self::assertCount(1, $result);
-        self::assertSame($name, iterator_to_array($result)[0]->getAliasName());
+        self::assertSame($name, $result[0]->getAliasName());
     }
 
     public function testSign(): void

--- a/src/Service/Lambda/.github/workflows/ci.yml
+++ b/src/Service/Lambda/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Lambda/Makefile
+++ b/src/Service/Lambda/Makefile
@@ -9,7 +9,7 @@ start-docker:
 	docker run -d -p 9001:9001 -e DOCKER_LAMBDA_STAY_OPEN=1 -v "$(ROOT_DIR)/tests/fixtures/lambda":/var/task:ro,delegated --name async_aws_lambda lambci/lambda:nodejs12.x index.handler
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Lambda/composer.json
+++ b/src/Service/Lambda/composer.json
@@ -16,6 +16,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Lambda\\": "src"

--- a/src/Service/Lambda/phpunit.xml.dist
+++ b/src/Service/Lambda/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/LocationService/.github/workflows/ci.yml
+++ b/src/Service/LocationService/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/LocationService/Makefile
+++ b/src/Service/LocationService/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/LocationService/composer.json
+++ b/src/Service/LocationService/composer.json
@@ -16,6 +16,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.20"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\LocationService\\": "src"

--- a/src/Service/LocationService/phpunit.xml.dist
+++ b/src/Service/LocationService/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/MediaConvert/.github/workflows/ci.yml
+++ b/src/Service/MediaConvert/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/MediaConvert/Makefile
+++ b/src/Service/MediaConvert/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/MediaConvert/composer.json
+++ b/src/Service/MediaConvert/composer.json
@@ -16,6 +16,11 @@
         "async-aws/core": "^1.9",
         "symfony/polyfill-uuid": "^1.13.1"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\MediaConvert\\": "src"

--- a/src/Service/MediaConvert/phpunit.xml.dist
+++ b/src/Service/MediaConvert/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/MediaConvert/tests/Unit/MediaConvertClientTest.php
+++ b/src/Service/MediaConvert/tests/Unit/MediaConvertClientTest.php
@@ -16,6 +16,7 @@ use AsyncAws\MediaConvert\Result\DescribeEndpointsResponse;
 use AsyncAws\MediaConvert\Result\GetJobResponse;
 use AsyncAws\MediaConvert\Result\ListJobsResponse;
 use AsyncAws\MediaConvert\ValueObject\JobSettings;
+use PHPUnit\Framework\Attributes\IgnoreDeprecations;
 use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Component\HttpClient\Response\MockResponse;
 
@@ -55,9 +56,7 @@ class MediaConvertClientTest extends TestCase
         self::assertFalse($result->info()['resolved']);
     }
 
-    /**
-     * @group legacy
-     */
+    #[IgnoreDeprecations]
     public function testDescribeEndpoints(): void
     {
         $client = new MediaConvertClient([], new NullProvider(), new MockHttpClient());

--- a/src/Service/RdsDataService/.github/workflows/ci.yml
+++ b/src/Service/RdsDataService/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/RdsDataService/Makefile
+++ b/src/Service/RdsDataService/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/RdsDataService/composer.json
+++ b/src/Service/RdsDataService/composer.json
@@ -17,6 +17,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\RdsDataService\\": "src"

--- a/src/Service/RdsDataService/phpunit.xml.dist
+++ b/src/Service/RdsDataService/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Rekognition/.github/workflows/ci.yml
+++ b/src/Service/Rekognition/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Rekognition/Makefile
+++ b/src/Service/Rekognition/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Rekognition/composer.json
+++ b/src/Service/Rekognition/composer.json
@@ -16,6 +16,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Rekognition\\": "src"

--- a/src/Service/Rekognition/phpunit.xml.dist
+++ b/src/Service/Rekognition/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Route53/.github/workflows/ci.yml
+++ b/src/Service/Route53/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Route53/Makefile
+++ b/src/Service/Route53/Makefile
@@ -9,7 +9,7 @@ start-docker:
 	docker run --rm --link async_aws_localstack-route53:localstack martin/wait -c localstack:4566
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Route53/composer.json
+++ b/src/Service/Route53/composer.json
@@ -17,6 +17,11 @@
         "ext-simplexml": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Route53\\": "src"

--- a/src/Service/Route53/phpunit.xml.dist
+++ b/src/Service/Route53/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/S3/.github/workflows/ci.yml
+++ b/src/Service/S3/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/S3/Makefile
+++ b/src/Service/S3/Makefile
@@ -8,7 +8,7 @@ start-docker:
 	docker run -d -p 4569:4569 --name async_aws_s3-client asyncaws/testing-s3
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/S3/composer.json
+++ b/src/Service/S3/composer.json
@@ -18,6 +18,11 @@
         "ext-simplexml": "*",
         "async-aws/core": "^1.22"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\S3\\": "src"

--- a/src/Service/S3/phpunit.xml.dist
+++ b/src/Service/S3/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Scheduler/.github/workflows/ci.yml
+++ b/src/Service/Scheduler/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Scheduler/Makefile
+++ b/src/Service/Scheduler/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Scheduler/composer.json
+++ b/src/Service/Scheduler/composer.json
@@ -17,6 +17,11 @@
         "async-aws/core": "^1.9",
         "symfony/polyfill-uuid": "^1.13.1"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Scheduler\\": "src"

--- a/src/Service/Scheduler/phpunit.xml.dist
+++ b/src/Service/Scheduler/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/SecretsManager/.github/workflows/ci.yml
+++ b/src/Service/SecretsManager/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/SecretsManager/Makefile
+++ b/src/Service/SecretsManager/Makefile
@@ -9,7 +9,7 @@ start-docker:
 	docker run --rm --link async_aws_localstack-secretsmanager:localstack martin/wait -c localstack:4566
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/SecretsManager/composer.json
+++ b/src/Service/SecretsManager/composer.json
@@ -17,6 +17,11 @@
         "async-aws/core": "^1.9",
         "symfony/polyfill-uuid": "^1.13.1"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\SecretsManager\\": "src"

--- a/src/Service/SecretsManager/phpunit.xml.dist
+++ b/src/Service/SecretsManager/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Ses/.github/workflows/ci.yml
+++ b/src/Service/Ses/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Ses/Makefile
+++ b/src/Service/Ses/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Ses/composer.json
+++ b/src/Service/Ses/composer.json
@@ -15,6 +15,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Ses\\": "src"

--- a/src/Service/Ses/phpunit.xml.dist
+++ b/src/Service/Ses/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Sns/.github/workflows/ci.yml
+++ b/src/Service/Sns/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Sns/Makefile
+++ b/src/Service/Sns/Makefile
@@ -9,7 +9,7 @@ start-docker:
 	docker run --rm --link async_aws_localstack-sns:localstack martin/wait -c localstack:4566
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Sns/composer.json
+++ b/src/Service/Sns/composer.json
@@ -16,6 +16,11 @@
         "ext-simplexml": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Sns\\": "src"

--- a/src/Service/Sns/phpunit.xml.dist
+++ b/src/Service/Sns/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Sns/tests/Integration/SnsClientTest.php
+++ b/src/Service/Sns/tests/Integration/SnsClientTest.php
@@ -192,7 +192,7 @@ class SnsClientTest extends TestCase
 
         self::assertStringContainsString('arn:aws:sns:us-east-1:000000000000:async-aws:', $result->getSubscriptionArn());
 
-        self::assertCount(1, $client->listSubscriptionsByTopic(['TopicArn' => $this->topicArn]));
+        self::assertCount(1, iterator_to_array($client->listSubscriptionsByTopic(['TopicArn' => $this->topicArn])));
     }
 
     public function testUnsubscribe(): void
@@ -207,7 +207,7 @@ class SnsClientTest extends TestCase
         ]);
 
         $result->resolve();
-        self::assertCount(1, $client->listSubscriptionsByTopic(['TopicArn' => $this->topicArn]));
+        self::assertCount(1, iterator_to_array($client->listSubscriptionsByTopic(['TopicArn' => $this->topicArn])));
 
         $input = new UnsubscribeInput([
             'SubscriptionArn' => $result->getSubscriptionArn(),
@@ -215,7 +215,7 @@ class SnsClientTest extends TestCase
         $result = $client->Unsubscribe($input);
 
         $result->resolve();
-        self::assertCount(0, $client->listSubscriptionsByTopic(['TopicArn' => $this->topicArn]));
+        self::assertCount(0, iterator_to_array($client->listSubscriptionsByTopic(['TopicArn' => $this->topicArn])));
     }
 
     private function getClient(): SnsClient

--- a/src/Service/Sqs/.github/workflows/ci.yml
+++ b/src/Service/Sqs/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Sqs/Makefile
+++ b/src/Service/Sqs/Makefile
@@ -7,7 +7,7 @@ start-docker:
 	docker run -d -p 9494:9494 --name async_aws_sqs asyncaws/testing-sqs
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Sqs/composer.json
+++ b/src/Service/Sqs/composer.json
@@ -16,6 +16,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Sqs\\": "src"

--- a/src/Service/Sqs/phpunit.xml.dist
+++ b/src/Service/Sqs/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Ssm/.github/workflows/ci.yml
+++ b/src/Service/Ssm/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Ssm/Makefile
+++ b/src/Service/Ssm/Makefile
@@ -9,7 +9,7 @@ start-docker:
 	docker run --rm --link async_aws_localstack-ssm:localstack martin/wait -c localstack:4566
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Ssm/composer.json
+++ b/src/Service/Ssm/composer.json
@@ -15,6 +15,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "conflict": {
         "symfony/http-client": "<4.4.16 <5.1.7"
     },

--- a/src/Service/Ssm/phpunit.xml.dist
+++ b/src/Service/Ssm/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Sso/.github/workflows/ci.yml
+++ b/src/Service/Sso/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Sso/Makefile
+++ b/src/Service/Sso/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Sso/composer.json
+++ b/src/Service/Sso/composer.json
@@ -14,6 +14,11 @@
         "php": "^8.2",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Sso\\": "src"

--- a/src/Service/Sso/phpunit.xml.dist
+++ b/src/Service/Sso/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/SsoOidc/.github/workflows/ci.yml
+++ b/src/Service/SsoOidc/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/SsoOidc/Makefile
+++ b/src/Service/SsoOidc/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/SsoOidc/composer.json
+++ b/src/Service/SsoOidc/composer.json
@@ -15,6 +15,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\SsoOidc\\": "src"

--- a/src/Service/SsoOidc/phpunit.xml.dist
+++ b/src/Service/SsoOidc/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/StepFunctions/.github/workflows/ci.yml
+++ b/src/Service/StepFunctions/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/StepFunctions/Makefile
+++ b/src/Service/StepFunctions/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/StepFunctions/composer.json
+++ b/src/Service/StepFunctions/composer.json
@@ -15,6 +15,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\StepFunctions\\": "src"

--- a/src/Service/StepFunctions/phpunit.xml.dist
+++ b/src/Service/StepFunctions/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/TimestreamQuery/.github/workflows/ci.yml
+++ b/src/Service/TimestreamQuery/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/TimestreamQuery/Makefile
+++ b/src/Service/TimestreamQuery/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/TimestreamQuery/composer.json
+++ b/src/Service/TimestreamQuery/composer.json
@@ -17,6 +17,11 @@
         "async-aws/core": "^1.16",
         "symfony/polyfill-uuid": "^1.13.1"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\TimestreamQuery\\": "src"

--- a/src/Service/TimestreamQuery/phpunit.xml.dist
+++ b/src/Service/TimestreamQuery/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/TimestreamWrite/.github/workflows/ci.yml
+++ b/src/Service/TimestreamWrite/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/TimestreamWrite/Makefile
+++ b/src/Service/TimestreamWrite/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/TimestreamWrite/composer.json
+++ b/src/Service/TimestreamWrite/composer.json
@@ -15,6 +15,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.16"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\TimestreamWrite\\": "src"

--- a/src/Service/TimestreamWrite/phpunit.xml.dist
+++ b/src/Service/TimestreamWrite/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/Translate/.github/workflows/ci.yml
+++ b/src/Service/Translate/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/Translate/Makefile
+++ b/src/Service/Translate/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/Translate/composer.json
+++ b/src/Service/Translate/composer.json
@@ -15,6 +15,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\Translate\\": "src"

--- a/src/Service/Translate/phpunit.xml.dist
+++ b/src/Service/Translate/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/src/Service/XRay/.github/workflows/ci.yml
+++ b/src/Service/XRay/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Download dependencies
         run: |
           composer config minimum-stability dev
-          composer req symfony/phpunit-bridge --no-update
           composer update --no-interaction --prefer-dist --optimize-autoloader --prefer-stable
 
       - name: Run tests
-        run: ./vendor/bin/simple-phpunit
+        run: ./vendor/bin/phpunit

--- a/src/Service/XRay/Makefile
+++ b/src/Service/XRay/Makefile
@@ -5,7 +5,7 @@ start-docker:
 	echo "Noop"
 
 test: initialize
-	./vendor/bin/simple-phpunit
+	./vendor/bin/phpunit
 
 clean: stop-docker
 stop-docker:

--- a/src/Service/XRay/composer.json
+++ b/src/Service/XRay/composer.json
@@ -15,6 +15,11 @@
         "ext-json": "*",
         "async-aws/core": "^1.9"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^11.5.42",
+        "symfony/error-handler": "^7.3.2 || ^8.0",
+        "symfony/phpunit-bridge": "^7.3.2 || ^8.0"
+    },
     "autoload": {
         "psr-4": {
             "AsyncAws\\XRay\\": "src"

--- a/src/Service/XRay/phpunit.xml.dist
+++ b/src/Service/XRay/phpunit.xml.dist
@@ -1,17 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
          backupGlobals="false"
          colors="true"
          bootstrap="vendor/autoload.php"
          failOnRisky="true"
          failOnWarning="true"
+         failOnDeprecation="true"
+         failOnNotice="true"
 >
-  <coverage>
+  <source ignoreSuppressionOfDeprecations="true">
     <include>
       <directory>./src</directory>
     </include>
-  </coverage>
+    <deprecationTrigger>
+      <function>trigger_deprecation</function>
+    </deprecationTrigger>
+  </source>
   <php>
     <ini name="error_reporting" value="-1"/>
   </php>
@@ -20,4 +25,7 @@
       <directory>./tests/</directory>
     </testsuite>
   </testsuites>
+  <extensions>
+    <bootstrap class="Symfony\Bridge\PhpUnit\SymfonyExtension"/>
+  </extensions>
 </phpunit>

--- a/tests/Unit/BranchAliasTest.php
+++ b/tests/Unit/BranchAliasTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\Test\Unit;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
 
@@ -21,9 +22,7 @@ use Symfony\Component\Finder\Finder;
  */
 class BranchAliasTest extends TestCase
 {
-    /**
-     * @dataProvider provideChangedlogFiles
-     */
+    #[DataProvider('provideChangedlogFiles')]
     public function testBranchAliasValue(string $changelogPath)
     {
         $composerPath = \dirname($changelogPath) . '/composer.json';

--- a/tests/Unit/ChangelogTest.php
+++ b/tests/Unit/ChangelogTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace AsyncAws\Test\Unit;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Finder\Finder;
 
@@ -12,9 +13,7 @@ use Symfony\Component\Finder\Finder;
  */
 class ChangelogTest extends TestCase
 {
-    /**
-     * @dataProvider provideChangedlogFiles
-     */
+    #[DataProvider('provideChangedlogFiles')]
     public function testChangelogFormat(string $changelogPath)
     {
         $lines = explode("\n", file_get_contents($changelogPath));
@@ -131,9 +130,7 @@ class ChangelogTest extends TestCase
         self::assertTrue($finalWords, 'CHANGELOG MUST contains "First version"');
     }
 
-    /**
-     * @dataProvider provideChangedServicesWithoutChangelog
-     */
+    #[DataProvider('provideChangedServicesWithoutChangelog')]
     public function testChangelogEntryForService(string $service, string $base, $isCommentOnly)
     {
         if (!$isCommentOnly) {


### PR DESCRIPTION
This migrates the testsuite to use PHPUnit 11.

I'm now installing phpunit through composer rather than using `simple-phpunit` as it is much simpler: `matthiasnoback/symfony-config-test` already brings us a transitive dependency anyway (for which we needed to add a conflict rule to prevent issues).

I'm still registering `Symfony\Bridge\PhpUnit\SymfonyExtension` from the symfony phpunit bridge in our config. The feature I wanted is the registration of the DebugClassLoader of `symfony/error-handler` to report deprecations detecting by the DebugClassLoader (which was previously done for root tests where error-handler is installed by FrameworkBundle but not for component tests where it was not installed). It might also be useful if we want to use the ClockMock or DnsMock features in the future.