### PR TITLE
Fix camel case format for ignored case

### DIFF
--- a/src/CodeGenerator/src/Generator/GeneratorHelper.php
+++ b/src/CodeGenerator/src/Generator/GeneratorHelper.php
@@ -63,28 +63,28 @@ class GeneratorHelper
             'SS' => 'Ss',
         ];
         static $ignored = [
-            'GB' => 'Gb',
-            'GiB' => 'Gib',
-            'BFrame' => 'Bframe',
-            'BReference' => 'Breference',
-            'BBox' => 'Bbox',
-            'VCpu' => 'Vcpu',
-            'IInterval' => 'Iinterval',
-            'IFrame' => 'Iframe',
-            'XCoordinate' => 'Xcoordinate',
-            'YCoordinate' => 'Ycoordinate',
-            'XOffset' => 'Xoffset',
-            'YOffset' => 'Yoffset',
-            'XPosition' => 'Xposition',
-            'YPosition' => 'Yposition',
+            'GB',
+            'GiB',
+            'BFrame',
+            'BReference',
+            'BBox',
+            'VCpu',
+            'IInterval',
+            'IFrame',
+            'XCoordinate',
+            'YCoordinate',
+            'XOffset',
+            'YOffset',
+            'XPosition',
+            'YPosition',
         ];
 
         $originalPropertyName = $propertyName;
         $propertyName = strtr($propertyName, $replacements);
 
         if (preg_match('/[A-Z]{2,}/', $propertyName)) {
-            $propertyName = strtr($propertyName, $ignored);
-            if (preg_match('/[A-Z]{2,}/', $propertyName)) {
+            $propertyNameWithoutIgnored = strtr($propertyName, array_fill_keys($ignored, 'Xx'));
+            if (preg_match('/[A-Z]{2,}/', $propertyNameWithoutIgnored)) {
                 throw new \RuntimeException(\sprintf('No camel case property "%s" is not yet implemented', $originalPropertyName));
             }
         }

--- a/src/Service/DynamoDb/CHANGELOG.md
+++ b/src/Service/DynamoDb/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Apply new CodingStandard from latest php-cs-fixer.
 - AWS enhancement: Documentation updates.
 - Use a more stable sorting for the list of generated region metadata
+- change case of `getSizeEstimateRangeGb` method to `getSizeEstimateRangeGb`
 
 ## 3.8.0
 

--- a/src/Service/DynamoDb/src/ValueObject/ItemCollectionMetrics.php
+++ b/src/Service/DynamoDb/src/ValueObject/ItemCollectionMetrics.php
@@ -26,7 +26,7 @@ final class ItemCollectionMetrics
      *
      * @var float[]|null
      */
-    private $sizeEstimateRangeGb;
+    private $sizeEstimateRangeGB;
 
     /**
      * @param array{
@@ -37,7 +37,7 @@ final class ItemCollectionMetrics
     public function __construct(array $input)
     {
         $this->itemCollectionKey = isset($input['ItemCollectionKey']) ? array_map([AttributeValue::class, 'create'], $input['ItemCollectionKey']) : null;
-        $this->sizeEstimateRangeGb = $input['SizeEstimateRangeGB'] ?? null;
+        $this->sizeEstimateRangeGB = $input['SizeEstimateRangeGB'] ?? null;
     }
 
     /**
@@ -62,8 +62,8 @@ final class ItemCollectionMetrics
     /**
      * @return float[]
      */
-    public function getSizeEstimateRangeGb(): array
+    public function getSizeEstimateRangeGB(): array
     {
-        return $this->sizeEstimateRangeGb ?? [];
+        return $this->sizeEstimateRangeGB ?? [];
     }
 }

--- a/src/Service/Lambda/CHANGELOG.md
+++ b/src/Service/Lambda/CHANGELOG.md
@@ -23,6 +23,7 @@
 
 - Apply new CodingStandard from latest php-cs-fixer.
 - Use a more stable sorting for the list of generated region metadata
+- change case of `executionEnvironmentMemoryGibPerVcpu` method to `executionEnvironmentMemoryGiBPerVCpu`
 
 ## 2.12.0
 

--- a/src/Service/Lambda/src/ValueObject/LambdaManagedInstancesCapacityProviderConfig.php
+++ b/src/Service/Lambda/src/ValueObject/LambdaManagedInstancesCapacityProviderConfig.php
@@ -28,7 +28,7 @@ final class LambdaManagedInstancesCapacityProviderConfig
      *
      * @var float|null
      */
-    private $executionEnvironmentMemoryGibPerVcpu;
+    private $executionEnvironmentMemoryGiBPerVCpu;
 
     /**
      * @param array{
@@ -41,7 +41,7 @@ final class LambdaManagedInstancesCapacityProviderConfig
     {
         $this->capacityProviderArn = $input['CapacityProviderArn'] ?? $this->throwException(new InvalidArgument('Missing required field "CapacityProviderArn".'));
         $this->perExecutionEnvironmentMaxConcurrency = $input['PerExecutionEnvironmentMaxConcurrency'] ?? null;
-        $this->executionEnvironmentMemoryGibPerVcpu = $input['ExecutionEnvironmentMemoryGiBPerVCpu'] ?? null;
+        $this->executionEnvironmentMemoryGiBPerVCpu = $input['ExecutionEnvironmentMemoryGiBPerVCpu'] ?? null;
     }
 
     /**
@@ -61,9 +61,9 @@ final class LambdaManagedInstancesCapacityProviderConfig
         return $this->capacityProviderArn;
     }
 
-    public function getExecutionEnvironmentMemoryGibPerVcpu(): ?float
+    public function getExecutionEnvironmentMemoryGiBPerVCpu(): ?float
     {
-        return $this->executionEnvironmentMemoryGibPerVcpu;
+        return $this->executionEnvironmentMemoryGiBPerVCpu;
     }
 
     public function getPerExecutionEnvironmentMaxConcurrency(): ?int
@@ -82,7 +82,7 @@ final class LambdaManagedInstancesCapacityProviderConfig
         if (null !== $v = $this->perExecutionEnvironmentMaxConcurrency) {
             $payload['PerExecutionEnvironmentMaxConcurrency'] = $v;
         }
-        if (null !== $v = $this->executionEnvironmentMemoryGibPerVcpu) {
+        if (null !== $v = $this->executionEnvironmentMemoryGiBPerVCpu) {
             $payload['ExecutionEnvironmentMemoryGiBPerVCpu'] = $v;
         }
 

--- a/src/Service/LocationService/CHANGELOG.md
+++ b/src/Service/LocationService/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 - Apply new CodingStandard from latest php-cs-fixer.
 - AWS enhancement: Documentation updates.
+- change case of `getFilterBbox` method to `getFilterBBox` and `getRouteBbox` method to `getRouteBBox`
 
 ## 1.1.2
 

--- a/src/Service/LocationService/src/Input/SearchPlaceIndexForTextRequest.php
+++ b/src/Service/LocationService/src/Input/SearchPlaceIndexForTextRequest.php
@@ -58,7 +58,7 @@ final class SearchPlaceIndexForTextRequest extends Input
      *
      * @var float[]|null
      */
