### PR TITLE
Fix: filter not assigned from input in QueryVectorsInput constructor

### DIFF
--- a/src/Service/S3Vectors/src/Input/QueryVectorsInput.php
+++ b/src/Service/S3Vectors/src/Input/QueryVectorsInput.php
@@ -95,6 +95,7 @@ final class QueryVectorsInput extends Input
         $this->indexArn = $input['indexArn'] ?? null;
         $this->topK = $input['topK'] ?? null;
         $this->queryVector = isset($input['queryVector']) ? VectorData::create($input['queryVector']) : null;
+        $this->filter = $input['filter'] ?? null;
         $this->returnMetadata = $input['returnMetadata'] ?? null;
         $this->returnDistance = $input['returnDistance'] ?? null;
         parent::__construct($input);


### PR DESCRIPTION
The filter field is declared as a property but never assigned in __construct(), so any filter passed to queryVectors() is silently ignored and never included in the HTTP request body.