### PR TITLE
Handle Amazon header formatting so pre-signed S3 PUT URLs with metadata result in valid signatures

### DIFF
--- a/src/Core/CHANGELOG.md
+++ b/src/Core/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Fixed
+
+- SignerV4: Fix presign PUT requests for S3 objects not passing signature validation
+
 ## 1.28.1
 
 ### Changed


### PR DESCRIPTION
## Description

Closes https://github.com/async-aws/aws/issues/2043.

Pre-signed S3 PUT requests (with user-defined metadata) are rejected by S3 because the signature is not valid.

This was caused by [a change in the formatting of the user-defined metadata keys](https://github.com/async-aws/aws/pull/2037/changes#diff-e4d706be2f18732329a2930eeacfde8390a0dc965baedf636b4e8a1b9bcc8d24R247).

This fixes the issue by preserving the casing of S3 user-defined metadata - I've validated on my side that S3 PUT requests are now accepted.

### Can we apply the case change to `X-Amz-Meta-` still, if the signature _also_ includes the case change?

I tried uniformly applying `formatAmazonHeader` to all `x-amz` values in the `buildCanonicalRequest` too (so everything formatted as `X-Amz-<something>` and `X-Amz-Meta-<something>`), thinking it was just because the canonical request was still in lowercase and that effected the signature. However that didn't appear to make a difference - the signatures were still rejected by S3.

I _haven't_ looked into the official AWS SDK, but [my assumption from the docs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingMetadata.html#UserMetadata) is its an expectation that the user-defined metadata is all lowercase.