### PR TITLE
Detect unsupported union shapes in the code generator

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -473,7 +473,19 @@
                 "CommitTransaction",
                 "ExecuteStatement",
                 "RollbackTransaction"
-            ]
+            ],
+            "patches": {
+                "source": [
+                    {
+                        "op": "remove",
+                        "path": "/shapes/ArrayValue/union"
+                    },
+                    {
+                        "op": "remove",
+                        "path": "/shapes/Field/union"
+                    }
+                ]
+            }
         },
         "Rekognition": {
             "source": "https://raw.githubusercontent.com/aws/aws-sdk-php/${LATEST}/src/data/rekognition/2016-06-27/api-2.json",

--- a/src/CodeGenerator/src/Definition/Shape.php
+++ b/src/CodeGenerator/src/Definition/Shape.php
@@ -45,6 +45,8 @@ class Shape
                     $shape = new ExceptionShape();
                 } elseif ($data['document'] ?? false) {
                     $shape = new DocumentShape();
+                } elseif ($data['union'] ?? false) {
+                    throw new \UnexpectedValueException(\sprintf('Union shapes are not supported yet by the code generator. The shape "%s" is a union shape.', $name));
                 } else {
                     $shape = new StructureShape();
                 }


### PR DESCRIPTION
Union shapes _could_ be generated as normal structure shapes (some SDKs do that) but the discussion in #1900 goes in the direction of generating them using a dedicated type-safe API instead.
To avoid BC concerns once this is implemented, I'm adding a safeguard to make the code generator fail when encountering a union shape instead of treating it like a normal structure shape, in case someone adds an operation relying on union shapes.