### PR TITLE
Fix the handling of document shapes in the code generator

### DIFF
--- a/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/PopulatorGenerator.php
@@ -87,6 +87,7 @@ class PopulatorGenerator
             $nullable = $returnType = null;
             $memberShape = $member->getShape();
             $property = $classBuilder->addProperty($propertyName)->setPrivate();
+            $typeAlreadyNullable = false;
             if (null !== $propertyDocumentation = $memberShape->getDocumentationMember()) {
                 $property->setComment(GeneratorHelper::parseDocumentation($propertyDocumentation));
             }
@@ -129,7 +130,8 @@ class PopulatorGenerator
 
                 $nullable = false;
             } elseif ($memberShape instanceof DocumentShape) {
-                $nullable = false; // the type is already nullable, not need to add an extra union
+                $nullable = true;
+                $typeAlreadyNullable = true;
             } elseif ($member->isStreaming()) {
                 $returnType = ResultStream::class;
                 $parameterType = 'ResultStream';
@@ -158,11 +160,11 @@ class PopulatorGenerator
 
             $nullable = $nullable ?? !$member->isRequired();
             if ($parameterType && $parameterType !== $returnType && (empty($memberClassNames) || $memberClassNames[0]->getName() !== $parameterType)) {
-                $method->addComment('@return ' . $parameterType . ($nullable ? '|null' : ''));
+                $method->addComment('@return ' . $parameterType . ($nullable && !$typeAlreadyNullable ? '|null' : ''));
             }
             $method->setReturnNullable($nullable);
             if ($parameterType) {
-                $property->addComment('@var ' . $parameterType . ($nullable ? '|null' : ''));
+                $property->addComment('@var ' . $parameterType . ($nullable && !$typeAlreadyNullable ? '|null' : ''));
             }
         }
 

--- a/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
+++ b/src/CodeGenerator/src/Generator/CodeGenerator/TypeGenerator.php
@@ -92,7 +92,7 @@ class TypeGenerator
                     $param = 'array<string, ' . $param . '>';
                 }
             } elseif ($memberShape instanceof DocumentShape) {
-                $param = 'bool|string|int|float|null|list<mixed>|array<string, mixed>';
+                $param = 'bool|string|int|float|list<mixed>|array<string, mixed>|null';
             } elseif ($member->isStreaming()) {
                 $param = 'string|resource|(callable(int): string)|iterable<string>';
             } elseif ('timestamp' === $param = $memberShape->getType()) {
@@ -172,7 +172,7 @@ class TypeGenerator
         }
 
         if ($shape instanceof DocumentShape) {
-            return ['bool|string|int|float|null|array', 'bool|string|int|float|null|list<mixed>|array<string, mixed>', []];
+            return ['bool|string|int|float|array|null', 'bool|string|int|float|list<mixed>|array<string, mixed>|null', []];
         }
 
         $type = $doc = $this->getNativePhpType($shape->getType());

--- a/src/CodeGenerator/src/Generator/ObjectGenerator.php
+++ b/src/CodeGenerator/src/Generator/ObjectGenerator.php
@@ -277,6 +277,7 @@ class ObjectGenerator
                 $classBuilder->addUse($enumClassName->getFqdn());
             }
             $getterSetterNullable = null;
+            $typeAlreadyNullable = false;
 
             if ($memberShape instanceof StructureShape) {
                 $this->generate($memberShape);
@@ -309,7 +310,8 @@ class ObjectGenerator
                     $classBuilder->addUse($enumClassName->getFqdn());
                 }
             } elseif ($memberShape instanceof DocumentShape) {
-                $nullable = false;
+                $nullable = true;
+                $typeAlreadyNullable = true;
             } elseif ($member->isStreaming()) {
                 $returnType = ResultStream::class;
                 $parameterType = ResultStream::class;
@@ -344,11 +346,11 @@ class ObjectGenerator
             }
 
             if ($parameterType && $parameterType !== $returnType && (empty($memberClassNames) || $memberClassNames[0]->getName() !== $parameterType)) {
-                $method->addComment('@return ' . $parameterType . ($getterSetterNullable ? '|null' : ''));
+                $method->addComment('@return ' . $parameterType . ($getterSetterNullable && !$typeAlreadyNullable ? '|null' : ''));
             }
             $method->setReturnNullable($getterSetterNullable);
             if ($parameterType) {
-                $property->addComment('@var ' . $parameterType . ($nullable ? '|null' : ''));
+                $property->addComment('@var ' . $parameterType . ($nullable && !$typeAlreadyNullable ? '|null' : ''));
             }
         }
 


### PR DESCRIPTION
First actual usages of a document shape in #2017 revealed that my initial implementation was flawed (partially based on not noticing the exact behavior of the handling of nullable types, for which document shapes are special as the base type is already nullable).

This fixes those issues in the code generator, by always reporting document shapes as being nullable, but adding a concept of `$typeAlreadyNullable` for the code adding null types in phpdoc annotations separately from the code generator logic handling `setReturnNullable`