-    private $filterBbox;
+    private $filterBBox;
 
     /**
      * An optional parameter that limits the search results by returning only places that are in a specified list of
@@ -145,7 +145,7 @@ final class SearchPlaceIndexForTextRequest extends Input
         $this->indexName = $input['IndexName'] ?? null;
         $this->text = $input['Text'] ?? null;
         $this->biasPosition = $input['BiasPosition'] ?? null;
-        $this->filterBbox = $input['FilterBBox'] ?? null;
+        $this->filterBBox = $input['FilterBBox'] ?? null;
         $this->filterCountries = $input['FilterCountries'] ?? null;
         $this->maxResults = $input['MaxResults'] ?? null;
         $this->language = $input['Language'] ?? null;
@@ -184,9 +184,9 @@ final class SearchPlaceIndexForTextRequest extends Input
     /**
      * @return float[]
      */
-    public function getFilterBbox(): array
+    public function getFilterBBox(): array
     {
-        return $this->filterBbox ?? [];
+        return $this->filterBBox ?? [];
     }
 
     /**
@@ -276,9 +276,9 @@ final class SearchPlaceIndexForTextRequest extends Input
     /**
      * @param float[] $value
      */
-    public function setFilterBbox(array $value): self
+    public function setFilterBBox(array $value): self
     {
-        $this->filterBbox = $value;
+        $this->filterBBox = $value;
 
         return $this;
     }
@@ -354,7 +354,7 @@ final class SearchPlaceIndexForTextRequest extends Input
                 $payload['BiasPosition'][$index] = $listValue;
             }
         }
