### PR TITLE
Add support for Lists in querystring

### DIFF
--- a/src/CodeGenerator/src/Generator/InputGenerator.php
+++ b/src/CodeGenerator/src/Generator/InputGenerator.php
@@ -351,19 +351,28 @@ class InputGenerator
     {
         $memberShape = $member->getShape();
         if ($memberShape instanceof ListShape) {
-            if ('header' !== $requestPart) {
-                throw new \InvalidArgumentException(\sprintf('ListShape in request part "%s" is not yet implemented', $requestPart));
+            if ('header' === $requestPart) {
+                $bodyCode = '
+                APPLY_HOOK
+                $items = [];
+                foreach (INPUT as $value) {
+                    VALIDATE_ENUM
+                    $items[] = VALUE;
+                }
+                OUTPUT = implode(\',\', $items);
+                ';
+            } elseif ('querystring' === $requestPart) {
+                $bodyCode = '
+                APPLY_HOOK
+                foreach (INPUT as $value) {
+                    VALIDATE_ENUM
+                    OUTPUT[] = VALUE;
+                }
+                ';
+                $this->requirementsRegistry->addRequirement('async-aws/core', '^1.28');
+            } else {
+                throw new \InvalidArgumentException(\sprintf('ListShape in request part "%s" is not yet implemented.', $requestPart));
             }
-
-            $bodyCode = '
-            APPLY_HOOK
-            $items = [];
-            foreach (INPUT as $value) {
-                VALIDATE_ENUM
-                $items[] = VALUE;
-            }
-            OUTPUT = implode(\',\', $items);
-            ';
 
             return strtr($bodyCode, [
                 'INPUT' => $input,

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -15,6 +15,7 @@ use AsyncAws\Core\Exception\InvalidArgument;
 use AsyncAws\Core\Exception\LogicException;
 use AsyncAws\Core\Exception\RuntimeException;
 use AsyncAws\Core\HttpClient\AwsRetryStrategy;
+use AsyncAws\Core\HttpClient\BuildHttpQueryTrait;
 use AsyncAws\Core\Signer\Signer;
 use AsyncAws\Core\Signer\SignerV4;
 use AsyncAws\Core\Stream\StringStream;
@@ -32,6 +33,8 @@ use Symfony\Contracts\HttpClient\HttpClientInterface;
  */
 abstract class AbstractApi
 {
+    use BuildHttpQueryTrait;
+
     /**
      * @var HttpClientInterface
      */
@@ -230,9 +233,9 @@ abstract class AbstractApi
     /**
      * Build the endpoint full uri.
      *
-     * @param string                $uri    or path
-     * @param array<string, string> $query  parameters that should go in the query string
-     * @param ?string               $region region provided by the user in the `@region` parameter of the Input
+     * @param string                         $uri    or path
+     * @param array<string, string|string[]> $query  parameters that should go in the query string
+     * @param ?string                        $region region provided by the user in the `@region` parameter of the Input
      */
     protected function getEndpoint(string $uri, array $query, ?string $region): string
     {
@@ -260,7 +263,7 @@ abstract class AbstractApi
             return $endpoint;
         }
 
-        return $endpoint . (false === strpos($endpoint, '?') ? '?' : '&') . http_build_query($query, '', '&', \PHP_QUERY_RFC3986);
+        return $endpoint . (false === strpos($endpoint, '?') ? '?' : '&') . $this->buildHttpQuery($query);
     }
 
     /**
@@ -272,7 +275,7 @@ abstract class AbstractApi
     }
 
     /**
-     * @param array<string, string> $query
+     * @param array<string, string|string[]> $query
      *
      * @return string
      */
@@ -316,7 +319,7 @@ abstract class AbstractApi
             return $endpoint;
         }
 
-        return $endpoint . (false === strpos($endpoint, '?') ? '?' : '&') . http_build_query($query);
+        return $endpoint . (false === strpos($endpoint, '?') ? '?' : '&') . $this->buildHttpQuery($query);
     }
 
     /**

--- a/src/Core/src/HttpClient/BuildHttpQueryTrait.php
+++ b/src/Core/src/HttpClient/BuildHttpQueryTrait.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace AsyncAws\Core\HttpClient;
+
+/**
+ * @author Jérémy Derussé <jeremy@derusse.com>
+ */
+trait BuildHttpQueryTrait
+{
+    /**
+     * Build a query string from an array of key value pairs
+     * This function does not modify the provided keys when an array is encountered (like `http_build_query()` would).
+     *
+     * @param array<string, string|string[]> $query
+     */
+    private function buildHttpQuery(array $query): string
+    {
+        if (empty($query)) {
+            return '';
+        }
+
+        $qs = '';
+        foreach ($query as $k => $v) {
+            $k = rawurlencode($k);
+            if (!\is_array($v)) {
+                $qs .= $k . '=' . rawurlencode($v) . '&';
+            } else {
+                foreach ($v as $vv) {
+                    $qs .= $k . '=' . rawurlencode($vv) . '&';
+                }
+            }
+        }
+
+        return $qs ? substr($qs, 0, -1) : '';
+    }
+}

--- a/src/Core/src/Request.php
+++ b/src/Core/src/Request.php
@@ -4,6 +4,7 @@ namespace AsyncAws\Core;
 
 use AsyncAws\Core\Exception\InvalidArgument;
 use AsyncAws\Core\Exception\LogicException;
+use AsyncAws\Core\HttpClient\BuildHttpQueryTrait;
 use AsyncAws\Core\Stream\RequestStream;
 
 /**
@@ -13,6 +14,8 @@ use AsyncAws\Core\Stream\RequestStream;
  */
 final class Request
 {
+    use BuildHttpQueryTrait;
+
     /**
      * @var string
      */
@@ -39,7 +42,7 @@ final class Request
     private $queryString;
 
     /**
-     * @var array<string, string>
+     * @var array<string, string|string[]>
      */
     private $query;
 
@@ -59,8 +62,8 @@ final class Request
     private $parsed;
 
     /**
-     * @param array<string, string> $query
-     * @param array<string, string> $headers
+     * @param array<string, string|string[]> $query
+     * @param array<string, string>          $headers
      */
     public function __construct(string $method, string $uri, array $query, array $headers, RequestStream $body, string $hostPrefix = '')
     {
@@ -141,20 +144,26 @@ final class Request
         $this->endpoint = '';
     }
 
-    public function setQueryAttribute(string $name, string $value): void
+    /**
+     * @param string|string[] $value
+     */
+    public function setQueryAttribute(string $name, string|array $value): void
     {
         $this->query[$name] = $value;
         $this->queryString = null;
         $this->endpoint = '';
     }
 
-    public function getQueryAttribute(string $name): ?string
+    /**
+     * @return string|string[]|null
+     */
+    public function getQueryAttribute(string $name): string|array|null
     {
         return $this->query[$name] ?? null;
     }
 
     /**
-     * @return array<string, string>
+     * @return array<string, string|string[]>
      */
     public function getQuery(): array
     {
@@ -207,7 +216,7 @@ final class Request
     private function getQueryString(): string
     {
         if (null === $this->queryString) {
-            $this->queryString = http_build_query($this->query, '', '&', \PHP_QUERY_RFC3986);
+            $this->queryString = $this->buildHttpQuery($this->query);
         }
 
         return $this->queryString;


### PR DESCRIPTION
This PR adds support for List shapes in querystring.

It uses the same logic as the official AWS SDK: 
- build an object with either values (either string or array)
- pass the object to the Guzzle\PSR7 request
- build a querystring without altering the key (https://github.com/guzzle/psr7/blob/21dc724a0583619cd1652f673303492272778051/src/Query.php#L74-L117)

This PR should fix https://github.com/async-aws/aws/pull/2017#issuecomment-3691631490