### PR TITLE
Use a more stable sorting for the region metadata

### DIFF
--- a/src/CodeGenerator/src/Generator/ClientGenerator.php
+++ b/src/CodeGenerator/src/Generator/ClientGenerator.php
@@ -218,13 +218,11 @@ class ClientGenerator
                     false !== strpos($a['regions'][0], 'iso'),
                     false !== strpos($a['regions'][0], 'fips'),
                     false !== strpos($a['regions'][0], 'gov'),
-                    \count($b['regions']),
                     $a['regions'][0],
                 ] <=> [
                     false !== strpos($b['regions'][0], 'iso'),
                     false !== strpos($b['regions'][0], 'fips'),
                     false !== strpos($b['regions'][0], 'gov'),
-                    \count($a['regions']),
                     $b['regions'][0],
                 ];
             });

--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -19,6 +19,7 @@
 - Fix PHP 8.5 deprecation by avoiding using `null` as an array offset.
 - Harden code against error cases
 - AWS enhancement: Documentation updates.
+- Use a more stable sorting for the list of generated region metadata
 
 ### Fixed
 

--- a/src/Core/src/Sts/StsClient.php
+++ b/src/Core/src/Sts/StsClient.php
@@ -396,6 +396,13 @@ class StsClient extends AbstractApi
                     'signService' => 'sts',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://sts.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'sts',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -417,13 +424,6 @@ class StsClient extends AbstractApi
                 return [
                     'endpoint' => "https://sts.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'sts',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://sts.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'sts',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/Athena/CHANGELOG.md
+++ b/src/Service/Athena/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 3.4.0
 

--- a/src/Service/Athena/src/AthenaClient.php
+++ b/src/Service/Athena/src/AthenaClient.php
@@ -782,14 +782,6 @@ class AthenaClient extends AbstractApi
                     'signService' => 'athena',
                     'signVersions' => ['v4'],
                 ];
