### PR TITLE
Fallback to another protocol when the primary protocol is not supported

### DIFF
--- a/src/CodeGenerator/src/Definition/ServiceDefinition.php
+++ b/src/CodeGenerator/src/Definition/ServiceDefinition.php
@@ -15,6 +15,8 @@ use AsyncAws\CodeGenerator\Generator\GeneratorHelper;
  */
 class ServiceDefinition
 {
+    private const SUPPORTED_PROTOCOLS = ['json', 'rest-json', 'query', 'rest-xml'];
+
     /**
      * @var string
      */
@@ -150,7 +152,19 @@ class ServiceDefinition
 
     public function getProtocol(): string
     {
-        return $this->definition['metadata']['protocol'];
+        $protocol = $this->definition['metadata']['protocol'];
+        if (\in_array($protocol, self::SUPPORTED_PROTOCOLS, true)) {
+            return $protocol;
+        }
+
+        $protocols = $this->definition['metadata']['protocols'] ?? [];
+        foreach (self::SUPPORTED_PROTOCOLS as $supportedProtocol) {
+            if (\in_array($supportedProtocol, $protocols, true)) {
+                return $supportedProtocol;
+            }
+        }
+
+        return $protocol;
     }
 
     public function getApiReferenceUrl(): string


### PR DESCRIPTION
Since AWS change the protocol for the CloudWatch service from JSON to `smithy-rpc-v2-cbor`

The service generation fails https://github.com/async-aws/aws/actions/runs/20124360417/job/57750836251

This PR adds logic to fallbacks to another protocol when the primary one is not supported by the generator