### PR TITLE
Add a command adding a changelog entry in all modified packages

### DIFF
--- a/.github/workflows/bin/refresh
+++ b/.github/workflows/bin/refresh
@@ -1,6 +1,8 @@
 #!/usr/bin/env php
 <?php
 
+use AsyncAws\CodeGenerator\ChangeLogUpdater;
+
 $rootDir = __DIR__ . '/../../..';
 if (!file_exists($rootDir . '/manifest.json')) {
     echo "Unable to find the `manifest.json` script in `../../..`.\n";
@@ -143,9 +145,12 @@ if ($hasChange) {
     }
 }
 
-/**
+/*
  * Generating ChangeLog and Composer.json
  */
+
+$changeLogUpdater = new ChangeLogUpdater();
+
 foreach ($services as $service => $hasChange) {
     $awsServiceNames = array_merge([$service], $manifest['services'][$service]['alternative-names'] ?? []);
     $newLines = [];
@@ -170,74 +175,18 @@ foreach ($services as $service => $hasChange) {
 
     $newLines = array_unique($newLines);
 
-    console_log('Generating CHANGELOG for '. $service);
+    console_log('Generating CHANGELOG for ' .  $service);
     if ($service === 'Sts') {
-        $changeLogPath = $rootDir.'/src/Core/CHANGELOG.md';
+        $changeLogPath = $rootDir . '/src/Core/CHANGELOG.md';
     } else {
-        $changeLogPath = $rootDir.'/src/Service/'.$service.'/CHANGELOG.md';
+        $changeLogPath = $rootDir . '/src/Service/' . $service . '/CHANGELOG.md';
     }
-    $changeLog = explode("\n", file_get_contents($changeLogPath));
-    $nrSection = false;
-    $fixSection = false;
     $fixSectionLabel = $hasChange ? '### Added' : '### Changed';
-    $fixSectionOrder = [
-        '### BC-BREAK', '### Removed', // Major
-        '### Added', '### Deprecated', '### Dependency bumped', // Minor
-        '### Changed', '### Fixed', '### Security', // Patch
-    ];
-    $fixSectionIndex = array_search($fixSectionLabel, $fixSectionOrder);
-    foreach ($changeLog as $index => $line) {
-        if ($line === '## NOT RELEASED') {
-            $nrSection = true;
-            continue;
-        }
-        if (!$nrSection) {
-            continue;
-        }
-        if (strpos($line, '## ') === 0) {
-            break;
-        }
-        if (strpos($line, '### ') === 0 && array_search($line, $fixSectionOrder) > $fixSectionIndex) {
-            break;
-        }
-
-        if ($line === $fixSectionLabel) {
-            $fixSection = true;
-            continue;
-        }
-        if (!$fixSection) {
-            continue;
-        }
-
-        if ($line !== '' && false !== $index = array_search($line, $newLines, true)) {
-            array_splice($newLines, $index, 1);
-        }
-    }
-
-    if (empty($newLines)) {
-        console_log('duplicate entry in CHANGELOG '.$service);
-        continue;
-    }
-
-    if (!$nrSection) {
-        array_splice($changeLog, 2, 0, array_merge([
-            '## NOT RELEASED',
-            '',
-            $fixSectionLabel,
-            '',
-        ], $newLines, ['']));
-    } elseif (!$fixSection) {
-        array_splice($changeLog, $index, 0, array_merge([
-            $fixSectionLabel,
-            '',
-        ], $newLines, ['']));
-    } else {
-        array_splice($changeLog, $index - 1, 0, $newLines);
-    }
-    file_put_contents($changeLogPath, implode("\n", $changeLog));
+    $changeLogUpdater->addNewChangeLogLines($changeLogPath, $service, $fixSectionLabel, $newLines, console_log(...));
 
     // Fix branch-alias in composer.json
     if ($hasChange) {
+        $changeLog = explode("\n", file_get_contents($changeLogPath));
         $lastPackageVersion = null;
         $level = 1;
         switch ($changeLog[4]) {

--- a/add_change
+++ b/add_change
@@ -1,0 +1,19 @@
+#!/usr/bin/env php
+<?php
+
+use AsyncAws\CodeGenerator\Command\AddChangeLogCommand;
+use Symfony\Component\Console\Application;
+
+if (!file_exists(__DIR__ . '/vendor/autoload.php')) {
+    echo "Run `composer install` before you run the `generate` script.\n";
+    exit(1);
+}
+
+require __DIR__ . '/vendor/autoload.php';
+
+$app = new Application('AsyncAws', '0.1.0');
+$command = new AddChangeLogCommand();
+$app->add($command);
+$app->setDefaultCommand($command->getName(), true);
+
+$app->run();

--- a/src/CodeGenerator/ChangeLogUpdater.php
+++ b/src/CodeGenerator/ChangeLogUpdater.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace AsyncAws\CodeGenerator;
+
+/**
+ * @internal
+ */
+final class ChangeLogUpdater
+{
+    /**
+     * @param string[]               $newLines
+     * @param callable(string): void $warningReporter
+     */
+    public function addNewChangeLogLines(string $changeLogPath, string $service, string $sectionLabel, array $newLines, callable $warningReporter): void
+    {
+        $changeLog = explode("\n", file_get_contents($changeLogPath));
+        $nrSection = false;
+        $fixSection = false;
+        $fixSectionOrder = [
+            '### BC-BREAK', '### Removed', // Major
+            '### Added', '### Deprecated', '### Dependency bumped', // Minor
+            '### Changed', '### Fixed', '### Security', // Patch
+        ];
+        $fixSectionIndex = array_search($sectionLabel, $fixSectionOrder);
+        foreach ($changeLog as $index => $line) {
+            if ('## NOT RELEASED' === $line) {
+                $nrSection = true;
+
+                continue;
+            }
+            if (!$nrSection) {
+                continue;
+            }
+            if (str_starts_with($line, '## ')) {
+                break;
+            }
+            if (str_starts_with($line, '### ') && array_search($line, $fixSectionOrder) > $fixSectionIndex) {
+                break;
+            }
+
+            if ($line === $sectionLabel) {
+                $fixSection = true;
+
+                continue;
+            }
+            if (!$fixSection) {
+                continue;
+            }
+
+            if ('' !== $line && false !== $index = array_search($line, $newLines, true)) {
+                array_splice($newLines, $index, 1);
+            }
+        }
+
+        if (empty($newLines)) {
+            $warningReporter('duplicate entry in CHANGELOG ' . $service);
+
+            return;
+        }
+
+        if (!$nrSection) {
+            array_splice($changeLog, 2, 0, array_merge([
+                '## NOT RELEASED',
+                '',
+                $sectionLabel,
+                '',
+            ], $newLines, ['']));
+        } elseif (!$fixSection) {
+            array_splice($changeLog, $index, 0, array_merge([
+                $sectionLabel,
+                '',
+            ], $newLines, ['']));
+        } else {
+            array_splice($changeLog, $index - 1, 0, $newLines);
+        }
+        file_put_contents($changeLogPath, implode("\n", $changeLog));
+    }
+}

--- a/src/CodeGenerator/src/Command/AddChangeLogCommand.php
+++ b/src/CodeGenerator/src/Command/AddChangeLogCommand.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\CodeGenerator\Command;
+
+use AsyncAws\CodeGenerator\ChangeLogUpdater;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\Process;
+
+/**
+ * @internal
+ */
+#[AsCommand(name: 'add-change-log', description: 'Add a change log entry in all packages containing modified files.')]
+class AddChangeLogCommand extends Command
+{
+    private const CHANGELOG_LABELS = ['BC-BREAK', 'Removed', 'Added', 'Deprecated', 'Dependency bumped', 'Changed', 'Fixed', 'Security'];
+
+    private readonly ChangeLogUpdater $changeLogUpdater;
+
+    public function __construct()
+    {
+        $this->changeLogUpdater = new ChangeLogUpdater();
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('type', InputArgument::REQUIRED, 'The type of change. Supported values: ' . implode(', ', self::CHANGELOG_LABELS), null, self::CHANGELOG_LABELS);
+        $this->addArgument('message', InputArgument::REQUIRED);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $errorOutput = $output instanceof ConsoleOutput ? $output->getErrorOutput() : $output;
+
+        if (!\in_array($input->getArgument('type'), self::CHANGELOG_LABELS, true)) {
+            $errorOutput->writeln('Invalid type provided. It must be one of: ' . implode(', ', self::CHANGELOG_LABELS) . '.');
+
+            return 1;
+        }
+
+        $changedFiles = explode("\n", (new Process(['git', 'ls-files', '--modified']))->mustRun()->getOutput());
+
+        $changedServices = [];
+        foreach ($changedFiles as $file) {
+            $parts = explode('/', $file);
+            if ('src' !== $parts[0]) {
+                continue;
+            }
+            if (!isset($parts[1])) {
+                continue;
+            }
+
+            if ('Service' === $parts[1]) {
+                $service = $parts[2];
+                $base = 'src/Service/' . $service;
+
+                if ('.template' === $service) {
+                    continue; // The service template does not have an actual changelog
+                }
+            } elseif ('Integration' === $parts[1]) {
+                $service = $parts[2] . '/' . $parts[3];
+                $base = 'src/Integration/' . $service;
+            } elseif ('CodeGenerator' === $parts[1]) {
+                continue; // The code generator does not have a changelog as it has no releases
+            } elseif ('Core' === $parts[1]) {
+                $service = $parts[1];
+                $base = 'src/' . $service;
+            } else {
+                continue;
+            }
+
+            $subPath = substr($file, \strlen($base));
+            $normalizedSubPath = str_replace(\DIRECTORY_SEPARATOR, '/', $subPath);
+
+            if (\in_array($normalizedSubPath, ['/README.md', '/Makefile', '/.gitattributes', '/.gitignore', '/LICENSE', '/phpunit.xml.dist', '/roave-bc-check.yaml'], true) || str_starts_with($normalizedSubPath, '/.github/') || str_starts_with($normalizedSubPath, '/tests/')) {
+                // Scaffolding files don't require a changelog entry when modified as they don't impact the usage of the packages
+                continue;
+            }
+
+            if (!isset($changedServices[$service])) {
+                $changedServices[$service] = ['base' => $base, 'files' => []];
+            }
+            $changedServices[$service]['files'][] = $subPath;
+        }
+
+        $fixSectionLabel = '### ' . $input->getArgument('type');
+        $message = $input->getArgument('message');
+
+        foreach ($changedServices as $service => $info) {
+            $newLines = ['- ' . $message];
+
+            $changeLogPath = $info['base'] . '/CHANGELOG.md';
+            $this->changeLogUpdater->addNewChangeLogLines($changeLogPath, $service, $fixSectionLabel, $newLines, $errorOutput->writeln(...));
+        }
+
+        return 0;
+    }
+}


### PR DESCRIPTION
This command is useful when doing updates in the code generator or the php-cs-fixer configuration, where we know that all changes will have the same cause.

For reference, the changelog entries of #2014 have been generated with this command.