-            case 'us-isof-east-1':
-            case 'us-isof-south-1':
-                return [
-                    'endpoint' => "https://athena.$region.csp.hci.ic.gov",
-                    'signRegion' => $region,
-                    'signService' => 'athena',
-                    'signVersions' => ['v4'],
-                ];
             case 'eu-isoe-west-1':
                 return [
                     'endpoint' => 'https://athena.eu-isoe-west-1.cloud.adc-e.uk',
@@ -808,6 +800,14 @@ class AthenaClient extends AbstractApi
                 return [
                     'endpoint' => 'https://athena.us-isob-east-1.sc2s.sgov.gov',
                     'signRegion' => 'us-isob-east-1',
+                    'signService' => 'athena',
+                    'signVersions' => ['v4'],
+                ];
+            case 'us-isof-east-1':
+            case 'us-isof-south-1':
+                return [
+                    'endpoint' => "https://athena.$region.csp.hci.ic.gov",
+                    'signRegion' => $region,
                     'signService' => 'athena',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/CloudFormation/CHANGELOG.md
+++ b/src/Service/CloudFormation/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 - AWS enhancement: Documentation updates.
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 1.10.0
 

--- a/src/Service/CloudFormation/src/CloudFormationClient.php
+++ b/src/Service/CloudFormation/src/CloudFormationClient.php
@@ -168,6 +168,13 @@ class CloudFormationClient extends AbstractApi
                     'signService' => 'cloudformation',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://cloudformation.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'cloudformation',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -189,13 +196,6 @@ class CloudFormationClient extends AbstractApi
                 return [
                     'endpoint' => "https://cloudformation.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'cloudformation',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://cloudformation.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'cloudformation',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/CloudWatch/CHANGELOG.md
+++ b/src/Service/CloudWatch/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 1.3.1
 

--- a/src/Service/CloudWatch/src/CloudWatchClient.php
+++ b/src/Service/CloudWatch/src/CloudWatchClient.php
@@ -381,6 +381,13 @@ class CloudWatchClient extends AbstractApi
                     'signService' => 'monitoring',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://monitoring.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'monitoring',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -402,13 +409,6 @@ class CloudWatchClient extends AbstractApi
                 return [
                     'endpoint' => "https://monitoring.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'monitoring',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://monitoring.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'monitoring',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/CloudWatchLogs/CHANGELOG.md
+++ b/src/Service/CloudWatchLogs/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - AWS enhancement: Documentation updates.
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 2.7.1
 

--- a/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
+++ b/src/Service/CloudWatchLogs/src/CloudWatchLogsClient.php
@@ -441,6 +441,13 @@ class CloudWatchLogsClient extends AbstractApi
                     'signService' => 'logs',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://logs.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'logs',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -462,13 +469,6 @@ class CloudWatchLogsClient extends AbstractApi
                 return [
                     'endpoint' => "https://logs.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'logs',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://logs.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'logs',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/CodeBuild/CHANGELOG.md
+++ b/src/Service/CodeBuild/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 2.11.1
 

--- a/src/Service/CodeBuild/src/CodeBuildClient.php
+++ b/src/Service/CodeBuild/src/CodeBuildClient.php
@@ -216,18 +216,18 @@ class CodeBuildClient extends AbstractApi
                     'signService' => 'codebuild',
                     'signVersions' => ['v4'],
                 ];
+            case 'us-isob-east-1':
+                return [
+                    'endpoint' => 'https://codebuild.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
+                    'signService' => 'codebuild',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-isof-east-1':
             case 'us-isof-south-1':
                 return [
                     'endpoint' => "https://codebuild.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'codebuild',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-isob-east-1':
-                return [
-                    'endpoint' => 'https://codebuild.us-isob-east-1.sc2s.sgov.gov',
-                    'signRegion' => 'us-isob-east-1',
                     'signService' => 'codebuild',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/CodeCommit/CHANGELOG.md
+++ b/src/Service/CodeCommit/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 1.2.2
 

--- a/src/Service/CodeCommit/src/CodeCommitClient.php
+++ b/src/Service/CodeCommit/src/CodeCommitClient.php
@@ -482,18 +482,18 @@ class CodeCommitClient extends AbstractApi
                     'signService' => 'codecommit',
                     'signVersions' => ['v4'],
                 ];
+            case 'ca-central-1-fips':
+                return [
+                    'endpoint' => 'https://codecommit-fips.ca-central-1.amazonaws.com',
+                    'signRegion' => 'ca-central-1',
+                    'signService' => 'codecommit',
+                    'signVersions' => ['v4'],
+                ];
             case 'fips':
             case 'us-gov-west-1-fips':
                 return [
                     'endpoint' => 'https://codecommit-fips.us-gov-west-1.amazonaws.com',
                     'signRegion' => 'us-gov-west-1',
-                    'signService' => 'codecommit',
-                    'signVersions' => ['v4'],
-                ];
-            case 'ca-central-1-fips':
-                return [
-                    'endpoint' => 'https://codecommit-fips.ca-central-1.amazonaws.com',
-                    'signRegion' => 'ca-central-1',
                     'signService' => 'codecommit',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/CodeDeploy/CHANGELOG.md
+++ b/src/Service/CodeDeploy/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 2.3.0
 

--- a/src/Service/CodeDeploy/src/CodeDeployClient.php
+++ b/src/Service/CodeDeploy/src/CodeDeployClient.php
@@ -283,6 +283,13 @@ class CodeDeployClient extends AbstractApi
                     'signService' => 'codedeploy',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://codedeploy.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'codedeploy',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -304,13 +311,6 @@ class CodeDeployClient extends AbstractApi
                 return [
                     'endpoint' => "https://codedeploy.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'codedeploy',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://codedeploy.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'codedeploy',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/Comprehend/CHANGELOG.md
+++ b/src/Service/Comprehend/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 1.4.0
 

--- a/src/Service/Comprehend/src/ComprehendClient.php
+++ b/src/Service/Comprehend/src/ComprehendClient.php
@@ -112,18 +112,18 @@ class ComprehendClient extends AbstractApi
                     'signService' => 'comprehend',
                     'signVersions' => ['v4'],
                 ];
+            case 'us-iso-east-1':
+                return [
+                    'endpoint' => 'https://comprehend.us-iso-east-1.c2s.ic.gov',
+                    'signRegion' => 'us-iso-east-1',
+                    'signService' => 'comprehend',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-isof-east-1':
             case 'us-isof-south-1':
                 return [
                     'endpoint' => "https://comprehend.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'comprehend',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-iso-east-1':
-                return [
-                    'endpoint' => 'https://comprehend.us-iso-east-1.c2s.ic.gov',
-                    'signRegion' => 'us-iso-east-1',
                     'signService' => 'comprehend',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/DynamoDb/CHANGELOG.md
+++ b/src/Service/DynamoDb/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 - Apply new CodingStandard from latest php-cs-fixer.
 - AWS enhancement: Documentation updates.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 3.8.0
 

--- a/src/Service/DynamoDb/src/DynamoDbClient.php
+++ b/src/Service/DynamoDb/src/DynamoDbClient.php
@@ -1201,6 +1201,13 @@ class DynamoDbClient extends AbstractApi
                     'signService' => 'dynamodb',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://dynamodb.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'dynamodb',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -1222,13 +1229,6 @@ class DynamoDbClient extends AbstractApi
                 return [
                     'endpoint' => "https://dynamodb.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'dynamodb',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://dynamodb.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'dynamodb',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/Ecr/CHANGELOG.md
+++ b/src/Service/Ecr/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 1.11.0
 

--- a/src/Service/Ecr/src/EcrClient.php
+++ b/src/Service/Ecr/src/EcrClient.php
@@ -164,6 +164,13 @@ class EcrClient extends AbstractApi
                     'signService' => 'ecr',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://api.ecr.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'ecr',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -185,13 +192,6 @@ class EcrClient extends AbstractApi
                 return [
                     'endpoint' => "https://api.ecr.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'ecr',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://api.ecr.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'ecr',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/ElastiCache/CHANGELOG.md
+++ b/src/Service/ElastiCache/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 1.4.0
 

--- a/src/Service/ElastiCache/src/ElastiCacheClient.php
+++ b/src/Service/ElastiCache/src/ElastiCacheClient.php
@@ -126,6 +126,13 @@ class ElastiCacheClient extends AbstractApi
                     'signService' => 'elasticache',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://elasticache.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'elasticache',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -147,13 +154,6 @@ class ElastiCacheClient extends AbstractApi
                 return [
                     'endpoint' => "https://elasticache.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'elasticache',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://elasticache.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'elasticache',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/EventBridge/CHANGELOG.md
+++ b/src/Service/EventBridge/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 1.9.0
 

--- a/src/Service/EventBridge/src/EventBridgeClient.php
+++ b/src/Service/EventBridge/src/EventBridgeClient.php
@@ -118,6 +118,13 @@ class EventBridgeClient extends AbstractApi
                     'signService' => 'events',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://events.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'events',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -139,13 +146,6 @@ class EventBridgeClient extends AbstractApi
                 return [
                     'endpoint' => "https://events.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'events',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://events.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'events',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/Firehose/CHANGELOG.md
+++ b/src/Service/Firehose/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 1.5.0
 

--- a/src/Service/Firehose/src/FirehoseClient.php
+++ b/src/Service/Firehose/src/FirehoseClient.php
@@ -254,6 +254,13 @@ class FirehoseClient extends AbstractApi
                     'signService' => 'firehose',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://firehose.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'firehose',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -262,25 +269,18 @@ class FirehoseClient extends AbstractApi
                     'signService' => 'firehose',
                     'signVersions' => ['v4'],
                 ];
+            case 'us-isob-east-1':
+                return [
+                    'endpoint' => 'https://firehose.us-isob-east-1.sc2s.sgov.gov',
+                    'signRegion' => 'us-isob-east-1',
+                    'signService' => 'firehose',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-isof-east-1':
             case 'us-isof-south-1':
                 return [
                     'endpoint' => "https://firehose.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'firehose',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://firehose.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
-                    'signService' => 'firehose',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-isob-east-1':
-                return [
-                    'endpoint' => 'https://firehose.us-isob-east-1.sc2s.sgov.gov',
-                    'signRegion' => 'us-isob-east-1',
                     'signService' => 'firehose',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/Iam/CHANGELOG.md
+++ b/src/Service/Iam/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 1.7.0
 

--- a/src/Service/Iam/src/IamClient.php
+++ b/src/Service/Iam/src/IamClient.php
@@ -568,19 +568,19 @@ class IamClient extends AbstractApi
                     'signService' => 'iam',
                     'signVersions' => ['v4'],
                 ];
+            case 'iam-govcloud':
+                return [
+                    'endpoint' => 'https://iam.iam-govcloud.amazonaws.com',
+                    'signRegion' => 'us-gov-west-1',
+                    'signService' => 'iam',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-gov-east-1':
             case 'us-gov-west-1':
             case 'aws-us-gov-global-fips':
             case 'iam-govcloud-fips':
                 return [
                     'endpoint' => 'https://iam.us-gov.amazonaws.com',
-                    'signRegion' => 'us-gov-west-1',
-                    'signService' => 'iam',
-                    'signVersions' => ['v4'],
-                ];
-            case 'iam-govcloud':
-                return [
-                    'endpoint' => 'https://iam.iam-govcloud.amazonaws.com',
                     'signRegion' => 'us-gov-west-1',
                     'signService' => 'iam',
                     'signVersions' => ['v4'],

--- a/src/Service/Kinesis/CHANGELOG.md
+++ b/src/Service/Kinesis/CHANGELOG.md
@@ -17,6 +17,7 @@
 
 - Apply new CodingStandard from latest php-cs-fixer.
 - AWS enhancement: Documentation updates.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 3.3.0
 

--- a/src/Service/Kinesis/src/KinesisClient.php
+++ b/src/Service/Kinesis/src/KinesisClient.php
@@ -1654,6 +1654,13 @@ class KinesisClient extends AbstractApi
                     'signService' => 'kinesis',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://kinesis.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'kinesis',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -1675,13 +1682,6 @@ class KinesisClient extends AbstractApi
                 return [
                     'endpoint' => "https://kinesis.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'kinesis',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://kinesis.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'kinesis',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/Kms/CHANGELOG.md
+++ b/src/Service/Kms/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 - AWS enhancement: Documentation updates.
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 1.10.0
 

--- a/src/Service/Kms/src/KmsClient.php
+++ b/src/Service/Kms/src/KmsClient.php
@@ -1326,6 +1326,13 @@ class KmsClient extends AbstractApi
                     'signService' => 'kms',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://kms.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'kms',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -1347,13 +1354,6 @@ class KmsClient extends AbstractApi
                 return [
                     'endpoint' => "https://kms.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'kms',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://kms.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'kms',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/Lambda/CHANGELOG.md
+++ b/src/Service/Lambda/CHANGELOG.md
@@ -22,6 +22,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 2.12.0
 

--- a/src/Service/Lambda/src/LambdaClient.php
+++ b/src/Service/Lambda/src/LambdaClient.php
@@ -632,6 +632,13 @@ class LambdaClient extends AbstractApi
                     'signService' => 'lambda',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://lambda.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'lambda',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -653,13 +660,6 @@ class LambdaClient extends AbstractApi
                 return [
                     'endpoint' => "https://lambda.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'lambda',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://lambda.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'lambda',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/Route53/CHANGELOG.md
+++ b/src/Service/Route53/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 2.11.0
 

--- a/src/Service/Route53/src/Route53Client.php
+++ b/src/Service/Route53/src/Route53Client.php
@@ -538,6 +538,13 @@ class Route53Client extends AbstractApi
                     'signService' => 'route53',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://route53.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'route53',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -559,13 +566,6 @@ class Route53Client extends AbstractApi
                 return [
                     'endpoint' => 'https://route53.csp.hci.ic.gov',
                     'signRegion' => 'us-isof-south-1',
-                    'signService' => 'route53',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://route53.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'route53',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/S3/CHANGELOG.md
+++ b/src/Service/S3/CHANGELOG.md
@@ -24,6 +24,7 @@
 - Apply new CodingStandard from latest php-cs-fixer.
 - Harden code against error cases
 - AWS enhancement: Documentation updates.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 2.10.0
 

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -3488,6 +3488,13 @@ class S3Client extends AbstractApi
                     'signService' => 's3',
                     'signVersions' => ['s3v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://s3.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 's3',
+                    'signVersions' => ['s3v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -3509,13 +3516,6 @@ class S3Client extends AbstractApi
                 return [
                     'endpoint' => "https://s3.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 's3',
-                    'signVersions' => ['s3v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://s3.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 's3',
                     'signVersions' => ['s3v4'],
                 ];

--- a/src/Service/Scheduler/CHANGELOG.md
+++ b/src/Service/Scheduler/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 1.5.0
 

--- a/src/Service/Scheduler/src/SchedulerClient.php
+++ b/src/Service/Scheduler/src/SchedulerClient.php
@@ -384,6 +384,13 @@ class SchedulerClient extends AbstractApi
                     'signService' => 'scheduler',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://scheduler.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'scheduler',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -405,13 +412,6 @@ class SchedulerClient extends AbstractApi
                 return [
                     'endpoint' => "https://scheduler.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'scheduler',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://scheduler.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'scheduler',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/SecretsManager/CHANGELOG.md
+++ b/src/Service/SecretsManager/CHANGELOG.md
@@ -16,6 +16,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 2.9.0
 

--- a/src/Service/SecretsManager/src/SecretsManagerClient.php
+++ b/src/Service/SecretsManager/src/SecretsManagerClient.php
@@ -508,6 +508,13 @@ class SecretsManagerClient extends AbstractApi
                     'signService' => 'secretsmanager',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://secretsmanager.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'secretsmanager',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-east-1-fips':
             case 'us-iso-west-1':
@@ -532,13 +539,6 @@ class SecretsManagerClient extends AbstractApi
                 return [
                     'endpoint' => "https://secretsmanager.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'secretsmanager',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://secretsmanager.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'secretsmanager',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/Sns/CHANGELOG.md
+++ b/src/Service/Sns/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 1.11.0
 

--- a/src/Service/Sns/src/SnsClient.php
+++ b/src/Service/Sns/src/SnsClient.php
@@ -615,6 +615,13 @@ class SnsClient extends AbstractApi
                     'signService' => 'sns',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://sns.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'sns',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -636,13 +643,6 @@ class SnsClient extends AbstractApi
                 return [
                     'endpoint' => "https://sns.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'sns',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://sns.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'sns',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/Ssm/CHANGELOG.md
+++ b/src/Service/Ssm/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 2.3.1
 

--- a/src/Service/Ssm/src/SsmClient.php
+++ b/src/Service/Ssm/src/SsmClient.php
@@ -358,6 +358,13 @@ class SsmClient extends AbstractApi
                     'signService' => 'ssm',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://ssm.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'ssm',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -379,13 +386,6 @@ class SsmClient extends AbstractApi
                 return [
                     'endpoint' => "https://ssm.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'ssm',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://ssm.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'ssm',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/StepFunctions/CHANGELOG.md
+++ b/src/Service/StepFunctions/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 1.6.1
 

--- a/src/Service/StepFunctions/src/StepFunctionsClient.php
+++ b/src/Service/StepFunctions/src/StepFunctionsClient.php
@@ -374,6 +374,13 @@ class StepFunctionsClient extends AbstractApi
                     'signService' => 'states',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://states.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'states',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -395,13 +402,6 @@ class StepFunctionsClient extends AbstractApi
                 return [
                     'endpoint' => "https://states.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'states',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://states.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'states',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/Translate/CHANGELOG.md
+++ b/src/Service/Translate/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 1.2.1
 

--- a/src/Service/Translate/src/TranslateClient.php
+++ b/src/Service/Translate/src/TranslateClient.php
@@ -136,18 +136,18 @@ class TranslateClient extends AbstractApi
                     'signService' => 'translate',
                     'signVersions' => ['v4'],
                 ];
+            case 'us-iso-east-1':
+                return [
+                    'endpoint' => 'https://translate.us-iso-east-1.c2s.ic.gov',
+                    'signRegion' => 'us-iso-east-1',
+                    'signService' => 'translate',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-isof-east-1':
             case 'us-isof-south-1':
                 return [
                     'endpoint' => "https://translate.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'translate',
-                    'signVersions' => ['v4'],
-                ];
-            case 'us-iso-east-1':
-                return [
-                    'endpoint' => 'https://translate.us-iso-east-1.c2s.ic.gov',
-                    'signRegion' => 'us-iso-east-1',
                     'signService' => 'translate',
                     'signVersions' => ['v4'],
                 ];

--- a/src/Service/XRay/CHANGELOG.md
+++ b/src/Service/XRay/CHANGELOG.md
@@ -14,6 +14,7 @@
 ### Changed
 
 - Apply new CodingStandard from latest php-cs-fixer.
+- Use a more stable sorting for the list of generated region metadata
 
 ## 1.4.0
 

--- a/src/Service/XRay/src/XRayClient.php
+++ b/src/Service/XRay/src/XRayClient.php
@@ -146,6 +146,13 @@ class XRayClient extends AbstractApi
                     'signService' => 'xray',
                     'signVersions' => ['v4'],
                 ];
+            case 'eu-isoe-west-1':
+                return [
+                    'endpoint' => 'https://xray.eu-isoe-west-1.cloud.adc-e.uk',
+                    'signRegion' => 'eu-isoe-west-1',
+                    'signService' => 'xray',
+                    'signVersions' => ['v4'],
+                ];
             case 'us-iso-east-1':
             case 'us-iso-west-1':
                 return [
@@ -167,13 +174,6 @@ class XRayClient extends AbstractApi
                 return [
                     'endpoint' => "https://xray.$region.csp.hci.ic.gov",
                     'signRegion' => $region,
-                    'signService' => 'xray',
-                    'signVersions' => ['v4'],
-                ];
-            case 'eu-isoe-west-1':
-                return [
-                    'endpoint' => 'https://xray.eu-isoe-west-1.cloud.adc-e.uk',
-                    'signRegion' => 'eu-isoe-west-1',
                     'signService' => 'xray',
                     'signVersions' => ['v4'],
                 ];


### PR DESCRIPTION
Sorting region groups based on the numer of regions in the group generates some unnecessary changes during SDK updates when adding a new region in a group.

This implements the change discussed in https://github.com/async-aws/aws/issues/1968#issuecomment-3448673755 (it does not close the issue as that change is not the main topic of the issue)