-        if (null !== $v = $this->filterBbox) {
+        if (null !== $v = $this->filterBBox) {
             $index = -1;
             $payload['FilterBBox'] = [];
             foreach ($v as $listValue) {

--- a/src/Service/LocationService/src/ValueObject/CalculateRouteSummary.php
+++ b/src/Service/LocationService/src/ValueObject/CalculateRouteSummary.php
@@ -26,7 +26,7 @@ final class CalculateRouteSummary
      *
      * @var float[]
      */
-    private $routeBbox;
+    private $routeBBox;
 
     /**
      * The data provider of traffic and road network data used to calculate the route. Indicates one of the available
@@ -79,7 +79,7 @@ final class CalculateRouteSummary
      */
     public function __construct(array $input)
     {
-        $this->routeBbox = $input['RouteBBox'] ?? $this->throwException(new InvalidArgument('Missing required field "RouteBBox".'));
+        $this->routeBBox = $input['RouteBBox'] ?? $this->throwException(new InvalidArgument('Missing required field "RouteBBox".'));
         $this->dataSource = $input['DataSource'] ?? $this->throwException(new InvalidArgument('Missing required field "DataSource".'));
         $this->distance = $input['Distance'] ?? $this->throwException(new InvalidArgument('Missing required field "Distance".'));
         $this->durationSeconds = $input['DurationSeconds'] ?? $this->throwException(new InvalidArgument('Missing required field "DurationSeconds".'));
@@ -126,9 +126,9 @@ final class CalculateRouteSummary
     /**
      * @return float[]
      */
-    public function getRouteBbox(): array
+    public function getRouteBBox(): array
     {
-        return $this->routeBbox;
+        return $this->routeBBox;
     }
 
     /**

--- a/src/Service/LocationService/src/ValueObject/SearchPlaceIndexForTextSummary.php
+++ b/src/Service/LocationService/src/ValueObject/SearchPlaceIndexForTextSummary.php
@@ -33,7 +33,7 @@ final class SearchPlaceIndexForTextSummary
      *
      * @var float[]|null
      */
-    private $filterBbox;
+    private $filterBBox;
 
     /**
      * Contains the optional country filter specified in the request.
@@ -56,7 +56,7 @@ final class SearchPlaceIndexForTextSummary
      *
      * @var float[]|null
      */
-    private $resultBbox;
+    private $resultBBox;
 
     /**
      * The geospatial data provider attached to the place index resource specified in the request. Values can be one of the
@@ -108,10 +108,10 @@ final class SearchPlaceIndexForTextSummary
     {
         $this->text = $input['Text'] ?? $this->throwException(new InvalidArgument('Missing required field "Text".'));
         $this->biasPosition = $input['BiasPosition'] ?? null;
-        $this->filterBbox = $input['FilterBBox'] ?? null;
+        $this->filterBBox = $input['FilterBBox'] ?? null;
         $this->filterCountries = $input['FilterCountries'] ?? null;
         $this->maxResults = $input['MaxResults'] ?? null;
-        $this->resultBbox = $input['ResultBBox'] ?? null;
+        $this->resultBBox = $input['ResultBBox'] ?? null;
         $this->dataSource = $input['DataSource'] ?? $this->throwException(new InvalidArgument('Missing required field "DataSource".'));
         $this->language = $input['Language'] ?? null;
         $this->filterCategories = $input['FilterCategories'] ?? null;
@@ -151,9 +151,9 @@ final class SearchPlaceIndexForTextSummary
     /**
      * @return float[]
      */
-    public function getFilterBbox(): array
+    public function getFilterBBox(): array
     {
-        return $this->filterBbox ?? [];
+        return $this->filterBBox ?? [];
     }
 
     /**
@@ -185,9 +185,9 @@ final class SearchPlaceIndexForTextSummary
     /**
      * @return float[]
      */
-    public function getResultBbox(): array
+    public function getResultBBox(): array
     {
-        return $this->resultBbox ?? [];
+        return $this->resultBBox ?? [];
     }
 
     public function getText(): string

--- a/src/Service/MediaConvert/CHANGELOG.md
+++ b/src/Service/MediaConvert/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Change case of of various properties.
 
 ## 1.11.0
 

--- a/src/Service/MediaConvert/src/ValueObject/Av1Settings.php
+++ b/src/Service/MediaConvert/src/ValueObject/Av1Settings.php
@@ -112,7 +112,7 @@ final class Av1Settings
      *
      * @var int|null
      */
-    private $numberBframesBetweenReferenceFrames;
+    private $numberBFramesBetweenReferenceFrames;
 
     /**
      * Optionally choose one or more per frame metric reports to generate along with your output. You can use these metrics
@@ -203,7 +203,7 @@ final class Av1Settings
         $this->framerateNumerator = $input['FramerateNumerator'] ?? null;
         $this->gopSize = $input['GopSize'] ?? null;
         $this->maxBitrate = $input['MaxBitrate'] ?? null;
-        $this->numberBframesBetweenReferenceFrames = $input['NumberBFramesBetweenReferenceFrames'] ?? null;
+        $this->numberBFramesBetweenReferenceFrames = $input['NumberBFramesBetweenReferenceFrames'] ?? null;
         $this->perFrameMetrics = $input['PerFrameMetrics'] ?? null;
         $this->qvbrSettings = isset($input['QvbrSettings']) ? Av1QvbrSettings::create($input['QvbrSettings']) : null;
         $this->rateControlMode = $input['RateControlMode'] ?? null;
@@ -295,9 +295,9 @@ final class Av1Settings
         return $this->maxBitrate;
     }
 
-    public function getNumberBframesBetweenReferenceFrames(): ?int
+    public function getNumberBFramesBetweenReferenceFrames(): ?int
     {
-        return $this->numberBframesBetweenReferenceFrames;
+        return $this->numberBFramesBetweenReferenceFrames;
     }
 
     /**
@@ -382,7 +382,7 @@ final class Av1Settings
         if (null !== $v = $this->maxBitrate) {
             $payload['maxBitrate'] = $v;
         }
-        if (null !== $v = $this->numberBframesBetweenReferenceFrames) {
+        if (null !== $v = $this->numberBFramesBetweenReferenceFrames) {
             $payload['numberBFramesBetweenReferenceFrames'] = $v;
         }
         if (null !== $v = $this->perFrameMetrics) {

--- a/src/Service/MediaConvert/src/ValueObject/BurninDestinationSettings.php
+++ b/src/Service/MediaConvert/src/ValueObject/BurninDestinationSettings.php
@@ -203,7 +203,7 @@ final class BurninDestinationSettings
      *
      * @var int|null
      */
-    private $shadowXoffset;
+    private $shadowXOffset;
 
     /**
      * Specify the vertical offset of the shadow relative to the captions in pixels. A value of -2 would result in a shadow
@@ -212,7 +212,7 @@ final class BurninDestinationSettings
      *
      * @var int|null
      */
-    private $shadowYoffset;
+    private $shadowYOffset;
 
     /**
      * To use the available style, color, and position information from your input captions: Set Style passthrough to
@@ -243,7 +243,7 @@ final class BurninDestinationSettings
      *
      * @var int|null
      */
-    private $xposition;
+    private $xPosition;
 
     /**
      * Specify the vertical position of the captions, relative to the top of the output in pixels. A value of 10 would
@@ -252,7 +252,7 @@ final class BurninDestinationSettings
      *
      * @var int|null
      */
-    private $yposition;
+    private $yPosition;
 
     /**
      * @param array{
@@ -306,12 +306,12 @@ final class BurninDestinationSettings
         $this->removeRubyReserveAttributes = $input['RemoveRubyReserveAttributes'] ?? null;
         $this->shadowColor = $input['ShadowColor'] ?? null;
         $this->shadowOpacity = $input['ShadowOpacity'] ?? null;
-        $this->shadowXoffset = $input['ShadowXOffset'] ?? null;
-        $this->shadowYoffset = $input['ShadowYOffset'] ?? null;
+        $this->shadowXOffset = $input['ShadowXOffset'] ?? null;
+        $this->shadowYOffset = $input['ShadowYOffset'] ?? null;
         $this->stylePassthrough = $input['StylePassthrough'] ?? null;
         $this->teletextSpacing = $input['TeletextSpacing'] ?? null;
-        $this->xposition = $input['XPosition'] ?? null;
-        $this->yposition = $input['YPosition'] ?? null;
+        $this->xPosition = $input['XPosition'] ?? null;
+        $this->yPosition = $input['YPosition'] ?? null;
     }
 
     /**
@@ -476,14 +476,14 @@ final class BurninDestinationSettings
         return $this->shadowOpacity;
     }
 
-    public function getShadowXoffset(): ?int
+    public function getShadowXOffset(): ?int
     {
-        return $this->shadowXoffset;
+        return $this->shadowXOffset;
     }
 
-    public function getShadowYoffset(): ?int
+    public function getShadowYOffset(): ?int
     {
-        return $this->shadowYoffset;
+        return $this->shadowYOffset;
     }
 
     /**
@@ -502,14 +502,14 @@ final class BurninDestinationSettings
         return $this->teletextSpacing;
     }
 
-    public function getXposition(): ?int
+    public function getXPosition(): ?int
     {
-        return $this->xposition;
+        return $this->xPosition;
     }
 
-    public function getYposition(): ?int
+    public function getYPosition(): ?int
     {
-        return $this->yposition;
+        return $this->yPosition;
     }
 
     /**
@@ -605,10 +605,10 @@ final class BurninDestinationSettings
         if (null !== $v = $this->shadowOpacity) {
             $payload['shadowOpacity'] = $v;
         }
-        if (null !== $v = $this->shadowXoffset) {
+        if (null !== $v = $this->shadowXOffset) {
             $payload['shadowXOffset'] = $v;
         }
-        if (null !== $v = $this->shadowYoffset) {
+        if (null !== $v = $this->shadowYOffset) {
             $payload['shadowYOffset'] = $v;
         }
         if (null !== $v = $this->stylePassthrough) {
@@ -623,10 +623,10 @@ final class BurninDestinationSettings
             }
             $payload['teletextSpacing'] = $v;
         }
-        if (null !== $v = $this->xposition) {
+        if (null !== $v = $this->xPosition) {
             $payload['xPosition'] = $v;
         }
-        if (null !== $v = $this->yposition) {
+        if (null !== $v = $this->yPosition) {
             $payload['yPosition'] = $v;
         }
 

--- a/src/Service/MediaConvert/src/ValueObject/CmafGroupSettings.php
+++ b/src/Service/MediaConvert/src/ValueObject/CmafGroupSettings.php
@@ -71,7 +71,7 @@ final class CmafGroupSettings
      *
      * @var string|null
      */
-    private $dashIframeTrickPlayNameModifier;
+    private $dashIFrameTrickPlayNameModifier;
 
     /**
      * Specify how MediaConvert writes SegmentTimeline in your output DASH manifest. To write a SegmentTimeline for outputs
@@ -202,7 +202,7 @@ final class CmafGroupSettings
      *
      * @var CmafPtsOffsetHandlingForBFrames::*|null
      */
-    private $ptsOffsetHandlingForBframes;
+    private $ptsOffsetHandlingForBFrames;
 
     /**
      * When set to SINGLE_FILE, a single output file is generated, which is internally segmented using the Fragment Length
@@ -331,7 +331,7 @@ final class CmafGroupSettings
         $this->baseUrl = $input['BaseUrl'] ?? null;
         $this->clientCache = $input['ClientCache'] ?? null;
         $this->codecSpecification = $input['CodecSpecification'] ?? null;
-        $this->dashIframeTrickPlayNameModifier = $input['DashIFrameTrickPlayNameModifier'] ?? null;
+        $this->dashIFrameTrickPlayNameModifier = $input['DashIFrameTrickPlayNameModifier'] ?? null;
         $this->dashManifestStyle = $input['DashManifestStyle'] ?? null;
         $this->destination = $input['Destination'] ?? null;
         $this->destinationSettings = isset($input['DestinationSettings']) ? DestinationSettings::create($input['DestinationSettings']) : null;
@@ -345,7 +345,7 @@ final class CmafGroupSettings
         $this->minFinalSegmentLength = $input['MinFinalSegmentLength'] ?? null;
         $this->mpdManifestBandwidthType = $input['MpdManifestBandwidthType'] ?? null;
         $this->mpdProfile = $input['MpdProfile'] ?? null;
-        $this->ptsOffsetHandlingForBframes = $input['PtsOffsetHandlingForBFrames'] ?? null;
+        $this->ptsOffsetHandlingForBFrames = $input['PtsOffsetHandlingForBFrames'] ?? null;
         $this->segmentControl = $input['SegmentControl'] ?? null;
         $this->segmentLength = $input['SegmentLength'] ?? null;
         $this->segmentLengthControl = $input['SegmentLengthControl'] ?? null;
@@ -423,9 +423,9 @@ final class CmafGroupSettings
         return $this->codecSpecification;
     }
 
-    public function getDashIframeTrickPlayNameModifier(): ?string
+    public function getDashIFrameTrickPlayNameModifier(): ?string
     {
-        return $this->dashIframeTrickPlayNameModifier;
+        return $this->dashIFrameTrickPlayNameModifier;
     }
 
     /**
@@ -514,9 +514,9 @@ final class CmafGroupSettings
     /**
      * @return CmafPtsOffsetHandlingForBFrames::*|null
      */
-    public function getPtsOffsetHandlingForBframes(): ?string
+    public function getPtsOffsetHandlingForBFrames(): ?string
     {
-        return $this->ptsOffsetHandlingForBframes;
+        return $this->ptsOffsetHandlingForBFrames;
     }
 
     /**
@@ -617,7 +617,7 @@ final class CmafGroupSettings
             }
             $payload['codecSpecification'] = $v;
         }
-        if (null !== $v = $this->dashIframeTrickPlayNameModifier) {
+        if (null !== $v = $this->dashIFrameTrickPlayNameModifier) {
             $payload['dashIFrameTrickPlayNameModifier'] = $v;
         }
         if (null !== $v = $this->dashManifestStyle) {
@@ -677,7 +677,7 @@ final class CmafGroupSettings
             }
             $payload['mpdProfile'] = $v;
         }
-        if (null !== $v = $this->ptsOffsetHandlingForBframes) {
+        if (null !== $v = $this->ptsOffsetHandlingForBFrames) {
             if (!CmafPtsOffsetHandlingForBFrames::exists($v)) {
                 throw new InvalidArgument(\sprintf('Invalid parameter "ptsOffsetHandlingForBFrames" for "%s". The value "%s" is not a valid "CmafPtsOffsetHandlingForBFrames".', __CLASS__, $v));
             }

--- a/src/Service/MediaConvert/src/ValueObject/CmfcSettings.php
+++ b/src/Service/MediaConvert/src/ValueObject/CmfcSettings.php
@@ -120,7 +120,7 @@ final class CmfcSettings
      *
      * @var CmfcIFrameOnlyManifest::*|null
      */
-    private $iframeOnlyManifest;
+    private $iFrameOnlyManifest;
 
     /**
      * To include key-length-value metadata in this output: Set KLV metadata insertion to Passthrough. MediaConvert reads
@@ -235,7 +235,7 @@ final class CmfcSettings
         $this->c2paManifest = $input['C2paManifest'] ?? null;
         $this->certificateSecret = $input['CertificateSecret'] ?? null;
         $this->descriptiveVideoServiceFlag = $input['DescriptiveVideoServiceFlag'] ?? null;
-        $this->iframeOnlyManifest = $input['IFrameOnlyManifest'] ?? null;
+        $this->iFrameOnlyManifest = $input['IFrameOnlyManifest'] ?? null;
         $this->klvMetadata = $input['KlvMetadata'] ?? null;
         $this->manifestMetadataSignaling = $input['ManifestMetadataSignaling'] ?? null;
         $this->scte35Esam = $input['Scte35Esam'] ?? null;
@@ -323,9 +323,9 @@ final class CmfcSettings
     /**
      * @return CmfcIFrameOnlyManifest::*|null
      */
-    public function getIframeOnlyManifest(): ?string
+    public function getIFrameOnlyManifest(): ?string
     {
-        return $this->iframeOnlyManifest;
+        return $this->iFrameOnlyManifest;
     }
 
     /**
@@ -430,7 +430,7 @@ final class CmfcSettings
             }
             $payload['descriptiveVideoServiceFlag'] = $v;
         }
-        if (null !== $v = $this->iframeOnlyManifest) {
+        if (null !== $v = $this->iFrameOnlyManifest) {
             if (!CmfcIFrameOnlyManifest::exists($v)) {
                 throw new InvalidArgument(\sprintf('Invalid parameter "iFrameOnlyManifest" for "%s". The value "%s" is not a valid "CmfcIFrameOnlyManifest".', __CLASS__, $v));
             }

--- a/src/Service/MediaConvert/src/ValueObject/DashIsoGroupSettings.php
+++ b/src/Service/MediaConvert/src/ValueObject/DashIsoGroupSettings.php
@@ -61,7 +61,7 @@ final class DashIsoGroupSettings
      *
      * @var string|null
      */
-    private $dashIframeTrickPlayNameModifier;
+    private $dashIFrameTrickPlayNameModifier;
 
     /**
      * Specify how MediaConvert writes SegmentTimeline in your output DASH manifest. To write a SegmentTimeline for outputs
@@ -185,7 +185,7 @@ final class DashIsoGroupSettings
      *
      * @var DashIsoPtsOffsetHandlingForBFrames::*|null
      */
-    private $ptsOffsetHandlingForBframes;
+    private $ptsOffsetHandlingForBFrames;
 
     /**
      * When set to SINGLE_FILE, a single output file is generated, which is internally segmented using the Fragment Length
@@ -275,7 +275,7 @@ final class DashIsoGroupSettings
         $this->additionalManifests = isset($input['AdditionalManifests']) ? array_map([DashAdditionalManifest::class, 'create'], $input['AdditionalManifests']) : null;
         $this->audioChannelConfigSchemeIdUri = $input['AudioChannelConfigSchemeIdUri'] ?? null;
         $this->baseUrl = $input['BaseUrl'] ?? null;
-        $this->dashIframeTrickPlayNameModifier = $input['DashIFrameTrickPlayNameModifier'] ?? null;
+        $this->dashIFrameTrickPlayNameModifier = $input['DashIFrameTrickPlayNameModifier'] ?? null;
         $this->dashManifestStyle = $input['DashManifestStyle'] ?? null;
         $this->destination = $input['Destination'] ?? null;
         $this->destinationSettings = isset($input['DestinationSettings']) ? DestinationSettings::create($input['DestinationSettings']) : null;
@@ -288,7 +288,7 @@ final class DashIsoGroupSettings
         $this->minFinalSegmentLength = $input['MinFinalSegmentLength'] ?? null;
         $this->mpdManifestBandwidthType = $input['MpdManifestBandwidthType'] ?? null;
         $this->mpdProfile = $input['MpdProfile'] ?? null;
-        $this->ptsOffsetHandlingForBframes = $input['PtsOffsetHandlingForBFrames'] ?? null;
+        $this->ptsOffsetHandlingForBFrames = $input['PtsOffsetHandlingForBFrames'] ?? null;
         $this->segmentControl = $input['SegmentControl'] ?? null;
         $this->segmentLength = $input['SegmentLength'] ?? null;
         $this->segmentLengthControl = $input['SegmentLengthControl'] ?? null;
@@ -348,9 +348,9 @@ final class DashIsoGroupSettings
         return $this->baseUrl;
     }
 
-    public function getDashIframeTrickPlayNameModifier(): ?string
+    public function getDashIFrameTrickPlayNameModifier(): ?string
     {
-        return $this->dashIframeTrickPlayNameModifier;
+        return $this->dashIFrameTrickPlayNameModifier;
     }
 
     /**
@@ -431,9 +431,9 @@ final class DashIsoGroupSettings
     /**
      * @return DashIsoPtsOffsetHandlingForBFrames::*|null
      */
-    public function getPtsOffsetHandlingForBframes(): ?string
+    public function getPtsOffsetHandlingForBFrames(): ?string
     {
-        return $this->ptsOffsetHandlingForBframes;
+        return $this->ptsOffsetHandlingForBFrames;
     }
 
     /**
@@ -496,7 +496,7 @@ final class DashIsoGroupSettings
         if (null !== $v = $this->baseUrl) {
             $payload['baseUrl'] = $v;
         }
-        if (null !== $v = $this->dashIframeTrickPlayNameModifier) {
+        if (null !== $v = $this->dashIFrameTrickPlayNameModifier) {
             $payload['dashIFrameTrickPlayNameModifier'] = $v;
         }
         if (null !== $v = $this->dashManifestStyle) {
@@ -550,7 +550,7 @@ final class DashIsoGroupSettings
             }
             $payload['mpdProfile'] = $v;
         }
-        if (null !== $v = $this->ptsOffsetHandlingForBframes) {
+        if (null !== $v = $this->ptsOffsetHandlingForBFrames) {
             if (!DashIsoPtsOffsetHandlingForBFrames::exists($v)) {
                 throw new InvalidArgument(\sprintf('Invalid parameter "ptsOffsetHandlingForBFrames" for "%s". The value "%s" is not a valid "DashIsoPtsOffsetHandlingForBFrames".', __CLASS__, $v));
             }

--- a/src/Service/MediaConvert/src/ValueObject/DvbSubDestinationSettings.php
+++ b/src/Service/MediaConvert/src/ValueObject/DvbSubDestinationSettings.php
@@ -89,7 +89,7 @@ final class DvbSubDestinationSettings
      *
      * @var int|null
      */
-    private $ddsXcoordinate;
+    private $ddsXCoordinate;
 
     /**
      * Use this setting, along with DDS x-coordinate, to specify the upper left corner of the display definition segment
@@ -101,7 +101,7 @@ final class DvbSubDestinationSettings
      *
      * @var int|null
      */
-    private $ddsYcoordinate;
+    private $ddsYCoordinate;
 
     /**
      * Specify the font that you want the service to use for your burn in captions when your input captions specify a font
@@ -251,7 +251,7 @@ final class DvbSubDestinationSettings
      *
      * @var int|null
      */
-    private $shadowXoffset;
+    private $shadowXOffset;
 
     /**
      * Specify the vertical offset of the shadow relative to the captions in pixels. A value of -2 would result in a shadow
@@ -261,7 +261,7 @@ final class DvbSubDestinationSettings
      *
      * @var int|null
      */
-    private $shadowYoffset;
+    private $shadowYOffset;
 
     /**
      * To use the available style, color, and position information from your input captions: Set Style passthrough to
@@ -311,7 +311,7 @@ final class DvbSubDestinationSettings
      *
      * @var int|null
      */
-    private $xposition;
+    private $xPosition;
 
     /**
      * Specify the vertical position of the captions, relative to the top of the output in pixels. A value of 10 would
@@ -321,7 +321,7 @@ final class DvbSubDestinationSettings
      *
      * @var int|null
      */
-    private $yposition;
+    private $yPosition;
 
     /**
      * @param array{
@@ -365,8 +365,8 @@ final class DvbSubDestinationSettings
         $this->backgroundColor = $input['BackgroundColor'] ?? null;
         $this->backgroundOpacity = $input['BackgroundOpacity'] ?? null;
         $this->ddsHandling = $input['DdsHandling'] ?? null;
-        $this->ddsXcoordinate = $input['DdsXCoordinate'] ?? null;
-        $this->ddsYcoordinate = $input['DdsYCoordinate'] ?? null;
+        $this->ddsXCoordinate = $input['DdsXCoordinate'] ?? null;
+        $this->ddsYCoordinate = $input['DdsYCoordinate'] ?? null;
         $this->fallbackFont = $input['FallbackFont'] ?? null;
         $this->fontColor = $input['FontColor'] ?? null;
         $this->fontFileBold = $input['FontFileBold'] ?? null;
@@ -383,14 +383,14 @@ final class DvbSubDestinationSettings
         $this->outlineSize = $input['OutlineSize'] ?? null;
         $this->shadowColor = $input['ShadowColor'] ?? null;
         $this->shadowOpacity = $input['ShadowOpacity'] ?? null;
-        $this->shadowXoffset = $input['ShadowXOffset'] ?? null;
-        $this->shadowYoffset = $input['ShadowYOffset'] ?? null;
+        $this->shadowXOffset = $input['ShadowXOffset'] ?? null;
+        $this->shadowYOffset = $input['ShadowYOffset'] ?? null;
         $this->stylePassthrough = $input['StylePassthrough'] ?? null;
         $this->subtitlingType = $input['SubtitlingType'] ?? null;
         $this->teletextSpacing = $input['TeletextSpacing'] ?? null;
         $this->width = $input['Width'] ?? null;
-        $this->xposition = $input['XPosition'] ?? null;
-        $this->yposition = $input['YPosition'] ?? null;
+        $this->xPosition = $input['XPosition'] ?? null;
+        $this->yPosition = $input['YPosition'] ?? null;
     }
 
     /**
@@ -470,14 +470,14 @@ final class DvbSubDestinationSettings
         return $this->ddsHandling;
     }
 
-    public function getDdsXcoordinate(): ?int
+    public function getDdsXCoordinate(): ?int
     {
-        return $this->ddsXcoordinate;
+        return $this->ddsXCoordinate;
     }
 
-    public function getDdsYcoordinate(): ?int
+    public function getDdsYCoordinate(): ?int
     {
-        return $this->ddsYcoordinate;
+        return $this->ddsYCoordinate;
     }
 
     /**
@@ -575,14 +575,14 @@ final class DvbSubDestinationSettings
         return $this->shadowOpacity;
     }
 
-    public function getShadowXoffset(): ?int
+    public function getShadowXOffset(): ?int
     {
-        return $this->shadowXoffset;
+        return $this->shadowXOffset;
     }
 
-    public function getShadowYoffset(): ?int
+    public function getShadowYOffset(): ?int
     {
-        return $this->shadowYoffset;
+        return $this->shadowYOffset;
     }
 
     /**
@@ -614,14 +614,14 @@ final class DvbSubDestinationSettings
         return $this->width;
     }
 
-    public function getXposition(): ?int
+    public function getXPosition(): ?int
     {
-        return $this->xposition;
+        return $this->xPosition;
     }
 
-    public function getYposition(): ?int
+    public function getYPosition(): ?int
     {
-        return $this->yposition;
+        return $this->yPosition;
     }
 
     /**
@@ -657,10 +657,10 @@ final class DvbSubDestinationSettings
             }
             $payload['ddsHandling'] = $v;
         }
-        if (null !== $v = $this->ddsXcoordinate) {
+        if (null !== $v = $this->ddsXCoordinate) {
             $payload['ddsXCoordinate'] = $v;
         }
-        if (null !== $v = $this->ddsYcoordinate) {
+        if (null !== $v = $this->ddsYCoordinate) {
             $payload['ddsYCoordinate'] = $v;
         }
         if (null !== $v = $this->fallbackFont) {
@@ -726,10 +726,10 @@ final class DvbSubDestinationSettings
         if (null !== $v = $this->shadowOpacity) {
             $payload['shadowOpacity'] = $v;
         }
-        if (null !== $v = $this->shadowXoffset) {
+        if (null !== $v = $this->shadowXOffset) {
             $payload['shadowXOffset'] = $v;
         }
-        if (null !== $v = $this->shadowYoffset) {
+        if (null !== $v = $this->shadowYOffset) {
             $payload['shadowYOffset'] = $v;
         }
         if (null !== $v = $this->stylePassthrough) {
@@ -753,10 +753,10 @@ final class DvbSubDestinationSettings
         if (null !== $v = $this->width) {
             $payload['width'] = $v;
         }
-        if (null !== $v = $this->xposition) {
+        if (null !== $v = $this->xPosition) {
             $payload['xPosition'] = $v;
         }
-        if (null !== $v = $this->yposition) {
+        if (null !== $v = $this->yPosition) {
             $payload['yPosition'] = $v;
         }
 

--- a/src/Service/MediaConvert/src/ValueObject/H264Settings.php
+++ b/src/Service/MediaConvert/src/ValueObject/H264Settings.php
@@ -190,7 +190,7 @@ final class H264Settings
      *
      * @var H264GopBReference::*|null
      */
-    private $gopBreference;
+    private $gopBReference;
 
     /**
      * Specify the relative frequency of open to closed GOPs in this output. For example, if you want to allow four open
@@ -284,7 +284,7 @@ final class H264Settings
      *
      * @var int|null
      */
-    private $minIinterval;
+    private $minIInterval;
 
     /**
      * Specify the number of B-frames between reference frames in this output. For the best video quality: Leave blank.
@@ -293,7 +293,7 @@ final class H264Settings
      *
      * @var int|null
      */
-    private $numberBframesBetweenReferenceFrames;
+    private $numberBFramesBetweenReferenceFrames;
 
     /**
      * Number of reference frames to use. The encoder may use more than requested if using B-frames and/or interlaced
@@ -594,7 +594,7 @@ final class H264Settings
         $this->framerateConversionAlgorithm = $input['FramerateConversionAlgorithm'] ?? null;
         $this->framerateDenominator = $input['FramerateDenominator'] ?? null;
         $this->framerateNumerator = $input['FramerateNumerator'] ?? null;
-        $this->gopBreference = $input['GopBReference'] ?? null;
+        $this->gopBReference = $input['GopBReference'] ?? null;
         $this->gopClosedCadence = $input['GopClosedCadence'] ?? null;
         $this->gopSize = $input['GopSize'] ?? null;
         $this->gopSizeUnits = $input['GopSizeUnits'] ?? null;
@@ -603,8 +603,8 @@ final class H264Settings
         $this->hrdBufferSize = $input['HrdBufferSize'] ?? null;
         $this->interlaceMode = $input['InterlaceMode'] ?? null;
         $this->maxBitrate = $input['MaxBitrate'] ?? null;
-        $this->minIinterval = $input['MinIInterval'] ?? null;
-        $this->numberBframesBetweenReferenceFrames = $input['NumberBFramesBetweenReferenceFrames'] ?? null;
+        $this->minIInterval = $input['MinIInterval'] ?? null;
+        $this->numberBFramesBetweenReferenceFrames = $input['NumberBFramesBetweenReferenceFrames'] ?? null;
         $this->numberReferenceFrames = $input['NumberReferenceFrames'] ?? null;
         $this->parControl = $input['ParControl'] ?? null;
         $this->parDenominator = $input['ParDenominator'] ?? null;
@@ -786,9 +786,9 @@ final class H264Settings
     /**
      * @return H264GopBReference::*|null
      */
-    public function getGopBreference(): ?string
+    public function getGopBReference(): ?string
     {
-        return $this->gopBreference;
+        return $this->gopBReference;
     }
 
     public function getGopClosedCadence(): ?int
@@ -837,14 +837,14 @@ final class H264Settings
         return $this->maxBitrate;
     }
 
-    public function getMinIinterval(): ?int
+    public function getMinIInterval(): ?int
     {
-        return $this->minIinterval;
+        return $this->minIInterval;
     }
 
-    public function getNumberBframesBetweenReferenceFrames(): ?int
+    public function getNumberBFramesBetweenReferenceFrames(): ?int
     {
-        return $this->numberBframesBetweenReferenceFrames;
+        return $this->numberBFramesBetweenReferenceFrames;
     }
 
     public function getNumberReferenceFrames(): ?int
@@ -1075,7 +1075,7 @@ final class H264Settings
         if (null !== $v = $this->framerateNumerator) {
             $payload['framerateNumerator'] = $v;
         }
-        if (null !== $v = $this->gopBreference) {
+        if (null !== $v = $this->gopBReference) {
             if (!H264GopBReference::exists($v)) {
                 throw new InvalidArgument(\sprintf('Invalid parameter "gopBReference" for "%s". The value "%s" is not a valid "H264GopBReference".', __CLASS__, $v));
             }
@@ -1111,10 +1111,10 @@ final class H264Settings
         if (null !== $v = $this->maxBitrate) {
             $payload['maxBitrate'] = $v;
         }
-        if (null !== $v = $this->minIinterval) {
+        if (null !== $v = $this->minIInterval) {
             $payload['minIInterval'] = $v;
         }
-        if (null !== $v = $this->numberBframesBetweenReferenceFrames) {
+        if (null !== $v = $this->numberBFramesBetweenReferenceFrames) {
             $payload['numberBFramesBetweenReferenceFrames'] = $v;
         }
         if (null !== $v = $this->numberReferenceFrames) {

--- a/src/Service/MediaConvert/src/ValueObject/H265Settings.php
+++ b/src/Service/MediaConvert/src/ValueObject/H265Settings.php
@@ -190,7 +190,7 @@ final class H265Settings
      *
      * @var H265GopBReference::*|null
      */
-    private $gopBreference;
+    private $gopBReference;
 
     /**
      * Specify the relative frequency of open to closed GOPs in this output. For example, if you want to allow four open
@@ -285,7 +285,7 @@ final class H265Settings
      *
      * @var int|null
      */
-    private $minIinterval;
+    private $minIInterval;
 
     /**
      * If you are setting up the picture as a tile, you must set this to "disabled". In all other configurations, you
@@ -310,7 +310,7 @@ final class H265Settings
      *
      * @var int|null
      */
-    private $numberBframesBetweenReferenceFrames;
+    private $numberBFramesBetweenReferenceFrames;
 
     /**
      * Number of reference frames to use. The encoder may use more than requested if using B-frames and/or interlaced
@@ -626,7 +626,7 @@ final class H265Settings
         $this->framerateConversionAlgorithm = $input['FramerateConversionAlgorithm'] ?? null;
         $this->framerateDenominator = $input['FramerateDenominator'] ?? null;
         $this->framerateNumerator = $input['FramerateNumerator'] ?? null;
-        $this->gopBreference = $input['GopBReference'] ?? null;
+        $this->gopBReference = $input['GopBReference'] ?? null;
         $this->gopClosedCadence = $input['GopClosedCadence'] ?? null;
         $this->gopSize = $input['GopSize'] ?? null;
         $this->gopSizeUnits = $input['GopSizeUnits'] ?? null;
@@ -635,10 +635,10 @@ final class H265Settings
         $this->hrdBufferSize = $input['HrdBufferSize'] ?? null;
         $this->interlaceMode = $input['InterlaceMode'] ?? null;
         $this->maxBitrate = $input['MaxBitrate'] ?? null;
-        $this->minIinterval = $input['MinIInterval'] ?? null;
+        $this->minIInterval = $input['MinIInterval'] ?? null;
         $this->mvOverPictureBoundaries = $input['MvOverPictureBoundaries'] ?? null;
         $this->mvTemporalPredictor = $input['MvTemporalPredictor'] ?? null;
-        $this->numberBframesBetweenReferenceFrames = $input['NumberBFramesBetweenReferenceFrames'] ?? null;
+        $this->numberBFramesBetweenReferenceFrames = $input['NumberBFramesBetweenReferenceFrames'] ?? null;
         $this->numberReferenceFrames = $input['NumberReferenceFrames'] ?? null;
         $this->parControl = $input['ParControl'] ?? null;
         $this->parDenominator = $input['ParDenominator'] ?? null;
@@ -828,9 +828,9 @@ final class H265Settings
     /**
      * @return H265GopBReference::*|null
      */
-    public function getGopBreference(): ?string
+    public function getGopBReference(): ?string
     {
-        return $this->gopBreference;
+        return $this->gopBReference;
     }
 
     public function getGopClosedCadence(): ?int
@@ -879,9 +879,9 @@ final class H265Settings
         return $this->maxBitrate;
     }
 
-    public function getMinIinterval(): ?int
+    public function getMinIInterval(): ?int
     {
-        return $this->minIinterval;
+        return $this->minIInterval;
     }
 
     /**
@@ -900,9 +900,9 @@ final class H265Settings
         return $this->mvTemporalPredictor;
     }
 
-    public function getNumberBframesBetweenReferenceFrames(): ?int
+    public function getNumberBFramesBetweenReferenceFrames(): ?int
     {
-        return $this->numberBframesBetweenReferenceFrames;
+        return $this->numberBFramesBetweenReferenceFrames;
     }
 
     public function getNumberReferenceFrames(): ?int
@@ -1154,7 +1154,7 @@ final class H265Settings
         if (null !== $v = $this->framerateNumerator) {
             $payload['framerateNumerator'] = $v;
         }
-        if (null !== $v = $this->gopBreference) {
+        if (null !== $v = $this->gopBReference) {
             if (!H265GopBReference::exists($v)) {
                 throw new InvalidArgument(\sprintf('Invalid parameter "gopBReference" for "%s". The value "%s" is not a valid "H265GopBReference".', __CLASS__, $v));
             }
@@ -1190,7 +1190,7 @@ final class H265Settings
         if (null !== $v = $this->maxBitrate) {
             $payload['maxBitrate'] = $v;
         }
-        if (null !== $v = $this->minIinterval) {
+        if (null !== $v = $this->minIInterval) {
             $payload['minIInterval'] = $v;
         }
         if (null !== $v = $this->mvOverPictureBoundaries) {
@@ -1205,7 +1205,7 @@ final class H265Settings
             }
             $payload['mvTemporalPredictor'] = $v;
         }
-        if (null !== $v = $this->numberBframesBetweenReferenceFrames) {
+        if (null !== $v = $this->numberBFramesBetweenReferenceFrames) {
             $payload['numberBFramesBetweenReferenceFrames'] = $v;
         }
         if (null !== $v = $this->numberReferenceFrames) {

--- a/src/Service/MediaConvert/src/ValueObject/HlsSettings.php
+++ b/src/Service/MediaConvert/src/ValueObject/HlsSettings.php
@@ -70,7 +70,7 @@ final class HlsSettings
      *
      * @var HlsIFrameOnlyManifest::*|null
      */
-    private $iframeOnlyManifest;
+    private $iFrameOnlyManifest;
 
     /**
      * Use this setting to add an identifying string to the filename of each segment. The service adds this string between
@@ -99,7 +99,7 @@ final class HlsSettings
         $this->audioRenditionSets = $input['AudioRenditionSets'] ?? null;
         $this->audioTrackType = $input['AudioTrackType'] ?? null;
         $this->descriptiveVideoServiceFlag = $input['DescriptiveVideoServiceFlag'] ?? null;
-        $this->iframeOnlyManifest = $input['IFrameOnlyManifest'] ?? null;
+        $this->iFrameOnlyManifest = $input['IFrameOnlyManifest'] ?? null;
         $this->segmentModifier = $input['SegmentModifier'] ?? null;
     }
 
@@ -156,9 +156,9 @@ final class HlsSettings
     /**
      * @return HlsIFrameOnlyManifest::*|null
      */
-    public function getIframeOnlyManifest(): ?string
+    public function getIFrameOnlyManifest(): ?string
     {
-        return $this->iframeOnlyManifest;
+        return $this->iFrameOnlyManifest;
     }
 
     public function getSegmentModifier(): ?string
@@ -196,7 +196,7 @@ final class HlsSettings
             }
             $payload['descriptiveVideoServiceFlag'] = $v;
         }
-        if (null !== $v = $this->iframeOnlyManifest) {
+        if (null !== $v = $this->iFrameOnlyManifest) {
             if (!HlsIFrameOnlyManifest::exists($v)) {
                 throw new InvalidArgument(\sprintf('Invalid parameter "iFrameOnlyManifest" for "%s". The value "%s" is not a valid "HlsIFrameOnlyManifest".', __CLASS__, $v));
             }

--- a/src/Service/MediaConvert/src/ValueObject/Mpeg2Settings.php
+++ b/src/Service/MediaConvert/src/ValueObject/Mpeg2Settings.php
@@ -207,7 +207,7 @@ final class Mpeg2Settings
      *
      * @var int|null
      */
-    private $minIinterval;
+    private $minIInterval;
 
     /**
      * Specify the number of B-frames that MediaConvert puts between reference frames in this output. Valid values are whole
@@ -215,7 +215,7 @@ final class Mpeg2Settings
      *
      * @var int|null
      */
-    private $numberBframesBetweenReferenceFrames;
+    private $numberBFramesBetweenReferenceFrames;
 
     /**
      * Optional. Specify how the service determines the pixel aspect ratio (PAR) for this output. The default behavior,
@@ -431,8 +431,8 @@ final class Mpeg2Settings
         $this->interlaceMode = $input['InterlaceMode'] ?? null;
         $this->intraDcPrecision = $input['IntraDcPrecision'] ?? null;
         $this->maxBitrate = $input['MaxBitrate'] ?? null;
-        $this->minIinterval = $input['MinIInterval'] ?? null;
-        $this->numberBframesBetweenReferenceFrames = $input['NumberBFramesBetweenReferenceFrames'] ?? null;
+        $this->minIInterval = $input['MinIInterval'] ?? null;
+        $this->numberBFramesBetweenReferenceFrames = $input['NumberBFramesBetweenReferenceFrames'] ?? null;
         $this->parControl = $input['ParControl'] ?? null;
         $this->parDenominator = $input['ParDenominator'] ?? null;
         $this->parNumerator = $input['ParNumerator'] ?? null;
@@ -609,14 +609,14 @@ final class Mpeg2Settings
         return $this->maxBitrate;
     }
 
-    public function getMinIinterval(): ?int
+    public function getMinIInterval(): ?int
     {
-        return $this->minIinterval;
+        return $this->minIInterval;
     }
 
-    public function getNumberBframesBetweenReferenceFrames(): ?int
+    public function getNumberBFramesBetweenReferenceFrames(): ?int
     {
-        return $this->numberBframesBetweenReferenceFrames;
+        return $this->numberBFramesBetweenReferenceFrames;
     }
 
     /**
@@ -809,10 +809,10 @@ final class Mpeg2Settings
         if (null !== $v = $this->maxBitrate) {
             $payload['maxBitrate'] = $v;
         }
-        if (null !== $v = $this->minIinterval) {
+        if (null !== $v = $this->minIInterval) {
             $payload['minIInterval'] = $v;
         }
-        if (null !== $v = $this->numberBframesBetweenReferenceFrames) {
+        if (null !== $v = $this->numberBFramesBetweenReferenceFrames) {
             $payload['numberBFramesBetweenReferenceFrames'] = $v;
         }
         if (null !== $v = $this->parControl) {

--- a/src/Service/MediaConvert/src/ValueObject/VideoOverlayPosition.php
+++ b/src/Service/MediaConvert/src/ValueObject/VideoOverlayPosition.php
@@ -60,7 +60,7 @@ final class VideoOverlayPosition
      *
      * @var int|null
      */
-    private $xposition;
+    private $xPosition;
 
     /**
      * To position the top edge of your video overlay along the top edge of the base input video's frame: Keep blank, or
@@ -72,7 +72,7 @@ final class VideoOverlayPosition
      *
      * @var int|null
      */
-    private $yposition;
+    private $yPosition;
 
     /**
      * @param array{
@@ -90,8 +90,8 @@ final class VideoOverlayPosition
         $this->opacity = $input['Opacity'] ?? null;
         $this->unit = $input['Unit'] ?? null;
         $this->width = $input['Width'] ?? null;
-        $this->xposition = $input['XPosition'] ?? null;
-        $this->yposition = $input['YPosition'] ?? null;
+        $this->xPosition = $input['XPosition'] ?? null;
+        $this->yPosition = $input['YPosition'] ?? null;
     }
 
     /**
@@ -132,14 +132,14 @@ final class VideoOverlayPosition
         return $this->width;
     }
 
-    public function getXposition(): ?int
+    public function getXPosition(): ?int
     {
-        return $this->xposition;
+        return $this->xPosition;
     }
 
-    public function getYposition(): ?int
+    public function getYPosition(): ?int
     {
-        return $this->yposition;
+        return $this->yPosition;
     }
 
     /**
@@ -163,10 +163,10 @@ final class VideoOverlayPosition
         if (null !== $v = $this->width) {
             $payload['width'] = $v;
         }
-        if (null !== $v = $this->xposition) {
+        if (null !== $v = $this->xPosition) {
             $payload['xPosition'] = $v;
         }
-        if (null !== $v = $this->yposition) {
+        if (null !== $v = $this->yPosition) {
             $payload['yPosition'] = $v;
         }
 

--- a/src/Service/MediaConvert/src/ValueObject/Xavc4kProfileSettings.php
+++ b/src/Service/MediaConvert/src/ValueObject/Xavc4kProfileSettings.php
@@ -52,7 +52,7 @@ final class Xavc4kProfileSettings
      *
      * @var XavcGopBReference::*|null
      */
-    private $gopBreference;
+    private $gopBReference;
 
     /**
      * Frequency of closed GOPs. In streaming applications, it is recommended that this be set to 1 so a decoder joining
@@ -104,7 +104,7 @@ final class Xavc4kProfileSettings
         $this->bitrateClass = $input['BitrateClass'] ?? null;
         $this->codecProfile = $input['CodecProfile'] ?? null;
         $this->flickerAdaptiveQuantization = $input['FlickerAdaptiveQuantization'] ?? null;
-        $this->gopBreference = $input['GopBReference'] ?? null;
+        $this->gopBReference = $input['GopBReference'] ?? null;
         $this->gopClosedCadence = $input['GopClosedCadence'] ?? null;
         $this->hrdBufferSize = $input['HrdBufferSize'] ?? null;
         $this->qualityTuningLevel = $input['QualityTuningLevel'] ?? null;
@@ -155,9 +155,9 @@ final class Xavc4kProfileSettings
     /**
      * @return XavcGopBReference::*|null
      */
-    public function getGopBreference(): ?string
+    public function getGopBReference(): ?string
     {
-        return $this->gopBreference;
+        return $this->gopBReference;
     }
 
     public function getGopClosedCadence(): ?int
@@ -207,7 +207,7 @@ final class Xavc4kProfileSettings
             }
             $payload['flickerAdaptiveQuantization'] = $v;
         }
-        if (null !== $v = $this->gopBreference) {
+        if (null !== $v = $this->gopBReference) {
             if (!XavcGopBReference::exists($v)) {
                 throw new InvalidArgument(\sprintf('Invalid parameter "gopBReference" for "%s". The value "%s" is not a valid "XavcGopBReference".', __CLASS__, $v));
             }

--- a/src/Service/MediaConvert/src/ValueObject/XavcHdProfileSettings.php
+++ b/src/Service/MediaConvert/src/ValueObject/XavcHdProfileSettings.php
@@ -45,7 +45,7 @@ final class XavcHdProfileSettings
      *
      * @var XavcGopBReference::*|null
      */
-    private $gopBreference;
+    private $gopBReference;
 
     /**
      * Frequency of closed GOPs. In streaming applications, it is recommended that this be set to 1 so a decoder joining
@@ -119,7 +119,7 @@ final class XavcHdProfileSettings
     {
         $this->bitrateClass = $input['BitrateClass'] ?? null;
         $this->flickerAdaptiveQuantization = $input['FlickerAdaptiveQuantization'] ?? null;
-        $this->gopBreference = $input['GopBReference'] ?? null;
+        $this->gopBReference = $input['GopBReference'] ?? null;
         $this->gopClosedCadence = $input['GopClosedCadence'] ?? null;
         $this->hrdBufferSize = $input['HrdBufferSize'] ?? null;
         $this->interlaceMode = $input['InterlaceMode'] ?? null;
@@ -165,9 +165,9 @@ final class XavcHdProfileSettings
     /**
      * @return XavcGopBReference::*|null
      */
-    public function getGopBreference(): ?string
+    public function getGopBReference(): ?string
     {
-        return $this->gopBreference;
+        return $this->gopBReference;
     }
 
     public function getGopClosedCadence(): ?int
@@ -227,7 +227,7 @@ final class XavcHdProfileSettings
             }
             $payload['flickerAdaptiveQuantization'] = $v;
         }
-        if (null !== $v = $this->gopBreference) {
+        if (null !== $v = $this->gopBReference) {
             if (!XavcGopBReference::exists($v)) {
                 throw new InvalidArgument(\sprintf('Invalid parameter "gopBReference" for "%s". The value "%s" is not a valid "XavcGopBReference".', __CLASS__, $v));
             }


### PR DESCRIPTION
From AWS spec's properties we tried to normalize these name to camelCase.

For some cases, (when the name contains multiple consecutive UpperCases) where the generator is not able to generate the CamelCase value by itself, we maintain a list of (opinionated) exceptions telling that we shoiuld use the form "first char upper, rest lower". ie `ETag` become `Etag`.

We also maintain a list of "ignored" cases where multiple consecutive Upper cases are fine.
ie `XOffset` stays `XOffset`.

The issue, is: By mistake, we also convert the second list to the form "first char upper, rest lower".

This PR fix that.

This might not be a BC break, because PHP is not strict about case on methods.. But I wonder if it worth it...