### PR TITLE
Fix badges in the readme of subtree packages

### DIFF
--- a/src/CodeGenerator/README.md
+++ b/src/CodeGenerator/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Code Generator
 
-![](https://github.com/async-aws/code-generator/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/code-generator/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/code-generator/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/code-generator/actions/workflows/checks.yml/badge.svg?branch=master)
 
 This package generate code for the API clients.
 

--- a/src/Core/README.md
+++ b/src/Core/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Core
 
-![](https://github.com/async-aws/core/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/core/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/core/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/core/actions/workflows/checks.yml/badge.svg?branch=master)
 
 The repository contains shared classes between all AWS services. It also contains
 the STS client to handle authentication.

--- a/src/Integration/Aws/DynamoDbSession/README.md
+++ b/src/Integration/Aws/DynamoDbSession/README.md
@@ -1,7 +1,7 @@
 # AsyncAws DynamoDB integration for PHP Sessions
 
-![](https://github.com/async-aws/dynamo-db-session/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/dynamo-db-session/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/dynamo-db-session/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/dynamo-db-session/actions/workflows/checks.yml/badge.svg?branch=master)
 
 Store your PHP Sessions in DynamoDB.
 

--- a/src/Integration/Aws/SimpleS3/README.md
+++ b/src/Integration/Aws/SimpleS3/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Simple S3 client
 
-![](https://github.com/async-aws/simple-s3/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/simple-s3/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/simple-s3/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/simple-s3/actions/workflows/checks.yml/badge.svg?branch=master)
 
 A thin layer on top of the S3 client to make it easier to work with.
 

--- a/src/Integration/Laravel/Cache/README.md
+++ b/src/Integration/Laravel/Cache/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Illuminate Cache integration
 
-![](https://github.com/async-aws/illuminate-cache/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/illuminate-cache/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/illuminate-cache/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/illuminate-cache/actions/workflows/checks.yml/badge.svg?branch=master)
 
 ## Install
 

--- a/src/Integration/Laravel/Queue/README.md
+++ b/src/Integration/Laravel/Queue/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Illuminate Queue integration
 
-![](https://github.com/async-aws/illuminate-queue/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/illuminate-queue/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/illuminate-queue/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/illuminate-queue/actions/workflows/checks.yml/badge.svg?branch=master)
 
 ## Install
 

--- a/src/Integration/Monolog/CloudWatch/README.md
+++ b/src/Integration/Monolog/CloudWatch/README.md
@@ -1,7 +1,7 @@
 # Monolog integration with CloudWatch logs
 
-![](https://github.com/async-aws/monolog-cloud-watch/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/monolog-cloud-watch/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/monolog-cloud-watch/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/monolog-cloud-watch/actions/workflows/checks.yml/badge.svg?branch=master)
 
 CloudWatch Logs adapter for Monolog version 1 and 2.
 

--- a/src/Integration/Symfony/Bundle/README.md
+++ b/src/Integration/Symfony/Bundle/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Symfony Bundle
 
-![](https://github.com/async-aws/symfony-bundle/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/symfony-bundle/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/symfony-bundle/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/symfony-bundle/actions/workflows/checks.yml/badge.svg?branch=master)
 
 A small SymfonyBundle that helps with configuration and autowiring.
 

--- a/src/Service/.template/README.md
+++ b/src/Service/.template/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Foobar Client
 
-![](https://github.com/async-aws/foobar/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/foobar/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/foobar/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/foobar/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for Foobar.
 

--- a/src/Service/AppSync/README.md
+++ b/src/Service/AppSync/README.md
@@ -1,7 +1,7 @@
 # AsyncAws AppSync Client
 
-![](https://github.com/async-aws/app-sync/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/app-sync/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/app-sync/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/app-sync/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for AppSync.
 

--- a/src/Service/Athena/README.md
+++ b/src/Service/Athena/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Athena Client
 
-![](https://github.com/async-aws/athena/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/athena/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/athena/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/athena/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for Athena.
 

--- a/src/Service/BedrockRuntime/README.md
+++ b/src/Service/BedrockRuntime/README.md
@@ -1,7 +1,7 @@
 # AsyncAws BedrockRuntime Client
 
-![](https://github.com/async-aws/bedrock-runtime/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/bedrock-runtime/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/bedrock-runtime/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/bedrock-runtime/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for BedrockRuntime.
 

--- a/src/Service/CloudFormation/README.md
+++ b/src/Service/CloudFormation/README.md
@@ -1,7 +1,7 @@
 # AsyncAws CloudFormation Client
 
-![](https://github.com/async-aws/cloud-formation/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/cloud-formation/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/cloud-formation/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/cloud-formation/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for CloudFormation.
 

--- a/src/Service/CloudFront/README.md
+++ b/src/Service/CloudFront/README.md
@@ -1,7 +1,7 @@
 # AsyncAws CloudFront Client
 
-![](https://github.com/async-aws/cloud-front/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/cloud-front/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/cloud-front/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/cloud-front/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for CloudFront.
 

--- a/src/Service/CloudWatch/README.md
+++ b/src/Service/CloudWatch/README.md
@@ -1,7 +1,7 @@
 # AsyncAws CloudWatch Client
 
-![](https://github.com/async-aws/cloud-watch/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/cloud-watch/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/cloud-watch/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/cloud-watch/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for CloudWatch.
 

--- a/src/Service/CloudWatchLogs/README.md
+++ b/src/Service/CloudWatchLogs/README.md
@@ -1,7 +1,7 @@
 # AsyncAws CloudWatchLogs Client
 
-![](https://github.com/async-aws/cloud-watch-logs/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/cloud-watch-logs/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/cloud-watch-logs/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/cloud-watch-logs/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for CloudWatchLogs.
 

--- a/src/Service/CodeBuild/README.md
+++ b/src/Service/CodeBuild/README.md
@@ -1,7 +1,7 @@
 # AsyncAws CodeBuild Client
 
-![](https://github.com/async-aws/code-build/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/code-build/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/code-build/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/code-build/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for CodeBuild.
 

--- a/src/Service/CodeCommit/README.md
+++ b/src/Service/CodeCommit/README.md
@@ -1,7 +1,7 @@
 # AsyncAws CodeCommit Client
 
-![](https://github.com/async-aws/code-commit/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/code-commit/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/code-commit/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/code-commit/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for CodeCommit.
 

--- a/src/Service/CodeDeploy/README.md
+++ b/src/Service/CodeDeploy/README.md
@@ -1,7 +1,7 @@
 # AsyncAws CodeDeploy Client
 
-![](https://github.com/async-aws/code-deploy/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/code-deploy/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/code-deploy/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/code-deploy/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for CodeDeploy.
 

--- a/src/Service/CognitoIdentityProvider/README.md
+++ b/src/Service/CognitoIdentityProvider/README.md
@@ -1,7 +1,7 @@
 # AsyncAws CognitoIdentityProvider Client
 
-![](https://github.com/async-aws/cognito-identity-provider/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/cognito-identity-provider/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/cognito-identity-provider/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/cognito-identity-provider/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for CognitoIdentityProvider.
 

--- a/src/Service/Comprehend/README.md
+++ b/src/Service/Comprehend/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Comprehend Client
 
-![](https://github.com/async-aws/comprehend/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/comprehend/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/comprehend/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/comprehend/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for Comprehend.
 

--- a/src/Service/DynamoDb/README.md
+++ b/src/Service/DynamoDb/README.md
@@ -1,7 +1,7 @@
 # AsyncAws DynamoDb Client
 
-![](https://github.com/async-aws/dynamo-db/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/dynamo-db/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/dynamo-db/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/dynamo-db/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for DynamoDb.
 

--- a/src/Service/Ecr/README.md
+++ b/src/Service/Ecr/README.md
@@ -1,7 +1,7 @@
 # AsyncAws ECR Client
 
-![](https://github.com/async-aws/ecr/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/ecr/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/ecr/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/ecr/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for ECR.
 

--- a/src/Service/ElastiCache/README.md
+++ b/src/Service/ElastiCache/README.md
@@ -1,7 +1,7 @@
 # AsyncAws ElastiCache Client
 
-![](https://github.com/async-aws/elasti-cache/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/elasti-cache/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/elasti-cache/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/elasti-cache/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for ElastiCache.
 

--- a/src/Service/EventBridge/README.md
+++ b/src/Service/EventBridge/README.md
@@ -1,7 +1,7 @@
 # AsyncAws EventBridge Client
 
-![](https://github.com/async-aws/event-bridge/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/event-bridge/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/event-bridge/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/event-bridge/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for EventBridge.
 

--- a/src/Service/Firehose/README.md
+++ b/src/Service/Firehose/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Firehose Client
 
-![](https://github.com/async-aws/firehose/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/firehose/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/firehose/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/firehose/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for Kinesis Data Firehose Service.
 

--- a/src/Service/Iam/README.md
+++ b/src/Service/Iam/README.md
@@ -1,7 +1,7 @@
 # AsyncAws IAM Client
 
-![](https://github.com/async-aws/iam/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/iam/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/iam/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/iam/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for IAM.
 

--- a/src/Service/Iot/README.md
+++ b/src/Service/Iot/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Iot Client
 
-![](https://github.com/async-aws/iot/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/iot/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/iot/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/iot/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for Iot.
 

--- a/src/Service/IotData/README.md
+++ b/src/Service/IotData/README.md
@@ -1,7 +1,7 @@
 # AsyncAws IotData Client
 
-![](https://github.com/async-aws/iot-data/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/iot-data/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/iot-data/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/iot-data/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for IotData.
 

--- a/src/Service/Kinesis/README.md
+++ b/src/Service/Kinesis/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Kinesis Client
 
-![](https://github.com/async-aws/kinesis/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/kinesis/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/kinesis/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/kinesis/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for Kinesis Data Streams Service.
 

--- a/src/Service/Kms/README.md
+++ b/src/Service/Kms/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Kms Client
 
-![](https://github.com/async-aws/kms/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/kms/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/kms/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/kms/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for Kms.
 

--- a/src/Service/Lambda/README.md
+++ b/src/Service/Lambda/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Lambda Client
 
-![](https://github.com/async-aws/lambda/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/lambda/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/lambda/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/lambda/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for Lambda.
 

--- a/src/Service/LocationService/README.md
+++ b/src/Service/LocationService/README.md
@@ -1,7 +1,7 @@
 # AsyncAws LocationService Client
 
-![](https://github.com/async-aws/location-service/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/location-service/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/location-service/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/location-service/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for LocationService.
 

--- a/src/Service/MediaConvert/README.md
+++ b/src/Service/MediaConvert/README.md
@@ -1,7 +1,7 @@
 # AsyncAws MediaConvert Client
 
-![](https://github.com/async-aws/media-convert/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/media-convert/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/media-convert/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/media-convert/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for MediaConvert.
 

--- a/src/Service/RdsDataService/README.md
+++ b/src/Service/RdsDataService/README.md
@@ -1,7 +1,7 @@
 # AsyncAws RdsDataService Client
 
-![](https://github.com/async-aws/rds-data-service/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/rds-data-service/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/rds-data-service/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/rds-data-service/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for the RDS data service.
 

--- a/src/Service/Rekognition/README.md
+++ b/src/Service/Rekognition/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Rekognition Client
 
-![](https://github.com/async-aws/rekognition/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/rekognition/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/rekognition/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/rekognition/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for Rekognition.
 

--- a/src/Service/Route53/README.md
+++ b/src/Service/Route53/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Route53 Client
 
-![](https://github.com/async-aws/route53/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/route53/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/route53/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/route53/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for Route53.
 

--- a/src/Service/S3/README.md
+++ b/src/Service/S3/README.md
@@ -1,7 +1,7 @@
 # AsyncAws S3 Client
 
-![](https://github.com/async-aws/s3/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/s3/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/s3/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/s3/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for S3.
 

--- a/src/Service/Scheduler/README.md
+++ b/src/Service/Scheduler/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Scheduler Client
 
-![](https://github.com/async-aws/scheduler/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/scheduler/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/scheduler/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/scheduler/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for Scheduler.
 

--- a/src/Service/SecretsManager/README.md
+++ b/src/Service/SecretsManager/README.md
@@ -1,7 +1,7 @@
 # AsyncAws SecretsManager Client
 
-![](https://github.com/async-aws/secrets-manager/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/secrets-manager/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/secrets-manager/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/secrets-manager/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for SecretsManager.
 

--- a/src/Service/Ses/README.md
+++ b/src/Service/Ses/README.md
@@ -1,7 +1,7 @@
 # AsyncAws SES Client
 
-![](https://github.com/async-aws/ses/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/ses/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/ses/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/ses/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for SES.
 

--- a/src/Service/Sns/README.md
+++ b/src/Service/Sns/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Sns Client
 
-![](https://github.com/async-aws/sns/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/sns/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/sns/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/sns/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for Sns.
 

--- a/src/Service/Sqs/README.md
+++ b/src/Service/Sqs/README.md
@@ -1,7 +1,7 @@
 # AsyncAws SQS Client
 
-![](https://github.com/async-aws/sqs/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/sqs/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/sqs/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/sqs/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for SQS.
 

--- a/src/Service/Ssm/README.md
+++ b/src/Service/Ssm/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Ssm Client
 
-![](https://github.com/async-aws/ssm/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/ssm/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/ssm/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/ssm/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for Ssm.
 

--- a/src/Service/Sso/README.md
+++ b/src/Service/Sso/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Sso Client
 
-![](https://github.com/async-aws/sso/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/sso/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/sso/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/sso/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for Sso.
 

--- a/src/Service/SsoOidc/README.md
+++ b/src/Service/SsoOidc/README.md
@@ -1,7 +1,7 @@
 # AsyncAws SsoOidc Client
 
-![](https://github.com/async-aws/sso-oidc/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/sso-oidc/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/sso-oidc/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/sso-oidc/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for SsoOidc.
 

--- a/src/Service/StepFunctions/README.md
+++ b/src/Service/StepFunctions/README.md
@@ -1,7 +1,7 @@
 # AsyncAws StepFunctions Client
 
-![](https://github.com/async-aws/step-functions/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/step-functions/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/step-functions/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/step-functions/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for StepFunctions.
 

--- a/src/Service/TimestreamQuery/README.md
+++ b/src/Service/TimestreamQuery/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Timestream Query Client
 
-![](https://github.com/async-aws/timestream-query/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/timestream-query/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/timestream-query/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/timestream-query/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for Timestream Query.
 

--- a/src/Service/TimestreamWrite/README.md
+++ b/src/Service/TimestreamWrite/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Timestream Write Client
 
-![](https://github.com/async-aws/timestream-write/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/timestream-write/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/timestream-write/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/timestream-write/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for Timestream Write.
 

--- a/src/Service/Translate/README.md
+++ b/src/Service/Translate/README.md
@@ -1,7 +1,7 @@
 # AsyncAws Translate Client
 
-![](https://github.com/async-aws/translate/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/translate/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/translate/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/translate/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for Translate.
 

--- a/src/Service/XRay/README.md
+++ b/src/Service/XRay/README.md
@@ -1,7 +1,7 @@
 # AsyncAws X-Ray Client
 
-![](https://github.com/async-aws/x-ray/workflows/Tests/badge.svg?branch=master)
-![](https://github.com/async-aws/x-ray/workflows/BC%20Check/badge.svg?branch=master)
+![CI](https://github.com/async-aws/x-ray/actions/workflows/ci.yml/badge.svg?branch=master)
+![BC Check](https://github.com/async-aws/x-ray/actions/workflows/checks.yml/badge.svg?branch=master)
 
 An API client for XRay.
 


### PR DESCRIPTION
when I fixed the URL of the GHA badges in the main readme in https://github.com/async-aws/aws/pull/1970, I missed the fact that subtree repos also have such badges in their readme.