### PR TITLE
feat: add non-buffered response streaming

### DIFF
--- a/docs/clients/s3.md
+++ b/docs/clients/s3.md
@@ -73,8 +73,10 @@ request which could have a performance impact.
 ### Download files
 
 When you download a file from S3, AsyncAws gives you a `ResultStream` which
-can be used as a string, as a resource, or iterated over. This allows you to handle
-larger files without having them in memory.
+can be used as a string, as a resource, or iterated over. By default, response
+bodies are buffered into temporary storage so the stream can be replayed and
+safely reused by another request. This avoids loading large objects into PHP
+memory, but large objects can still use local temporary storage.
 
 ```
 // download a file and use it directly as string
@@ -103,6 +105,31 @@ foreach ($result->getBody()->getChunks() as $chunk) {
     $progress->advance();
 }
 ```
+
+#### Non-buffered downloads
+
+For one-pass processing of large objects, disable response buffering:
+
+```php
+$result = $s3->getObject([
+    'Bucket' => 'my-company-website',
+    'Key' => 'orders.csv',
+    '@responseBuffer' => false,
+]);
+
+$input = $result->getBody()->getContentAsResource();
+$output = fopen('/path/to/orders.csv', 'wb');
+
+stream_copy_to_stream($input, $output);
+fclose($input);
+fclose($output);
+```
+
+Non-buffered response streams are one-shot and non-rewindable. In this mode,
+`getChunks()` yields chunks without also copying them into `php://temp`. Do not
+pass a non-buffered response stream as the body of another AsyncAWS or Symfony
+HttpClient request. If you need a replayable stream or want to upload a
+downloaded object to another request, keep the default buffered behavior.
 
 ### Add tags to a bucket
 

--- a/src/CodeGenerator/src/Definition/Operation.php
+++ b/src/CodeGenerator/src/Definition/Operation.php
@@ -112,6 +112,21 @@ class Operation
         return null;
     }
 
+    public function hasStreamingOutputPayload(): bool
+    {
+        $output = $this->getOutput();
+        if (null === $output) {
+            return false;
+        }
+
+        $payload = $output->getPayload();
+        if (null === $payload) {
+            return false;
+        }
+
+        return $output->getMember($payload)->isStreaming();
+    }
+
     /**
      * @return ExceptionShape[]
      */

--- a/src/CodeGenerator/src/Generator/InputGenerator.php
+++ b/src/CodeGenerator/src/Generator/InputGenerator.php
@@ -284,6 +284,10 @@ class InputGenerator
             ->setBody('return $input instanceof self ? $input : new self($input);');
         $createMethod->addParameter('input');
         $pseudoOptions = ['  \'@region\'?: string|null,', '  \'@responseBuffer\'?: bool,'];
+        if (0 !== strpos($classBuilder->getClassName()->getFqdn(), 'AsyncAws\\Core\\')) {
+            $this->requirementsRegistry->addRequirement('async-aws/core', '^1.30');
+        }
+
         [$doc, $memberClassNames] = $this->typeGenerator->generateDocblock($shape, $className, true, true, false, $pseudoOptions);
         $createMethod->addComment($doc);
         foreach ($memberClassNames as $memberClassName) {

--- a/src/CodeGenerator/src/Generator/InputGenerator.php
+++ b/src/CodeGenerator/src/Generator/InputGenerator.php
@@ -116,6 +116,9 @@ class InputGenerator
             if ('region' === $member->getName()) {
                 throw new \RuntimeException('Member conflict with "@region" parameter.');
             }
+            if ('responseBuffer' === $member->getName()) {
+                throw new \RuntimeException('Member conflict with "@responseBuffer" parameter.');
+            }
             $memberShape = $member->getShape();
             [$returnType, $parameterType, $memberClassNames] = $this->typeGenerator->getPhpType($memberShape);
             foreach ($memberClassNames as $memberClassName) {
@@ -280,7 +283,8 @@ class InputGenerator
             ->setReturnType('self')
             ->setBody('return $input instanceof self ? $input : new self($input);');
         $createMethod->addParameter('input');
-        [$doc, $memberClassNames] = $this->typeGenerator->generateDocblock($shape, $className, true, true, false, ['  \'@region\'?: string|null,']);
+        $pseudoOptions = ['  \'@region\'?: string|null,', '  \'@responseBuffer\'?: bool,'];
+        [$doc, $memberClassNames] = $this->typeGenerator->generateDocblock($shape, $className, true, true, false, $pseudoOptions);
         $createMethod->addComment($doc);
         foreach ($memberClassNames as $memberClassName) {
             $classBuilder->addUse($memberClassName->getFqdn());
@@ -288,7 +292,7 @@ class InputGenerator
 
         $constructorBody .= 'parent::__construct($input);';
         $constructor = $classBuilder->addMethod('__construct');
-        [$doc, $memberClassNames] = $this->typeGenerator->generateDocblock($shape, $className, false, true, false, ['  \'@region\'?: string|null,']);
+        [$doc, $memberClassNames] = $this->typeGenerator->generateDocblock($shape, $className, false, true, false, $pseudoOptions);
         $constructor->addComment($doc);
         foreach ($memberClassNames as $memberClassName) {
             $classBuilder->addUse($memberClassName->getFqdn());

--- a/src/CodeGenerator/src/Generator/OperationGenerator.php
+++ b/src/CodeGenerator/src/Generator/OperationGenerator.php
@@ -118,7 +118,12 @@ class OperationGenerator
         $method->addComment('@see ' . $operation->getApiReferenceDocumentationUrl());
         $prefix = $operation->getService()->getEndpointPrefix();
         $method->addComment('@see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-' . $prefix . '-' . $operation->getService()->getApiVersion() . '.html#' . strtolower($operation->getName()));
-        [$doc, $memberClassNames] = $this->typeGenerator->generateDocblock($inputShape, $inputClass, true, false, false, ['  \'@region\'?: string|null,']);
+        $pseudoOptions = ['  \'@region\'?: string|null,'];
+        if ($operation->hasStreamingOutputPayload()) {
+            $pseudoOptions[] = '  \'@responseBuffer\'?: bool,';
+        }
+
+        [$doc, $memberClassNames] = $this->typeGenerator->generateDocblock($inputShape, $inputClass, true, false, false, $pseudoOptions);
         $method->addComment($doc);
         foreach ($memberClassNames as $memberClassName) {
             $classBuilder->addUse($memberClassName->getFqdn());
@@ -204,6 +209,14 @@ class OperationGenerator
         }
         if ($mapping) {
             $extra .= ", 'exceptionMapping' => [\n" . implode("\n", $mapping) . "\n]";
+        }
+
+        if ($operation->hasStreamingOutputPayload()) {
+            if (0 !== strpos($classBuilder->getClassName()->getFqdn(), 'AsyncAws\\Core\\')) {
+                $this->requirementsRegistry->addRequirement('async-aws/core', '^1.30');
+            }
+
+            $extra .= ", 'responseBuffer' => \$input->shouldBufferResponse()";
         }
 
         if ($operation->requiresEndpointDiscovery()) {

--- a/src/Core/src/AbstractApi.php
+++ b/src/Core/src/AbstractApi.php
@@ -161,12 +161,18 @@ abstract class AbstractApi
             $requestBody = $requestBody->stringify();
         }
 
+        $responseBuffer = $context ? $context->shouldBufferResponse() : true;
+        $options = [
+            'headers' => $request->getHeaders(),
+        ] + (0 === $length ? [] : ['body' => $requestBody]);
+        if (!$responseBuffer) {
+            $options['buffer'] = false;
+        }
+
         $response = $this->httpClient->request(
             $request->getMethod(),
             $request->getEndpoint(),
-            [
-                'headers' => $request->getHeaders(),
-            ] + (0 === $length ? [] : ['body' => $requestBody])
+            $options
         );
 
         if ($debug = filter_var($this->configuration->get('debug'), \FILTER_VALIDATE_BOOLEAN)) {
@@ -178,7 +184,7 @@ abstract class AbstractApi
             ]);
         }
 
-        return new Response($response, $this->httpClient, $this->logger, $this->awsErrorFactory, $this->endpointCache, $request, $debug, $context ? $context->getExceptionMapping() : []);
+        return new Response($response, $this->httpClient, $this->logger, $this->awsErrorFactory, $this->endpointCache, $request, $debug, $context ? $context->getExceptionMapping() : [], $responseBuffer);
     }
 
     /**

--- a/src/Core/src/Input.php
+++ b/src/Core/src/Input.php
@@ -15,11 +15,17 @@ abstract class Input
     public $region;
 
     /**
-     * @param array{'@region'?: ?string,...} $input
+     * @var bool
+     */
+    private $responseBuffer = true;
+
+    /**
+     * @param array{'@region'?: ?string, '@responseBuffer'?: bool, ...} $input
      */
     protected function __construct(array $input)
     {
         $this->region = $input['@region'] ?? null;
+        $this->responseBuffer = $input['@responseBuffer'] ?? true;
     }
 
     public function setRegion(?string $region): void
@@ -30,6 +36,11 @@ abstract class Input
     public function getRegion(): ?string
     {
         return $this->region;
+    }
+
+    public function shouldBufferResponse(): bool
+    {
+        return $this->responseBuffer;
     }
 
     abstract public function request(): Request;

--- a/src/Core/src/RequestContext.php
+++ b/src/Core/src/RequestContext.php
@@ -18,6 +18,7 @@ final class RequestContext
         'expirationDate' => true,
         'currentDate' => true,
         'exceptionMapping' => true,
+        'responseBuffer' => true,
         'usesEndpointDiscovery' => true,
         'requiresEndpointDiscovery' => true,
     ];
@@ -58,12 +59,18 @@ final class RequestContext
     private $exceptionMapping = [];
 
     /**
+     * @var bool
+     */
+    private $responseBuffer = true;
+
+    /**
      * @param array{
      *  operation?: string|null,
      *  region?: string|null,
      *  expirationDate?: \DateTimeImmutable|null,
      *  currentDate?: \DateTimeImmutable|null,
      *  exceptionMapping?: array<string, class-string<HttpException>>,
+     *  responseBuffer?: bool,
      *  usesEndpointDiscovery?: bool,
      *  requiresEndpointDiscovery?: bool,
      * } $options
@@ -105,6 +112,11 @@ final class RequestContext
     public function getExceptionMapping(): array
     {
         return $this->exceptionMapping;
+    }
+
+    public function shouldBufferResponse(): bool
+    {
+        return $this->responseBuffer;
     }
 
     public function usesEndpointDiscovery(): bool

--- a/src/Core/src/Response.php
+++ b/src/Core/src/Response.php
@@ -17,6 +17,7 @@ use AsyncAws\Core\Exception\InvalidArgument;
 use AsyncAws\Core\Exception\LogicException;
 use AsyncAws\Core\Exception\RuntimeException;
 use AsyncAws\Core\Exception\UnparsableResponse;
+use AsyncAws\Core\Stream\ResponseBodyNonBufferedStream;
 use AsyncAws\Core\Stream\ResponseBodyStream;
 use AsyncAws\Core\Stream\ResultStream;
 use Psr\Log\LoggerInterface;
@@ -103,9 +104,14 @@ final class Response
     private $exceptionMapping;
 
     /**
+     * @var bool
+     */
+    private $responseBuffer;
+
+    /**
      * @param array<string, class-string<HttpException>> $exceptionMapping
      */
-    public function __construct(ResponseInterface $response, HttpClientInterface $httpClient, LoggerInterface $logger, ?AwsErrorFactoryInterface $awsErrorFactory = null, ?EndpointCache $endpointCache = null, ?Request $request = null, bool $debug = false, array $exceptionMapping = [])
+    public function __construct(ResponseInterface $response, HttpClientInterface $httpClient, LoggerInterface $logger, ?AwsErrorFactoryInterface $awsErrorFactory = null, ?EndpointCache $endpointCache = null, ?Request $request = null, bool $debug = false, array $exceptionMapping = [], bool $responseBuffer = true)
     {
         $this->httpResponse = $response;
         $this->httpClient = $httpClient;
@@ -115,6 +121,7 @@ final class Response
         $this->request = $request;
         $this->debug = $debug;
         $this->exceptionMapping = $exceptionMapping;
+        $this->responseBuffer = $responseBuffer;
     }
 
     public function __destruct()
@@ -166,12 +173,18 @@ final class Response
                 // Network exception
                 $this->logger->debug('AsyncAws HTTP request could not be sent due network issues');
             } else {
+                if ($this->responseBuffer) {
+                    $body = $this->httpResponse->getContent(false);
+                    $this->bodyDownloaded = true;
+                } else {
+                    $body = '[response body omitted because buffering is disabled]';
+                }
+
                 $this->logger->debug('AsyncAws HTTP response received with status code {status_code}', [
                     'status_code' => $httpStatusCode,
                     'headers' => json_encode($this->httpResponse->getHeaders(false)),
-                    'body' => $this->httpResponse->getContent(false),
+                    'body' => $body,
                 ]);
-                $this->bodyDownloaded = true;
             }
         }
 
@@ -373,6 +386,15 @@ final class Response
         }
 
         try {
+            if (!$this->responseBuffer) {
+                $toStream = [$this->httpResponse, 'toStream'];
+                if (!\is_callable($toStream)) {
+                    throw new RuntimeException('The HTTP response does not support non-buffered streaming.');
+                }
+
+                return new ResponseBodyNonBufferedStream($toStream(false));
+            }
+
             return new ResponseBodyStream($this->httpClient->stream($this->httpResponse));
         } finally {
             $this->bodyDownloaded = true;

--- a/src/Core/src/Stream/ResponseBodyNonBufferedStream.php
+++ b/src/Core/src/Stream/ResponseBodyNonBufferedStream.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core\Stream;
+
+use AsyncAws\Core\Exception\LogicException;
+use AsyncAws\Core\Exception\RuntimeException;
+
+/**
+ * One-shot stream backed directly by an HTTP response body resource.
+ */
+final class ResponseBodyNonBufferedStream implements ReadOnceResultStream, ResultStream
+{
+    /**
+     * @var resource
+     */
+    private $resource;
+
+    /**
+     * @var bool
+     */
+    private $consumed = false;
+
+    /**
+     * @param resource $resource
+     */
+    public function __construct($resource)
+    {
+        if (!\is_resource($resource)) {
+            throw new RuntimeException('The response stream is not a valid resource.');
+        }
+
+        $this->resource = $resource;
+    }
+
+    public function __toString(): string
+    {
+        return $this->getContentAsString();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getChunks(): iterable
+    {
+        $this->markConsumed();
+
+        return $this->doGetChunks();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContentAsString(): string
+    {
+        $this->markConsumed();
+
+        $content = stream_get_contents($this->resource);
+        if (false === $content) {
+            throw new RuntimeException('Unable to read the response stream.');
+        }
+
+        return $content;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getContentAsResource()
+    {
+        $this->markConsumed();
+
+        return $this->resource;
+    }
+
+    /**
+     * @return \Generator<string>
+     */
+    private function doGetChunks(): \Generator
+    {
+        while (!feof($this->resource)) {
+            $chunk = fread($this->resource, 64 * 1024);
+            if (false === $chunk) {
+                throw new RuntimeException('Unable to read the response stream.');
+            }
+
+            if ('' !== $chunk) {
+                yield $chunk;
+            }
+        }
+    }
+
+    private function markConsumed(): void
+    {
+        if ($this->consumed) {
+            throw new LogicException('The non-buffered response stream has already been consumed.');
+        }
+
+        $this->consumed = true;
+    }
+}

--- a/src/Core/src/Stream/ResultStream.php
+++ b/src/Core/src/Stream/ResultStream.php
@@ -6,6 +6,10 @@ namespace AsyncAws\Core\Stream;
 
 /**
  * Stream for a Result.
+ *
+ * Most implementations buffer responses into temporary storage so content can be
+ * replayed. Some operations can opt into non-buffered response streams; those
+ * streams are one-shot and non-rewindable.
  */
 interface ResultStream
 {
@@ -22,12 +26,12 @@ interface ResultStream
     public function getChunks(): iterable;
 
     /**
-     * Download content into a temporary resource and return a string.
+     * Download content and return a string.
      */
     public function getContentAsString(): string;
 
     /**
-     * Download content into a resource and then return that resource.
+     * Return content as a resource.
      *
      * @return resource
      */

--- a/src/Core/src/Sts/Input/AssumeRoleRequest.php
+++ b/src/Core/src/Sts/Input/AssumeRoleRequest.php
@@ -269,6 +269,7 @@ final class AssumeRoleRequest extends Input
      *   SourceIdentity?: string|null,
      *   ProvidedContexts?: array<ProvidedContext|array>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -303,6 +304,7 @@ final class AssumeRoleRequest extends Input
      *   SourceIdentity?: string|null,
      *   ProvidedContexts?: array<ProvidedContext|array>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AssumeRoleRequest $input
      */
     public static function create($input): self

--- a/src/Core/src/Sts/Input/AssumeRoleWithWebIdentityRequest.php
+++ b/src/Core/src/Sts/Input/AssumeRoleWithWebIdentityRequest.php
@@ -161,6 +161,7 @@ final class AssumeRoleWithWebIdentityRequest extends Input
      *   Policy?: string|null,
      *   DurationSeconds?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -185,6 +186,7 @@ final class AssumeRoleWithWebIdentityRequest extends Input
      *   Policy?: string|null,
      *   DurationSeconds?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AssumeRoleWithWebIdentityRequest $input
      */
     public static function create($input): self

--- a/src/Core/src/Sts/Input/GetCallerIdentityRequest.php
+++ b/src/Core/src/Sts/Input/GetCallerIdentityRequest.php
@@ -11,6 +11,7 @@ final class GetCallerIdentityRequest extends Input
     /**
      * @param array{
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -21,6 +22,7 @@ final class GetCallerIdentityRequest extends Input
     /**
      * @param array{
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetCallerIdentityRequest $input
      */
     public static function create($input): self

--- a/src/Core/tests/Unit/AbstractApiTest.php
+++ b/src/Core/tests/Unit/AbstractApiTest.php
@@ -6,12 +6,15 @@ namespace AsyncAws\Core\Tests\Unit;
 
 use AsyncAws\Core\AbstractApi;
 use AsyncAws\Core\Configuration;
+use AsyncAws\Core\Credentials\NullProvider;
 use AsyncAws\Core\EndpointDiscovery\EndpointInterface;
 use AsyncAws\Core\Request;
 use AsyncAws\Core\RequestContext;
 use AsyncAws\Core\Response;
 use AsyncAws\Core\Stream\StringStream;
+use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpClient\MockHttpClient;
 use Symfony\Contracts\HttpClient\HttpClientInterface;
 use Symfony\Contracts\HttpClient\ResponseInterface;
 
@@ -56,6 +59,34 @@ class AbstractApiTest extends TestCase
 
         $response = $api->getResponseExposed(new Request('GET', '/foo', [], [], StringStream::create('')), new RequestContext(['requiresEndpointDiscovery' => true]));
         $response->cancel();
+    }
+
+    public function testGetResponseDoesNotDisableBufferingByDefault(): void
+    {
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {
+            self::assertNotSame(false, $options['buffer'] ?? null);
+
+            return new SimpleMockedResponse('OK');
+        });
+        $api = new DummyApi([], new NullProvider(), $httpClient);
+
+        $response = $api->getResponseExposed(new Request('GET', '/foo', [], [], StringStream::create('')), new RequestContext());
+
+        self::assertTrue($response->resolve());
+    }
+
+    public function testGetResponseCanDisableBuffering(): void
+    {
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {
+            self::assertSame(false, $options['buffer'] ?? null);
+
+            return new SimpleMockedResponse('OK');
+        });
+        $api = new DummyApi([], new NullProvider(), $httpClient);
+
+        $response = $api->getResponseExposed(new Request('GET', '/foo', [], [], StringStream::create('')), new RequestContext(['responseBuffer' => false]));
+
+        self::assertTrue($response->resolve());
     }
 }
 

--- a/src/Core/tests/Unit/InputTest.php
+++ b/src/Core/tests/Unit/InputTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core\Tests\Unit;
+
+use AsyncAws\Core\Input;
+use AsyncAws\Core\Request;
+use AsyncAws\Core\Stream\StringStream;
+use PHPUnit\Framework\TestCase;
+
+class InputTest extends TestCase
+{
+    public function testResponseBufferDefaultsToTrue(): void
+    {
+        $input = new TestInput();
+
+        self::assertTrue($input->shouldBufferResponse());
+    }
+
+    public function testResponseBufferCanBeDisabled(): void
+    {
+        $input = new TestInput(['@responseBuffer' => false]);
+
+        self::assertFalse($input->shouldBufferResponse());
+    }
+
+    public function testRegionBehaviorIsUnchanged(): void
+    {
+        $input = new TestInput(['@region' => 'eu-west-1']);
+
+        self::assertSame('eu-west-1', $input->getRegion());
+    }
+}
+
+class TestInput extends Input
+{
+    public function __construct(array $input = [])
+    {
+        parent::__construct($input);
+    }
+
+    public function request(): Request
+    {
+        return new Request('GET', '/', [], [], StringStream::create(''));
+    }
+}

--- a/src/Core/tests/Unit/RequestContextTest.php
+++ b/src/Core/tests/Unit/RequestContextTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core\Tests\Unit;
+
+use AsyncAws\Core\Exception\InvalidArgument;
+use AsyncAws\Core\RequestContext;
+use PHPUnit\Framework\TestCase;
+
+class RequestContextTest extends TestCase
+{
+    public function testResponseBufferDefaultsToTrue(): void
+    {
+        $context = new RequestContext();
+
+        self::assertTrue($context->shouldBufferResponse());
+    }
+
+    public function testResponseBufferCanBeDisabled(): void
+    {
+        $context = new RequestContext(['responseBuffer' => false]);
+
+        self::assertFalse($context->shouldBufferResponse());
+    }
+
+    public function testUnknownOptionsAreRejected(): void
+    {
+        $this->expectException(InvalidArgument::class);
+        $this->expectExceptionMessage('Invalid option(s) "foo" passed to "AsyncAws\Core\RequestContext::__construct".');
+
+        new RequestContext(['foo' => true]);
+    }
+}

--- a/src/Core/tests/Unit/ResponseTest.php
+++ b/src/Core/tests/Unit/ResponseTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core\Tests\Unit;
+
+use AsyncAws\Core\Exception\Http\ClientException;
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Stream\ResponseBodyNonBufferedStream;
+use AsyncAws\Core\Stream\ResponseBodyStream;
+use AsyncAws\Core\Test\Http\SimpleMockedResponse;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Contracts\HttpClient\HttpClientInterface;
+use Symfony\Contracts\HttpClient\ResponseInterface;
+
+class ResponseTest extends TestCase
+{
+    public function testToStreamDefaultsToBufferedStream(): void
+    {
+        $httpResponse = new SimpleMockedResponse('content');
+        $client = new MockHttpClient($httpResponse);
+        $response = new Response($client->request('GET', 'http://localhost'), $client, new NullLogger());
+
+        self::assertInstanceOf(ResponseBodyStream::class, $response->toStream());
+    }
+
+    public function testToStreamCanReturnNonBufferedStream(): void
+    {
+        $httpResponse = new SimpleMockedResponse('content');
+        $client = new MockHttpClient($httpResponse);
+        $response = new Response($client->request('GET', 'http://localhost'), $client, new NullLogger(), null, null, null, false, [], false);
+
+        $stream = $response->toStream();
+
+        self::assertInstanceOf(ResponseBodyNonBufferedStream::class, $stream);
+        self::assertSame('content', $stream->getContentAsString());
+    }
+
+    public function testToStreamResolvesHttpErrorsBeforeReturningNonBufferedStream(): void
+    {
+        $httpResponse = new SimpleMockedResponse('Bad request', [], 400);
+        $client = new MockHttpClient($httpResponse);
+        $response = new Response($client->request('GET', 'http://localhost'), $client, new NullLogger(), null, null, null, false, [], false);
+
+        $this->expectException(ClientException::class);
+
+        $response->toStream();
+    }
+
+    public function testDebugLoggingDoesNotReadBodyWhenBufferingIsDisabled(): void
+    {
+        $httpResponse = new NonContentResponse();
+        $client = $this->createMock(HttpClientInterface::class);
+        $response = new Response($httpResponse, $client, new NullLogger(), null, null, null, true, [], false);
+
+        $response->resolve();
+
+        self::assertTrue($response->info()['resolved']);
+        self::assertFalse($response->info()['body_downloaded']);
+    }
+}
+
+class NonContentResponse implements ResponseInterface
+{
+    public function getStatusCode(): int
+    {
+        return 200;
+    }
+
+    public function getHeaders(bool $throw = true): array
+    {
+        return [];
+    }
+
+    public function getContent(bool $throw = true): string
+    {
+        throw new \RuntimeException('getContent should not be called.');
+    }
+
+    public function toArray(bool $throw = true): array
+    {
+        return [];
+    }
+
+    public function cancel(): void
+    {
+    }
+
+    public function getInfo(?string $type = null): mixed
+    {
+        $info = [
+            'http_code' => 200,
+            'url' => 'http://localhost',
+        ];
+
+        return null === $type ? $info : ($info[$type] ?? null);
+    }
+}

--- a/src/Core/tests/Unit/Stream/ResponseBodyNonBufferedStreamTest.php
+++ b/src/Core/tests/Unit/Stream/ResponseBodyNonBufferedStreamTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace AsyncAws\Core\Tests\Unit\Stream;
+
+use AsyncAws\Core\Exception\LogicException;
+use AsyncAws\Core\Exception\RuntimeException;
+use AsyncAws\Core\Stream\ReadOnceResultStream;
+use AsyncAws\Core\Stream\ResponseBodyNonBufferedStream;
+use PHPUnit\Framework\TestCase;
+
+class ResponseBodyNonBufferedStreamTest extends TestCase
+{
+    public function testItReturnsOriginalResource(): void
+    {
+        $resource = self::createResource('abcdef');
+        $stream = new ResponseBodyNonBufferedStream($resource);
+
+        self::assertSame($resource, $stream->getContentAsResource());
+    }
+
+    public function testItIsMarkedAsReadOnce(): void
+    {
+        $stream = new ResponseBodyNonBufferedStream(self::createResource('abcdef'));
+
+        self::assertInstanceOf(ReadOnceResultStream::class, $stream);
+    }
+
+    public function testItReadsStringFromCurrentPosition(): void
+    {
+        $resource = self::createResource('abcdef');
+        fseek($resource, 2);
+        $stream = new ResponseBodyNonBufferedStream($resource);
+
+        self::assertSame('cdef', $stream->getContentAsString());
+    }
+
+    public function testItReadsChunksWithoutRewinding(): void
+    {
+        $resource = self::createResource('abcdef');
+        fseek($resource, 2);
+        $stream = new ResponseBodyNonBufferedStream($resource);
+
+        self::assertSame(['cdef'], iterator_to_array($stream->getChunks()));
+    }
+
+    public function testItCanOnlyBeConsumedOnce(): void
+    {
+        $stream = new ResponseBodyNonBufferedStream(self::createResource('abcdef'));
+
+        $stream->getContentAsResource();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('The non-buffered response stream has already been consumed.');
+
+        $stream->getContentAsString();
+    }
+
+    public function testGetChunksMarksStreamConsumedAtCallTime(): void
+    {
+        $stream = new ResponseBodyNonBufferedStream(self::createResource('abcdef'));
+
+        $chunks = $stream->getChunks();
+
+        $this->expectException(LogicException::class);
+        $stream->getChunks();
+
+        iterator_to_array($chunks);
+    }
+
+    public function testInvalidResourceIsRejected(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('The response stream is not a valid resource.');
+
+        new ResponseBodyNonBufferedStream('not-a-resource');
+    }
+
+    /**
+     * @return resource
+     */
+    private static function createResource(string $content)
+    {
+        $resource = fopen('php://temp', 'rb+');
+        self::assertIsResource($resource);
+        fwrite($resource, $content);
+        rewind($resource);
+
+        return $resource;
+    }
+}

--- a/src/Service/AppSync/composer.json
+++ b/src/Service/AppSync/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/AppSync/src/Input/CreateResolverRequest.php
+++ b/src/Service/AppSync/src/Input/CreateResolverRequest.php
@@ -151,6 +151,7 @@ final class CreateResolverRequest extends Input
      *   code?: string|null,
      *   metricsConfig?: ResolverLevelMetricsConfig::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -189,6 +190,7 @@ final class CreateResolverRequest extends Input
      *   code?: string|null,
      *   metricsConfig?: ResolverLevelMetricsConfig::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateResolverRequest $input
      */
     public static function create($input): self

--- a/src/Service/AppSync/src/Input/DeleteResolverRequest.php
+++ b/src/Service/AppSync/src/Input/DeleteResolverRequest.php
@@ -42,6 +42,7 @@ final class DeleteResolverRequest extends Input
      *   typeName?: string,
      *   fieldName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -58,6 +59,7 @@ final class DeleteResolverRequest extends Input
      *   typeName?: string,
      *   fieldName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteResolverRequest $input
      */
     public static function create($input): self

--- a/src/Service/AppSync/src/Input/GetSchemaCreationStatusRequest.php
+++ b/src/Service/AppSync/src/Input/GetSchemaCreationStatusRequest.php
@@ -22,6 +22,7 @@ final class GetSchemaCreationStatusRequest extends Input
      * @param array{
      *   apiId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class GetSchemaCreationStatusRequest extends Input
      * @param array{
      *   apiId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetSchemaCreationStatusRequest $input
      */
     public static function create($input): self

--- a/src/Service/AppSync/src/Input/ListApiKeysRequest.php
+++ b/src/Service/AppSync/src/Input/ListApiKeysRequest.php
@@ -39,6 +39,7 @@ final class ListApiKeysRequest extends Input
      *   nextToken?: string|null,
      *   maxResults?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -55,6 +56,7 @@ final class ListApiKeysRequest extends Input
      *   nextToken?: string|null,
      *   maxResults?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListApiKeysRequest $input
      */
     public static function create($input): self

--- a/src/Service/AppSync/src/Input/ListResolversRequest.php
+++ b/src/Service/AppSync/src/Input/ListResolversRequest.php
@@ -49,6 +49,7 @@ final class ListResolversRequest extends Input
      *   nextToken?: string|null,
      *   maxResults?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -67,6 +68,7 @@ final class ListResolversRequest extends Input
      *   nextToken?: string|null,
      *   maxResults?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListResolversRequest $input
      */
     public static function create($input): self

--- a/src/Service/AppSync/src/Input/StartSchemaCreationRequest.php
+++ b/src/Service/AppSync/src/Input/StartSchemaCreationRequest.php
@@ -32,6 +32,7 @@ final class StartSchemaCreationRequest extends Input
      *   apiId?: string,
      *   definition?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -46,6 +47,7 @@ final class StartSchemaCreationRequest extends Input
      *   apiId?: string,
      *   definition?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|StartSchemaCreationRequest $input
      */
     public static function create($input): self

--- a/src/Service/AppSync/src/Input/UpdateApiKeyRequest.php
+++ b/src/Service/AppSync/src/Input/UpdateApiKeyRequest.php
@@ -49,6 +49,7 @@ final class UpdateApiKeyRequest extends Input
      *   description?: string|null,
      *   expires?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -67,6 +68,7 @@ final class UpdateApiKeyRequest extends Input
      *   description?: string|null,
      *   expires?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|UpdateApiKeyRequest $input
      */
     public static function create($input): self

--- a/src/Service/AppSync/src/Input/UpdateDataSourceRequest.php
+++ b/src/Service/AppSync/src/Input/UpdateDataSourceRequest.php
@@ -139,6 +139,7 @@ final class UpdateDataSourceRequest extends Input
      *   eventBridgeConfig?: EventBridgeDataSourceConfig|array|null,
      *   metricsConfig?: DataSourceLevelMetricsConfig::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -175,6 +176,7 @@ final class UpdateDataSourceRequest extends Input
      *   eventBridgeConfig?: EventBridgeDataSourceConfig|array|null,
      *   metricsConfig?: DataSourceLevelMetricsConfig::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|UpdateDataSourceRequest $input
      */
     public static function create($input): self

--- a/src/Service/AppSync/src/Input/UpdateResolverRequest.php
+++ b/src/Service/AppSync/src/Input/UpdateResolverRequest.php
@@ -151,6 +151,7 @@ final class UpdateResolverRequest extends Input
      *   code?: string|null,
      *   metricsConfig?: ResolverLevelMetricsConfig::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -189,6 +190,7 @@ final class UpdateResolverRequest extends Input
      *   code?: string|null,
      *   metricsConfig?: ResolverLevelMetricsConfig::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|UpdateResolverRequest $input
      */
     public static function create($input): self

--- a/src/Service/Athena/composer.json
+++ b/src/Service/Athena/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.9",
+        "async-aws/core": "^1.30",
         "symfony/polyfill-uuid": "^1.13.1"
     },
     "require-dev": {

--- a/src/Service/Athena/src/Input/GetCalculationExecutionRequest.php
+++ b/src/Service/Athena/src/Input/GetCalculationExecutionRequest.php
@@ -22,6 +22,7 @@ final class GetCalculationExecutionRequest extends Input
      * @param array{
      *   CalculationExecutionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class GetCalculationExecutionRequest extends Input
      * @param array{
      *   CalculationExecutionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetCalculationExecutionRequest $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/GetCalculationExecutionStatusRequest.php
+++ b/src/Service/Athena/src/Input/GetCalculationExecutionStatusRequest.php
@@ -22,6 +22,7 @@ final class GetCalculationExecutionStatusRequest extends Input
      * @param array{
      *   CalculationExecutionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class GetCalculationExecutionStatusRequest extends Input
      * @param array{
      *   CalculationExecutionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetCalculationExecutionStatusRequest $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/GetDataCatalogInput.php
+++ b/src/Service/Athena/src/Input/GetDataCatalogInput.php
@@ -30,6 +30,7 @@ final class GetDataCatalogInput extends Input
      *   Name?: string,
      *   WorkGroup?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -44,6 +45,7 @@ final class GetDataCatalogInput extends Input
      *   Name?: string,
      *   WorkGroup?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetDataCatalogInput $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/GetDatabaseInput.php
+++ b/src/Service/Athena/src/Input/GetDatabaseInput.php
@@ -41,6 +41,7 @@ final class GetDatabaseInput extends Input
      *   DatabaseName?: string,
      *   WorkGroup?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -57,6 +58,7 @@ final class GetDatabaseInput extends Input
      *   DatabaseName?: string,
      *   WorkGroup?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetDatabaseInput $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/GetNamedQueryInput.php
+++ b/src/Service/Athena/src/Input/GetNamedQueryInput.php
@@ -22,6 +22,7 @@ final class GetNamedQueryInput extends Input
      * @param array{
      *   NamedQueryId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class GetNamedQueryInput extends Input
      * @param array{
      *   NamedQueryId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetNamedQueryInput $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/GetQueryExecutionInput.php
+++ b/src/Service/Athena/src/Input/GetQueryExecutionInput.php
@@ -22,6 +22,7 @@ final class GetQueryExecutionInput extends Input
      * @param array{
      *   QueryExecutionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class GetQueryExecutionInput extends Input
      * @param array{
      *   QueryExecutionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetQueryExecutionInput $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/GetQueryResultsInput.php
+++ b/src/Service/Athena/src/Input/GetQueryResultsInput.php
@@ -51,6 +51,7 @@ final class GetQueryResultsInput extends Input
      *   MaxResults?: int|null,
      *   QueryResultType?: QueryResultType::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -69,6 +70,7 @@ final class GetQueryResultsInput extends Input
      *   MaxResults?: int|null,
      *   QueryResultType?: QueryResultType::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetQueryResultsInput $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/GetSessionRequest.php
+++ b/src/Service/Athena/src/Input/GetSessionRequest.php
@@ -22,6 +22,7 @@ final class GetSessionRequest extends Input
      * @param array{
      *   SessionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class GetSessionRequest extends Input
      * @param array{
      *   SessionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetSessionRequest $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/GetSessionStatusRequest.php
+++ b/src/Service/Athena/src/Input/GetSessionStatusRequest.php
@@ -22,6 +22,7 @@ final class GetSessionStatusRequest extends Input
      * @param array{
      *   SessionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class GetSessionStatusRequest extends Input
      * @param array{
      *   SessionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetSessionStatusRequest $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/GetTableMetadataInput.php
+++ b/src/Service/Athena/src/Input/GetTableMetadataInput.php
@@ -51,6 +51,7 @@ final class GetTableMetadataInput extends Input
      *   TableName?: string,
      *   WorkGroup?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -69,6 +70,7 @@ final class GetTableMetadataInput extends Input
      *   TableName?: string,
      *   WorkGroup?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetTableMetadataInput $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/GetWorkGroupInput.php
+++ b/src/Service/Athena/src/Input/GetWorkGroupInput.php
@@ -22,6 +22,7 @@ final class GetWorkGroupInput extends Input
      * @param array{
      *   WorkGroup?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class GetWorkGroupInput extends Input
      * @param array{
      *   WorkGroup?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetWorkGroupInput $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/ListDatabasesInput.php
+++ b/src/Service/Athena/src/Input/ListDatabasesInput.php
@@ -49,6 +49,7 @@ final class ListDatabasesInput extends Input
      *   MaxResults?: int|null,
      *   WorkGroup?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -67,6 +68,7 @@ final class ListDatabasesInput extends Input
      *   MaxResults?: int|null,
      *   WorkGroup?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListDatabasesInput $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/ListNamedQueriesInput.php
+++ b/src/Service/Athena/src/Input/ListNamedQueriesInput.php
@@ -38,6 +38,7 @@ final class ListNamedQueriesInput extends Input
      *   MaxResults?: int|null,
      *   WorkGroup?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -54,6 +55,7 @@ final class ListNamedQueriesInput extends Input
      *   MaxResults?: int|null,
      *   WorkGroup?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListNamedQueriesInput $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/ListQueryExecutionsInput.php
+++ b/src/Service/Athena/src/Input/ListQueryExecutionsInput.php
@@ -38,6 +38,7 @@ final class ListQueryExecutionsInput extends Input
      *   MaxResults?: int|null,
      *   WorkGroup?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -54,6 +55,7 @@ final class ListQueryExecutionsInput extends Input
      *   MaxResults?: int|null,
      *   WorkGroup?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListQueryExecutionsInput $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/ListTableMetadataInput.php
+++ b/src/Service/Athena/src/Input/ListTableMetadataInput.php
@@ -66,6 +66,7 @@ final class ListTableMetadataInput extends Input
      *   MaxResults?: int|null,
      *   WorkGroup?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -88,6 +89,7 @@ final class ListTableMetadataInput extends Input
      *   MaxResults?: int|null,
      *   WorkGroup?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListTableMetadataInput $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/StartCalculationExecutionRequest.php
+++ b/src/Service/Athena/src/Input/StartCalculationExecutionRequest.php
@@ -62,6 +62,7 @@ final class StartCalculationExecutionRequest extends Input
      *   CodeBlock?: string|null,
      *   ClientRequestToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -82,6 +83,7 @@ final class StartCalculationExecutionRequest extends Input
      *   CodeBlock?: string|null,
      *   ClientRequestToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|StartCalculationExecutionRequest $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/StartQueryExecutionInput.php
+++ b/src/Service/Athena/src/Input/StartQueryExecutionInput.php
@@ -100,6 +100,7 @@ final class StartQueryExecutionInput extends Input
      *   ResultReuseConfiguration?: ResultReuseConfiguration|array|null,
      *   EngineConfiguration?: EngineConfiguration|array|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -126,6 +127,7 @@ final class StartQueryExecutionInput extends Input
      *   ResultReuseConfiguration?: ResultReuseConfiguration|array|null,
      *   EngineConfiguration?: EngineConfiguration|array|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|StartQueryExecutionInput $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/StartSessionRequest.php
+++ b/src/Service/Athena/src/Input/StartSessionRequest.php
@@ -110,6 +110,7 @@ final class StartSessionRequest extends Input
      *   Tags?: array<Tag|array>|null,
      *   CopyWorkGroupTags?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -140,6 +141,7 @@ final class StartSessionRequest extends Input
      *   Tags?: array<Tag|array>|null,
      *   CopyWorkGroupTags?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|StartSessionRequest $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/StopCalculationExecutionRequest.php
+++ b/src/Service/Athena/src/Input/StopCalculationExecutionRequest.php
@@ -22,6 +22,7 @@ final class StopCalculationExecutionRequest extends Input
      * @param array{
      *   CalculationExecutionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class StopCalculationExecutionRequest extends Input
      * @param array{
      *   CalculationExecutionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|StopCalculationExecutionRequest $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/StopQueryExecutionInput.php
+++ b/src/Service/Athena/src/Input/StopQueryExecutionInput.php
@@ -21,6 +21,7 @@ final class StopQueryExecutionInput extends Input
      * @param array{
      *   QueryExecutionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -33,6 +34,7 @@ final class StopQueryExecutionInput extends Input
      * @param array{
      *   QueryExecutionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|StopQueryExecutionInput $input
      */
     public static function create($input): self

--- a/src/Service/Athena/src/Input/TerminateSessionRequest.php
+++ b/src/Service/Athena/src/Input/TerminateSessionRequest.php
@@ -22,6 +22,7 @@ final class TerminateSessionRequest extends Input
      * @param array{
      *   SessionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class TerminateSessionRequest extends Input
      * @param array{
      *   SessionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|TerminateSessionRequest $input
      */
     public static function create($input): self

--- a/src/Service/BedrockAgent/composer.json
+++ b/src/Service/BedrockAgent/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.9",
+        "async-aws/core": "^1.30",
         "symfony/polyfill-uuid": "^1.13.1"
     },
     "require-dev": {

--- a/src/Service/BedrockAgent/src/Input/DeleteKnowledgeBaseDocumentsRequest.php
+++ b/src/Service/BedrockAgent/src/Input/DeleteKnowledgeBaseDocumentsRequest.php
@@ -55,6 +55,7 @@ final class DeleteKnowledgeBaseDocumentsRequest extends Input
      *   clientToken?: string|null,
      *   documentIdentifiers?: array<DocumentIdentifier|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -73,6 +74,7 @@ final class DeleteKnowledgeBaseDocumentsRequest extends Input
      *   clientToken?: string|null,
      *   documentIdentifiers?: array<DocumentIdentifier|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteKnowledgeBaseDocumentsRequest $input
      */
     public static function create($input): self

--- a/src/Service/BedrockAgent/src/Input/GetKnowledgeBaseDocumentsRequest.php
+++ b/src/Service/BedrockAgent/src/Input/GetKnowledgeBaseDocumentsRequest.php
@@ -43,6 +43,7 @@ final class GetKnowledgeBaseDocumentsRequest extends Input
      *   dataSourceId?: string,
      *   documentIdentifiers?: array<DocumentIdentifier|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -59,6 +60,7 @@ final class GetKnowledgeBaseDocumentsRequest extends Input
      *   dataSourceId?: string,
      *   documentIdentifiers?: array<DocumentIdentifier|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetKnowledgeBaseDocumentsRequest $input
      */
     public static function create($input): self

--- a/src/Service/BedrockAgent/src/Input/IngestKnowledgeBaseDocumentsRequest.php
+++ b/src/Service/BedrockAgent/src/Input/IngestKnowledgeBaseDocumentsRequest.php
@@ -55,6 +55,7 @@ final class IngestKnowledgeBaseDocumentsRequest extends Input
      *   clientToken?: string|null,
      *   documents?: array<KnowledgeBaseDocument|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -73,6 +74,7 @@ final class IngestKnowledgeBaseDocumentsRequest extends Input
      *   clientToken?: string|null,
      *   documents?: array<KnowledgeBaseDocument|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|IngestKnowledgeBaseDocumentsRequest $input
      */
     public static function create($input): self

--- a/src/Service/BedrockAgent/src/Input/ListKnowledgeBaseDocumentsRequest.php
+++ b/src/Service/BedrockAgent/src/Input/ListKnowledgeBaseDocumentsRequest.php
@@ -51,6 +51,7 @@ final class ListKnowledgeBaseDocumentsRequest extends Input
      *   maxResults?: int|null,
      *   nextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -69,6 +70,7 @@ final class ListKnowledgeBaseDocumentsRequest extends Input
      *   maxResults?: int|null,
      *   nextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListKnowledgeBaseDocumentsRequest $input
      */
     public static function create($input): self

--- a/src/Service/BedrockRuntime/composer.json
+++ b/src/Service/BedrockRuntime/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/BedrockRuntime/src/Input/InvokeModelRequest.php
+++ b/src/Service/BedrockRuntime/src/Input/InvokeModelRequest.php
@@ -123,6 +123,7 @@ final class InvokeModelRequest extends Input
      *   performanceConfigLatency?: PerformanceConfigLatency::*|null,
      *   serviceTier?: ServiceTierType::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -151,6 +152,7 @@ final class InvokeModelRequest extends Input
      *   performanceConfigLatency?: PerformanceConfigLatency::*|null,
      *   serviceTier?: ServiceTierType::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|InvokeModelRequest $input
      */
     public static function create($input): self

--- a/src/Service/CloudFormation/composer.json
+++ b/src/Service/CloudFormation/composer.json
@@ -14,7 +14,7 @@
         "php": "^8.2",
         "ext-filter": "*",
         "ext-simplexml": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/CloudFormation/src/Input/DescribeStackDriftDetectionStatusInput.php
+++ b/src/Service/CloudFormation/src/Input/DescribeStackDriftDetectionStatusInput.php
@@ -25,6 +25,7 @@ final class DescribeStackDriftDetectionStatusInput extends Input
      * @param array{
      *   StackDriftDetectionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -37,6 +38,7 @@ final class DescribeStackDriftDetectionStatusInput extends Input
      * @param array{
      *   StackDriftDetectionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DescribeStackDriftDetectionStatusInput $input
      */
     public static function create($input): self

--- a/src/Service/CloudFormation/src/Input/DescribeStackEventsInput.php
+++ b/src/Service/CloudFormation/src/Input/DescribeStackEventsInput.php
@@ -36,6 +36,7 @@ final class DescribeStackEventsInput extends Input
      *   StackName?: string,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -50,6 +51,7 @@ final class DescribeStackEventsInput extends Input
      *   StackName?: string,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DescribeStackEventsInput $input
      */
     public static function create($input): self

--- a/src/Service/CloudFormation/src/Input/DescribeStacksInput.php
+++ b/src/Service/CloudFormation/src/Input/DescribeStacksInput.php
@@ -44,6 +44,7 @@ final class DescribeStacksInput extends Input
      *   StackName?: string|null,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -58,6 +59,7 @@ final class DescribeStacksInput extends Input
      *   StackName?: string|null,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DescribeStacksInput $input
      */
     public static function create($input): self

--- a/src/Service/CloudFormation/src/Input/ListExportsInput.php
+++ b/src/Service/CloudFormation/src/Input/ListExportsInput.php
@@ -19,6 +19,7 @@ final class ListExportsInput extends Input
      * @param array{
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -31,6 +32,7 @@ final class ListExportsInput extends Input
      * @param array{
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListExportsInput $input
      */
     public static function create($input): self

--- a/src/Service/CloudFront/composer.json
+++ b/src/Service/CloudFront/composer.json
@@ -14,7 +14,7 @@
         "php": "^8.2",
         "ext-dom": "*",
         "ext-simplexml": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/CloudFront/src/Input/CreateInvalidationRequest.php
+++ b/src/Service/CloudFront/src/Input/CreateInvalidationRequest.php
@@ -36,6 +36,7 @@ final class CreateInvalidationRequest extends Input
      *   DistributionId?: string,
      *   InvalidationBatch?: InvalidationBatch|array,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -50,6 +51,7 @@ final class CreateInvalidationRequest extends Input
      *   DistributionId?: string,
      *   InvalidationBatch?: InvalidationBatch|array,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateInvalidationRequest $input
      */
     public static function create($input): self

--- a/src/Service/CloudWatch/composer.json
+++ b/src/Service/CloudWatch/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/CloudWatch/src/Input/GetMetricDataInput.php
+++ b/src/Service/CloudWatch/src/Input/GetMetricDataInput.php
@@ -113,6 +113,7 @@ final class GetMetricDataInput extends Input
      *   MaxDatapoints?: int|null,
      *   LabelOptions?: LabelOptions|array|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -137,6 +138,7 @@ final class GetMetricDataInput extends Input
      *   MaxDatapoints?: int|null,
      *   LabelOptions?: LabelOptions|array|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetMetricDataInput $input
      */
     public static function create($input): self

--- a/src/Service/CloudWatch/src/Input/GetMetricStatisticsInput.php
+++ b/src/Service/CloudWatch/src/Input/GetMetricStatisticsInput.php
@@ -142,6 +142,7 @@ final class GetMetricStatisticsInput extends Input
      *   ExtendedStatistics?: string[]|null,
      *   Unit?: StandardUnit::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -170,6 +171,7 @@ final class GetMetricStatisticsInput extends Input
      *   ExtendedStatistics?: string[]|null,
      *   Unit?: StandardUnit::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetMetricStatisticsInput $input
      */
     public static function create($input): self

--- a/src/Service/CloudWatch/src/Input/ListMetricsInput.php
+++ b/src/Service/CloudWatch/src/Input/ListMetricsInput.php
@@ -80,6 +80,7 @@ final class ListMetricsInput extends Input
      *   IncludeLinkedAccounts?: bool|null,
      *   OwningAccount?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -104,6 +105,7 @@ final class ListMetricsInput extends Input
      *   IncludeLinkedAccounts?: bool|null,
      *   OwningAccount?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListMetricsInput $input
      */
     public static function create($input): self

--- a/src/Service/CloudWatch/src/Input/PutMetricDataInput.php
+++ b/src/Service/CloudWatch/src/Input/PutMetricDataInput.php
@@ -82,6 +82,7 @@ final class PutMetricDataInput extends Input
      *   EntityMetricData?: array<EntityMetricData|array>|null,
      *   StrictEntityValidation?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -100,6 +101,7 @@ final class PutMetricDataInput extends Input
      *   EntityMetricData?: array<EntityMetricData|array>|null,
      *   StrictEntityValidation?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutMetricDataInput $input
      */
     public static function create($input): self

--- a/src/Service/CloudWatchLogs/composer.json
+++ b/src/Service/CloudWatchLogs/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/CloudWatchLogs/src/Input/CreateLogGroupRequest.php
+++ b/src/Service/CloudWatchLogs/src/Input/CreateLogGroupRequest.php
@@ -83,6 +83,7 @@ final class CreateLogGroupRequest extends Input
      *   logGroupClass?: LogGroupClass::*|null,
      *   deletionProtectionEnabled?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -103,6 +104,7 @@ final class CreateLogGroupRequest extends Input
      *   logGroupClass?: LogGroupClass::*|null,
      *   deletionProtectionEnabled?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateLogGroupRequest $input
      */
     public static function create($input): self

--- a/src/Service/CloudWatchLogs/src/Input/CreateLogStreamRequest.php
+++ b/src/Service/CloudWatchLogs/src/Input/CreateLogStreamRequest.php
@@ -32,6 +32,7 @@ final class CreateLogStreamRequest extends Input
      *   logGroupName?: string,
      *   logStreamName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -46,6 +47,7 @@ final class CreateLogStreamRequest extends Input
      *   logGroupName?: string,
      *   logStreamName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateLogStreamRequest $input
      */
     public static function create($input): self

--- a/src/Service/CloudWatchLogs/src/Input/DescribeLogGroupsRequest.php
+++ b/src/Service/CloudWatchLogs/src/Input/DescribeLogGroupsRequest.php
@@ -112,6 +112,7 @@ final class DescribeLogGroupsRequest extends Input
      *   logGroupClass?: LogGroupClass::*|null,
      *   logGroupIdentifiers?: string[]|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -138,6 +139,7 @@ final class DescribeLogGroupsRequest extends Input
      *   logGroupClass?: LogGroupClass::*|null,
      *   logGroupIdentifiers?: string[]|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DescribeLogGroupsRequest $input
      */
     public static function create($input): self

--- a/src/Service/CloudWatchLogs/src/Input/DescribeLogStreamsRequest.php
+++ b/src/Service/CloudWatchLogs/src/Input/DescribeLogStreamsRequest.php
@@ -85,6 +85,7 @@ final class DescribeLogStreamsRequest extends Input
      *   nextToken?: string|null,
      *   limit?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -109,6 +110,7 @@ final class DescribeLogStreamsRequest extends Input
      *   nextToken?: string|null,
      *   limit?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DescribeLogStreamsRequest $input
      */
     public static function create($input): self

--- a/src/Service/CloudWatchLogs/src/Input/FilterLogEventsRequest.php
+++ b/src/Service/CloudWatchLogs/src/Input/FilterLogEventsRequest.php
@@ -123,6 +123,7 @@ final class FilterLogEventsRequest extends Input
      *   interleaved?: bool|null,
      *   unmask?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -155,6 +156,7 @@ final class FilterLogEventsRequest extends Input
      *   interleaved?: bool|null,
      *   unmask?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|FilterLogEventsRequest $input
      */
     public static function create($input): self

--- a/src/Service/CloudWatchLogs/src/Input/PutLogEventsRequest.php
+++ b/src/Service/CloudWatchLogs/src/Input/PutLogEventsRequest.php
@@ -64,6 +64,7 @@ final class PutLogEventsRequest extends Input
      *   sequenceToken?: string|null,
      *   entity?: Entity|array|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -84,6 +85,7 @@ final class PutLogEventsRequest extends Input
      *   sequenceToken?: string|null,
      *   entity?: Entity|array|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutLogEventsRequest $input
      */
     public static function create($input): self

--- a/src/Service/CodeBuild/composer.json
+++ b/src/Service/CodeBuild/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/CodeBuild/src/Input/BatchGetBuildsInput.php
+++ b/src/Service/CodeBuild/src/Input/BatchGetBuildsInput.php
@@ -22,6 +22,7 @@ final class BatchGetBuildsInput extends Input
      * @param array{
      *   ids?: string[],
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class BatchGetBuildsInput extends Input
      * @param array{
      *   ids?: string[],
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|BatchGetBuildsInput $input
      */
     public static function create($input): self

--- a/src/Service/CodeBuild/src/Input/StartBuildInput.php
+++ b/src/Service/CodeBuild/src/Input/StartBuildInput.php
@@ -382,6 +382,7 @@ final class StartBuildInput extends Input
      *   fleetOverride?: ProjectFleet|array|null,
      *   autoRetryLimitOverride?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -458,6 +459,7 @@ final class StartBuildInput extends Input
      *   fleetOverride?: ProjectFleet|array|null,
      *   autoRetryLimitOverride?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|StartBuildInput $input
      */
     public static function create($input): self

--- a/src/Service/CodeBuild/src/Input/StopBuildInput.php
+++ b/src/Service/CodeBuild/src/Input/StopBuildInput.php
@@ -22,6 +22,7 @@ final class StopBuildInput extends Input
      * @param array{
      *   id?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class StopBuildInput extends Input
      * @param array{
      *   id?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|StopBuildInput $input
      */
     public static function create($input): self

--- a/src/Service/CodeCommit/composer.json
+++ b/src/Service/CodeCommit/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/CodeCommit/src/Input/CreateRepositoryInput.php
+++ b/src/Service/CodeCommit/src/Input/CreateRepositoryInput.php
@@ -67,6 +67,7 @@ final class CreateRepositoryInput extends Input
      *   tags?: array<string, string>|null,
      *   kmsKeyId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -85,6 +86,7 @@ final class CreateRepositoryInput extends Input
      *   tags?: array<string, string>|null,
      *   kmsKeyId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateRepositoryInput $input
      */
     public static function create($input): self

--- a/src/Service/CodeCommit/src/Input/DeleteRepositoryInput.php
+++ b/src/Service/CodeCommit/src/Input/DeleteRepositoryInput.php
@@ -25,6 +25,7 @@ final class DeleteRepositoryInput extends Input
      * @param array{
      *   repositoryName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -37,6 +38,7 @@ final class DeleteRepositoryInput extends Input
      * @param array{
      *   repositoryName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteRepositoryInput $input
      */
     public static function create($input): self

--- a/src/Service/CodeCommit/src/Input/GetBlobInput.php
+++ b/src/Service/CodeCommit/src/Input/GetBlobInput.php
@@ -35,6 +35,7 @@ final class GetBlobInput extends Input
      *   repositoryName?: string,
      *   blobId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -49,6 +50,7 @@ final class GetBlobInput extends Input
      *   repositoryName?: string,
      *   blobId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetBlobInput $input
      */
     public static function create($input): self

--- a/src/Service/CodeCommit/src/Input/GetBranchInput.php
+++ b/src/Service/CodeCommit/src/Input/GetBranchInput.php
@@ -30,6 +30,7 @@ final class GetBranchInput extends Input
      *   repositoryName?: string|null,
      *   branchName?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -44,6 +45,7 @@ final class GetBranchInput extends Input
      *   repositoryName?: string|null,
      *   branchName?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetBranchInput $input
      */
     public static function create($input): self

--- a/src/Service/CodeCommit/src/Input/GetCommitInput.php
+++ b/src/Service/CodeCommit/src/Input/GetCommitInput.php
@@ -35,6 +35,7 @@ final class GetCommitInput extends Input
      *   repositoryName?: string,
      *   commitId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -49,6 +50,7 @@ final class GetCommitInput extends Input
      *   repositoryName?: string,
      *   commitId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetCommitInput $input
      */
     public static function create($input): self

--- a/src/Service/CodeCommit/src/Input/GetDifferencesInput.php
+++ b/src/Service/CodeCommit/src/Input/GetDifferencesInput.php
@@ -77,6 +77,7 @@ final class GetDifferencesInput extends Input
      *   MaxResults?: int|null,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -101,6 +102,7 @@ final class GetDifferencesInput extends Input
      *   MaxResults?: int|null,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetDifferencesInput $input
      */
     public static function create($input): self

--- a/src/Service/CodeCommit/src/Input/ListRepositoriesInput.php
+++ b/src/Service/CodeCommit/src/Input/ListRepositoriesInput.php
@@ -43,6 +43,7 @@ final class ListRepositoriesInput extends Input
      *   sortBy?: SortByEnum::*|null,
      *   order?: OrderEnum::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -59,6 +60,7 @@ final class ListRepositoriesInput extends Input
      *   sortBy?: SortByEnum::*|null,
      *   order?: OrderEnum::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListRepositoriesInput $input
      */
     public static function create($input): self

--- a/src/Service/CodeCommit/src/Input/PutRepositoryTriggersInput.php
+++ b/src/Service/CodeCommit/src/Input/PutRepositoryTriggersInput.php
@@ -36,6 +36,7 @@ final class PutRepositoryTriggersInput extends Input
      *   repositoryName?: string,
      *   triggers?: array<RepositoryTrigger|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -50,6 +51,7 @@ final class PutRepositoryTriggersInput extends Input
      *   repositoryName?: string,
      *   triggers?: array<RepositoryTrigger|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutRepositoryTriggersInput $input
      */
     public static function create($input): self

--- a/src/Service/CodeDeploy/composer.json
+++ b/src/Service/CodeDeploy/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/CodeDeploy/src/Input/CreateDeploymentInput.php
+++ b/src/Service/CodeDeploy/src/Input/CreateDeploymentInput.php
@@ -147,6 +147,7 @@ final class CreateDeploymentInput extends Input
      *   fileExistsBehavior?: FileExistsBehavior::*|null,
      *   overrideAlarmConfiguration?: AlarmConfiguration|array|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -179,6 +180,7 @@ final class CreateDeploymentInput extends Input
      *   fileExistsBehavior?: FileExistsBehavior::*|null,
      *   overrideAlarmConfiguration?: AlarmConfiguration|array|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateDeploymentInput $input
      */
     public static function create($input): self

--- a/src/Service/CodeDeploy/src/Input/GetDeploymentInput.php
+++ b/src/Service/CodeDeploy/src/Input/GetDeploymentInput.php
@@ -25,6 +25,7 @@ final class GetDeploymentInput extends Input
      * @param array{
      *   deploymentId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -37,6 +38,7 @@ final class GetDeploymentInput extends Input
      * @param array{
      *   deploymentId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetDeploymentInput $input
      */
     public static function create($input): self

--- a/src/Service/CodeDeploy/src/Input/PutLifecycleEventHookExecutionStatusInput.php
+++ b/src/Service/CodeDeploy/src/Input/PutLifecycleEventHookExecutionStatusInput.php
@@ -40,6 +40,7 @@ final class PutLifecycleEventHookExecutionStatusInput extends Input
      *   lifecycleEventHookExecutionId?: string|null,
      *   status?: LifecycleEventStatus::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -56,6 +57,7 @@ final class PutLifecycleEventHookExecutionStatusInput extends Input
      *   lifecycleEventHookExecutionId?: string|null,
      *   status?: LifecycleEventStatus::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutLifecycleEventHookExecutionStatusInput $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/composer.json
+++ b/src/Service/CognitoIdentityProvider/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminAddUserToGroupRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminAddUserToGroupRequest.php
@@ -44,6 +44,7 @@ final class AdminAddUserToGroupRequest extends Input
      *   Username?: string,
      *   GroupName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -60,6 +61,7 @@ final class AdminAddUserToGroupRequest extends Input
      *   Username?: string,
      *   GroupName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AdminAddUserToGroupRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminConfirmSignUpRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminConfirmSignUpRequest.php
@@ -65,6 +65,7 @@ final class AdminConfirmSignUpRequest extends Input
      *   Username?: string,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -81,6 +82,7 @@ final class AdminConfirmSignUpRequest extends Input
      *   Username?: string,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AdminConfirmSignUpRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminCreateUserRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminCreateUserRequest.php
@@ -186,6 +186,7 @@ final class AdminCreateUserRequest extends Input
      *   DesiredDeliveryMediums?: array<DeliveryMediumType::*>|null,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -214,6 +215,7 @@ final class AdminCreateUserRequest extends Input
      *   DesiredDeliveryMediums?: array<DeliveryMediumType::*>|null,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AdminCreateUserRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminDeleteUserRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminDeleteUserRequest.php
@@ -37,6 +37,7 @@ final class AdminDeleteUserRequest extends Input
      *   UserPoolId?: string,
      *   Username?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -51,6 +52,7 @@ final class AdminDeleteUserRequest extends Input
      *   UserPoolId?: string,
      *   Username?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AdminDeleteUserRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminDisableUserRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminDisableUserRequest.php
@@ -37,6 +37,7 @@ final class AdminDisableUserRequest extends Input
      *   UserPoolId?: string,
      *   Username?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -51,6 +52,7 @@ final class AdminDisableUserRequest extends Input
      *   UserPoolId?: string,
      *   Username?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AdminDisableUserRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminEnableUserRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminEnableUserRequest.php
@@ -37,6 +37,7 @@ final class AdminEnableUserRequest extends Input
      *   UserPoolId?: string,
      *   Username?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -51,6 +52,7 @@ final class AdminEnableUserRequest extends Input
      *   UserPoolId?: string,
      *   Username?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AdminEnableUserRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminGetUserRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminGetUserRequest.php
@@ -37,6 +37,7 @@ final class AdminGetUserRequest extends Input
      *   UserPoolId?: string,
      *   Username?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -51,6 +52,7 @@ final class AdminGetUserRequest extends Input
      *   UserPoolId?: string,
      *   Username?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AdminGetUserRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminInitiateAuthRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminInitiateAuthRequest.php
@@ -201,6 +201,7 @@ final class AdminInitiateAuthRequest extends Input
      *   ContextData?: ContextDataType|array|null,
      *   Session?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -227,6 +228,7 @@ final class AdminInitiateAuthRequest extends Input
      *   ContextData?: ContextDataType|array|null,
      *   Session?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AdminInitiateAuthRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminRemoveUserFromGroupRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminRemoveUserFromGroupRequest.php
@@ -44,6 +44,7 @@ final class AdminRemoveUserFromGroupRequest extends Input
      *   Username?: string,
      *   GroupName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -60,6 +61,7 @@ final class AdminRemoveUserFromGroupRequest extends Input
      *   Username?: string,
      *   GroupName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AdminRemoveUserFromGroupRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminResetUserPasswordRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminResetUserPasswordRequest.php
@@ -65,6 +65,7 @@ final class AdminResetUserPasswordRequest extends Input
      *   Username?: string,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -81,6 +82,7 @@ final class AdminResetUserPasswordRequest extends Input
      *   Username?: string,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AdminResetUserPasswordRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminSetUserPasswordRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminSetUserPasswordRequest.php
@@ -55,6 +55,7 @@ final class AdminSetUserPasswordRequest extends Input
      *   Password?: string,
      *   Permanent?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -73,6 +74,7 @@ final class AdminSetUserPasswordRequest extends Input
      *   Password?: string,
      *   Permanent?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AdminSetUserPasswordRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminUpdateUserAttributesRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminUpdateUserAttributesRequest.php
@@ -88,6 +88,7 @@ final class AdminUpdateUserAttributesRequest extends Input
      *   UserAttributes?: array<AttributeType|array>,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -106,6 +107,7 @@ final class AdminUpdateUserAttributesRequest extends Input
      *   UserAttributes?: array<AttributeType|array>,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AdminUpdateUserAttributesRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/AdminUserGlobalSignOutRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AdminUserGlobalSignOutRequest.php
@@ -37,6 +37,7 @@ final class AdminUserGlobalSignOutRequest extends Input
      *   UserPoolId?: string,
      *   Username?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -51,6 +52,7 @@ final class AdminUserGlobalSignOutRequest extends Input
      *   UserPoolId?: string,
      *   Username?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AdminUserGlobalSignOutRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/AssociateSoftwareTokenRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/AssociateSoftwareTokenRequest.php
@@ -32,6 +32,7 @@ final class AssociateSoftwareTokenRequest extends Input
      *   AccessToken?: string|null,
      *   Session?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -46,6 +47,7 @@ final class AssociateSoftwareTokenRequest extends Input
      *   AccessToken?: string|null,
      *   Session?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AssociateSoftwareTokenRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/ChangePasswordRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/ChangePasswordRequest.php
@@ -44,6 +44,7 @@ final class ChangePasswordRequest extends Input
      *   ProposedPassword?: string,
      *   AccessToken?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -60,6 +61,7 @@ final class ChangePasswordRequest extends Input
      *   ProposedPassword?: string,
      *   AccessToken?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ChangePasswordRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/ConfirmForgotPasswordRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/ConfirmForgotPasswordRequest.php
@@ -124,6 +124,7 @@ final class ConfirmForgotPasswordRequest extends Input
      *   UserContextData?: UserContextDataType|array|null,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -150,6 +151,7 @@ final class ConfirmForgotPasswordRequest extends Input
      *   UserContextData?: UserContextDataType|array|null,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ConfirmForgotPasswordRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/ConfirmSignUpRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/ConfirmSignUpRequest.php
@@ -142,6 +142,7 @@ final class ConfirmSignUpRequest extends Input
      *   ClientMetadata?: array<string, string>|null,
      *   Session?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -170,6 +171,7 @@ final class ConfirmSignUpRequest extends Input
      *   ClientMetadata?: array<string, string>|null,
      *   Session?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ConfirmSignUpRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/CreateGroupRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/CreateGroupRequest.php
@@ -70,6 +70,7 @@ final class CreateGroupRequest extends Input
      *   RoleArn?: string|null,
      *   Precedence?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -90,6 +91,7 @@ final class CreateGroupRequest extends Input
      *   RoleArn?: string|null,
      *   Precedence?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateGroupRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/ForgotPasswordRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/ForgotPasswordRequest.php
@@ -102,6 +102,7 @@ final class ForgotPasswordRequest extends Input
      *   AnalyticsMetadata?: AnalyticsMetadataType|array|null,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -124,6 +125,7 @@ final class ForgotPasswordRequest extends Input
      *   AnalyticsMetadata?: AnalyticsMetadataType|array|null,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ForgotPasswordRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/GetUserRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/GetUserRequest.php
@@ -26,6 +26,7 @@ final class GetUserRequest extends Input
      * @param array{
      *   AccessToken?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -38,6 +39,7 @@ final class GetUserRequest extends Input
      * @param array{
      *   AccessToken?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetUserRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/InitiateAuthRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/InitiateAuthRequest.php
@@ -196,6 +196,7 @@ final class InitiateAuthRequest extends Input
      *   UserContextData?: UserContextDataType|array|null,
      *   Session?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -220,6 +221,7 @@ final class InitiateAuthRequest extends Input
      *   UserContextData?: UserContextDataType|array|null,
      *   Session?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|InitiateAuthRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/ListGroupsRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/ListGroupsRequest.php
@@ -41,6 +41,7 @@ final class ListGroupsRequest extends Input
      *   Limit?: int|null,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -57,6 +58,7 @@ final class ListGroupsRequest extends Input
      *   Limit?: int|null,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListGroupsRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/ListUsersRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/ListUsersRequest.php
@@ -109,6 +109,7 @@ final class ListUsersRequest extends Input
      *   PaginationToken?: string|null,
      *   Filter?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -129,6 +130,7 @@ final class ListUsersRequest extends Input
      *   PaginationToken?: string|null,
      *   Filter?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListUsersRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/ResendConfirmationCodeRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/ResendConfirmationCodeRequest.php
@@ -102,6 +102,7 @@ final class ResendConfirmationCodeRequest extends Input
      *   AnalyticsMetadata?: AnalyticsMetadataType|array|null,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -124,6 +125,7 @@ final class ResendConfirmationCodeRequest extends Input
      *   AnalyticsMetadata?: AnalyticsMetadataType|array|null,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ResendConfirmationCodeRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/RespondToAuthChallengeRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/RespondToAuthChallengeRequest.php
@@ -270,6 +270,7 @@ final class RespondToAuthChallengeRequest extends Input
      *   UserContextData?: UserContextDataType|array|null,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -294,6 +295,7 @@ final class RespondToAuthChallengeRequest extends Input
      *   UserContextData?: UserContextDataType|array|null,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|RespondToAuthChallengeRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/RevokeTokenRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/RevokeTokenRequest.php
@@ -40,6 +40,7 @@ final class RevokeTokenRequest extends Input
      *   ClientId?: string,
      *   ClientSecret?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -56,6 +57,7 @@ final class RevokeTokenRequest extends Input
      *   ClientId?: string,
      *   ClientSecret?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|RevokeTokenRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/SetUserMFAPreferenceRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/SetUserMFAPreferenceRequest.php
@@ -72,6 +72,7 @@ final class SetUserMFAPreferenceRequest extends Input
      *   WebAuthnMfaSettings?: WebAuthnMfaSettingsType|array|null,
      *   AccessToken?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -92,6 +93,7 @@ final class SetUserMFAPreferenceRequest extends Input
      *   WebAuthnMfaSettings?: WebAuthnMfaSettingsType|array|null,
      *   AccessToken?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|SetUserMFAPreferenceRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/SignUpRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/SignUpRequest.php
@@ -143,6 +143,7 @@ final class SignUpRequest extends Input
      *   UserContextData?: UserContextDataType|array|null,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -171,6 +172,7 @@ final class SignUpRequest extends Input
      *   UserContextData?: UserContextDataType|array|null,
      *   ClientMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|SignUpRequest $input
      */
     public static function create($input): self

--- a/src/Service/CognitoIdentityProvider/src/Input/VerifySoftwareTokenRequest.php
+++ b/src/Service/CognitoIdentityProvider/src/Input/VerifySoftwareTokenRequest.php
@@ -47,6 +47,7 @@ final class VerifySoftwareTokenRequest extends Input
      *   UserCode?: string,
      *   FriendlyDeviceName?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -65,6 +66,7 @@ final class VerifySoftwareTokenRequest extends Input
      *   UserCode?: string,
      *   FriendlyDeviceName?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|VerifySoftwareTokenRequest $input
      */
     public static function create($input): self

--- a/src/Service/Comprehend/composer.json
+++ b/src/Service/Comprehend/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/Comprehend/src/Input/DetectDominantLanguageRequest.php
+++ b/src/Service/Comprehend/src/Input/DetectDominantLanguageRequest.php
@@ -22,6 +22,7 @@ final class DetectDominantLanguageRequest extends Input
      * @param array{
      *   Text?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class DetectDominantLanguageRequest extends Input
      * @param array{
      *   Text?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DetectDominantLanguageRequest $input
      */
     public static function create($input): self

--- a/src/Service/DynamoDb/composer.json
+++ b/src/Service/DynamoDb/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.16",
+        "async-aws/core": "^1.30",
         "symfony/polyfill-uuid": "^1.13.1"
     },
     "require-dev": {

--- a/src/Service/DynamoDb/src/Input/BatchGetItemInput.php
+++ b/src/Service/DynamoDb/src/Input/BatchGetItemInput.php
@@ -84,6 +84,7 @@ final class BatchGetItemInput extends Input
      *   RequestItems?: array<string, KeysAndAttributes|array>,
      *   ReturnConsumedCapacity?: ReturnConsumedCapacity::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -103,6 +104,7 @@ final class BatchGetItemInput extends Input
      *   RequestItems?: array<string, KeysAndAttributes|array>,
      *   ReturnConsumedCapacity?: ReturnConsumedCapacity::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|BatchGetItemInput $input
      */
     public static function create($input): self

--- a/src/Service/DynamoDb/src/Input/BatchWriteItemInput.php
+++ b/src/Service/DynamoDb/src/Input/BatchWriteItemInput.php
@@ -64,6 +64,7 @@ final class BatchWriteItemInput extends Input
      *   ReturnConsumedCapacity?: ReturnConsumedCapacity::*|null,
      *   ReturnItemCollectionMetrics?: ReturnItemCollectionMetrics::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -85,6 +86,7 @@ final class BatchWriteItemInput extends Input
      *   ReturnConsumedCapacity?: ReturnConsumedCapacity::*|null,
      *   ReturnItemCollectionMetrics?: ReturnItemCollectionMetrics::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|BatchWriteItemInput $input
      */
     public static function create($input): self

--- a/src/Service/DynamoDb/src/Input/CreateTableInput.php
+++ b/src/Service/DynamoDb/src/Input/CreateTableInput.php
@@ -287,6 +287,7 @@ final class CreateTableInput extends Input
      *   GlobalTableSourceArn?: string|null,
      *   GlobalTableSettingsReplicationMode?: GlobalTableSettingsReplicationMode::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -331,6 +332,7 @@ final class CreateTableInput extends Input
      *   GlobalTableSourceArn?: string|null,
      *   GlobalTableSettingsReplicationMode?: GlobalTableSettingsReplicationMode::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateTableInput $input
      */
     public static function create($input): self

--- a/src/Service/DynamoDb/src/Input/DeleteItemInput.php
+++ b/src/Service/DynamoDb/src/Input/DeleteItemInput.php
@@ -199,6 +199,7 @@ final class DeleteItemInput extends Input
      *   ExpressionAttributeValues?: array<string, AttributeValue|array>|null,
      *   ReturnValuesOnConditionCheckFailure?: ReturnValuesOnConditionCheckFailure::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -249,6 +250,7 @@ final class DeleteItemInput extends Input
      *   ExpressionAttributeValues?: array<string, AttributeValue|array>|null,
      *   ReturnValuesOnConditionCheckFailure?: ReturnValuesOnConditionCheckFailure::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteItemInput $input
      */
     public static function create($input): self

--- a/src/Service/DynamoDb/src/Input/DeleteTableInput.php
+++ b/src/Service/DynamoDb/src/Input/DeleteTableInput.php
@@ -25,6 +25,7 @@ final class DeleteTableInput extends Input
      * @param array{
      *   TableName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -37,6 +38,7 @@ final class DeleteTableInput extends Input
      * @param array{
      *   TableName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteTableInput $input
      */
     public static function create($input): self

--- a/src/Service/DynamoDb/src/Input/DescribeEndpointsRequest.php
+++ b/src/Service/DynamoDb/src/Input/DescribeEndpointsRequest.php
@@ -11,6 +11,7 @@ final class DescribeEndpointsRequest extends Input
     /**
      * @param array{
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -21,6 +22,7 @@ final class DescribeEndpointsRequest extends Input
     /**
      * @param array{
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DescribeEndpointsRequest $input
      */
     public static function create($input): self

--- a/src/Service/DynamoDb/src/Input/DescribeTableInput.php
+++ b/src/Service/DynamoDb/src/Input/DescribeTableInput.php
@@ -26,6 +26,7 @@ final class DescribeTableInput extends Input
      * @param array{
      *   TableName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -38,6 +39,7 @@ final class DescribeTableInput extends Input
      * @param array{
      *   TableName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DescribeTableInput $input
      */
     public static function create($input): self

--- a/src/Service/DynamoDb/src/Input/ExecuteStatementInput.php
+++ b/src/Service/DynamoDb/src/Input/ExecuteStatementInput.php
@@ -81,6 +81,7 @@ final class ExecuteStatementInput extends Input
      *   Limit?: int|null,
      *   ReturnValuesOnConditionCheckFailure?: ReturnValuesOnConditionCheckFailure::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -105,6 +106,7 @@ final class ExecuteStatementInput extends Input
      *   Limit?: int|null,
      *   ReturnValuesOnConditionCheckFailure?: ReturnValuesOnConditionCheckFailure::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ExecuteStatementInput $input
      */
     public static function create($input): self

--- a/src/Service/DynamoDb/src/Input/GetItemInput.php
+++ b/src/Service/DynamoDb/src/Input/GetItemInput.php
@@ -121,6 +121,7 @@ final class GetItemInput extends Input
      *   ProjectionExpression?: string|null,
      *   ExpressionAttributeNames?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -151,6 +152,7 @@ final class GetItemInput extends Input
      *   ProjectionExpression?: string|null,
      *   ExpressionAttributeNames?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetItemInput $input
      */
     public static function create($input): self

--- a/src/Service/DynamoDb/src/Input/ListTablesInput.php
+++ b/src/Service/DynamoDb/src/Input/ListTablesInput.php
@@ -31,6 +31,7 @@ final class ListTablesInput extends Input
      *   ExclusiveStartTableName?: string|null,
      *   Limit?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -45,6 +46,7 @@ final class ListTablesInput extends Input
      *   ExclusiveStartTableName?: string|null,
      *   Limit?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListTablesInput $input
      */
     public static function create($input): self

--- a/src/Service/DynamoDb/src/Input/PutItemInput.php
+++ b/src/Service/DynamoDb/src/Input/PutItemInput.php
@@ -214,6 +214,7 @@ final class PutItemInput extends Input
      *   ExpressionAttributeValues?: array<string, AttributeValue|array>|null,
      *   ReturnValuesOnConditionCheckFailure?: ReturnValuesOnConditionCheckFailure::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -264,6 +265,7 @@ final class PutItemInput extends Input
      *   ExpressionAttributeValues?: array<string, AttributeValue|array>|null,
      *   ReturnValuesOnConditionCheckFailure?: ReturnValuesOnConditionCheckFailure::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutItemInput $input
      */
     public static function create($input): self

--- a/src/Service/DynamoDb/src/Input/QueryInput.php
+++ b/src/Service/DynamoDb/src/Input/QueryInput.php
@@ -340,6 +340,7 @@ final class QueryInput extends Input
      *   ExpressionAttributeNames?: array<string, string>|null,
      *   ExpressionAttributeValues?: array<string, AttributeValue|array>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -408,6 +409,7 @@ final class QueryInput extends Input
      *   ExpressionAttributeNames?: array<string, string>|null,
      *   ExpressionAttributeValues?: array<string, AttributeValue|array>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|QueryInput $input
      */
     public static function create($input): self

--- a/src/Service/DynamoDb/src/Input/ScanInput.php
+++ b/src/Service/DynamoDb/src/Input/ScanInput.php
@@ -296,6 +296,7 @@ final class ScanInput extends Input
      *   ExpressionAttributeValues?: array<string, AttributeValue|array>|null,
      *   ConsistentRead?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -356,6 +357,7 @@ final class ScanInput extends Input
      *   ExpressionAttributeValues?: array<string, AttributeValue|array>|null,
      *   ConsistentRead?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ScanInput $input
      */
     public static function create($input): self

--- a/src/Service/DynamoDb/src/Input/TransactWriteItemsInput.php
+++ b/src/Service/DynamoDb/src/Input/TransactWriteItemsInput.php
@@ -65,6 +65,7 @@ final class TransactWriteItemsInput extends Input
      *   ReturnItemCollectionMetrics?: ReturnItemCollectionMetrics::*|null,
      *   ClientRequestToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -83,6 +84,7 @@ final class TransactWriteItemsInput extends Input
      *   ReturnItemCollectionMetrics?: ReturnItemCollectionMetrics::*|null,
      *   ClientRequestToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|TransactWriteItemsInput $input
      */
     public static function create($input): self

--- a/src/Service/DynamoDb/src/Input/UpdateItemInput.php
+++ b/src/Service/DynamoDb/src/Input/UpdateItemInput.php
@@ -280,6 +280,7 @@ final class UpdateItemInput extends Input
      *   ExpressionAttributeValues?: array<string, AttributeValue|array>|null,
      *   ReturnValuesOnConditionCheckFailure?: ReturnValuesOnConditionCheckFailure::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -340,6 +341,7 @@ final class UpdateItemInput extends Input
      *   ExpressionAttributeValues?: array<string, AttributeValue|array>|null,
      *   ReturnValuesOnConditionCheckFailure?: ReturnValuesOnConditionCheckFailure::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|UpdateItemInput $input
      */
     public static function create($input): self

--- a/src/Service/DynamoDb/src/Input/UpdateTableInput.php
+++ b/src/Service/DynamoDb/src/Input/UpdateTableInput.php
@@ -209,6 +209,7 @@ final class UpdateTableInput extends Input
      *   WarmThroughput?: WarmThroughput|array|null,
      *   GlobalTableSettingsReplicationMode?: GlobalTableSettingsReplicationMode::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -249,6 +250,7 @@ final class UpdateTableInput extends Input
      *   WarmThroughput?: WarmThroughput|array|null,
      *   GlobalTableSettingsReplicationMode?: GlobalTableSettingsReplicationMode::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|UpdateTableInput $input
      */
     public static function create($input): self

--- a/src/Service/DynamoDb/src/Input/UpdateTimeToLiveInput.php
+++ b/src/Service/DynamoDb/src/Input/UpdateTimeToLiveInput.php
@@ -37,6 +37,7 @@ final class UpdateTimeToLiveInput extends Input
      *   TableName?: string,
      *   TimeToLiveSpecification?: TimeToLiveSpecification|array,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -51,6 +52,7 @@ final class UpdateTimeToLiveInput extends Input
      *   TableName?: string,
      *   TimeToLiveSpecification?: TimeToLiveSpecification|array,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|UpdateTimeToLiveInput $input
      */
     public static function create($input): self

--- a/src/Service/Ec2/composer.json
+++ b/src/Service/Ec2/composer.json
@@ -14,7 +14,7 @@
         "php": "^8.2",
         "ext-filter": "*",
         "ext-simplexml": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/Ec2/src/Input/DeleteSnapshotRequest.php
+++ b/src/Service/Ec2/src/Input/DeleteSnapshotRequest.php
@@ -32,6 +32,7 @@ final class DeleteSnapshotRequest extends Input
      *   SnapshotId?: string,
      *   DryRun?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -46,6 +47,7 @@ final class DeleteSnapshotRequest extends Input
      *   SnapshotId?: string,
      *   DryRun?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteSnapshotRequest $input
      */
     public static function create($input): self

--- a/src/Service/Ec2/src/Input/DeregisterImageRequest.php
+++ b/src/Service/Ec2/src/Input/DeregisterImageRequest.php
@@ -47,6 +47,7 @@ final class DeregisterImageRequest extends Input
      *   DeleteAssociatedSnapshots?: bool|null,
      *   DryRun?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -63,6 +64,7 @@ final class DeregisterImageRequest extends Input
      *   DeleteAssociatedSnapshots?: bool|null,
      *   DryRun?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeregisterImageRequest $input
      */
     public static function create($input): self

--- a/src/Service/Ec2/src/Input/DescribeImagesRequest.php
+++ b/src/Service/Ec2/src/Input/DescribeImagesRequest.php
@@ -163,6 +163,7 @@ final class DescribeImagesRequest extends Input
      *   DryRun?: bool|null,
      *   Filters?: array<Filter|array>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -191,6 +192,7 @@ final class DescribeImagesRequest extends Input
      *   DryRun?: bool|null,
      *   Filters?: array<Filter|array>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DescribeImagesRequest $input
      */
     public static function create($input): self

--- a/src/Service/Ecr/composer.json
+++ b/src/Service/Ecr/composer.json
@@ -14,7 +14,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/Ecr/src/Input/GetAuthorizationTokenRequest.php
+++ b/src/Service/Ecr/src/Input/GetAuthorizationTokenRequest.php
@@ -20,6 +20,7 @@ final class GetAuthorizationTokenRequest extends Input
      * @param array{
      *   registryIds?: string[]|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -32,6 +33,7 @@ final class GetAuthorizationTokenRequest extends Input
      * @param array{
      *   registryIds?: string[]|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetAuthorizationTokenRequest $input
      */
     public static function create($input): self

--- a/src/Service/ElastiCache/composer.json
+++ b/src/Service/ElastiCache/composer.json
@@ -14,7 +14,7 @@
         "php": "^8.2",
         "ext-filter": "*",
         "ext-simplexml": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/ElastiCache/src/Input/DescribeCacheClustersMessage.php
+++ b/src/Service/ElastiCache/src/Input/DescribeCacheClustersMessage.php
@@ -65,6 +65,7 @@ final class DescribeCacheClustersMessage extends Input
      *   ShowCacheNodeInfo?: bool|null,
      *   ShowCacheClustersNotInReplicationGroups?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -85,6 +86,7 @@ final class DescribeCacheClustersMessage extends Input
      *   ShowCacheNodeInfo?: bool|null,
      *   ShowCacheClustersNotInReplicationGroups?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DescribeCacheClustersMessage $input
      */
     public static function create($input): self

--- a/src/Service/EventBridge/composer.json
+++ b/src/Service/EventBridge/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/EventBridge/src/Input/PutEventsRequest.php
+++ b/src/Service/EventBridge/src/Input/PutEventsRequest.php
@@ -35,6 +35,7 @@ final class PutEventsRequest extends Input
      *   Entries?: array<PutEventsRequestEntry|array>,
      *   EndpointId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -49,6 +50,7 @@ final class PutEventsRequest extends Input
      *   Entries?: array<PutEventsRequestEntry|array>,
      *   EndpointId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutEventsRequest $input
      */
     public static function create($input): self

--- a/src/Service/Firehose/composer.json
+++ b/src/Service/Firehose/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/Firehose/src/Input/PutRecordBatchInput.php
+++ b/src/Service/Firehose/src/Input/PutRecordBatchInput.php
@@ -33,6 +33,7 @@ final class PutRecordBatchInput extends Input
      *   DeliveryStreamName?: string,
      *   Records?: array<Record|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -47,6 +48,7 @@ final class PutRecordBatchInput extends Input
      *   DeliveryStreamName?: string,
      *   Records?: array<Record|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutRecordBatchInput $input
      */
     public static function create($input): self

--- a/src/Service/Firehose/src/Input/PutRecordInput.php
+++ b/src/Service/Firehose/src/Input/PutRecordInput.php
@@ -33,6 +33,7 @@ final class PutRecordInput extends Input
      *   DeliveryStreamName?: string,
      *   Record?: Record|array,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -47,6 +48,7 @@ final class PutRecordInput extends Input
      *   DeliveryStreamName?: string,
      *   Record?: Record|array,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutRecordInput $input
      */
     public static function create($input): self

--- a/src/Service/Iam/composer.json
+++ b/src/Service/Iam/composer.json
@@ -17,7 +17,7 @@
         "php": "^8.2",
         "ext-filter": "*",
         "ext-simplexml": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/Iam/src/Input/AddUserToGroupRequest.php
+++ b/src/Service/Iam/src/Input/AddUserToGroupRequest.php
@@ -42,6 +42,7 @@ final class AddUserToGroupRequest extends Input
      *   GroupName?: string,
      *   UserName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -56,6 +57,7 @@ final class AddUserToGroupRequest extends Input
      *   GroupName?: string,
      *   UserName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AddUserToGroupRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iam/src/Input/CreateAccessKeyRequest.php
+++ b/src/Service/Iam/src/Input/CreateAccessKeyRequest.php
@@ -24,6 +24,7 @@ final class CreateAccessKeyRequest extends Input
      * @param array{
      *   UserName?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -36,6 +37,7 @@ final class CreateAccessKeyRequest extends Input
      * @param array{
      *   UserName?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateAccessKeyRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iam/src/Input/CreateServiceSpecificCredentialRequest.php
+++ b/src/Service/Iam/src/Input/CreateServiceSpecificCredentialRequest.php
@@ -48,6 +48,7 @@ final class CreateServiceSpecificCredentialRequest extends Input
      *   ServiceName?: string,
      *   CredentialAgeDays?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -64,6 +65,7 @@ final class CreateServiceSpecificCredentialRequest extends Input
      *   ServiceName?: string,
      *   CredentialAgeDays?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateServiceSpecificCredentialRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iam/src/Input/CreateUserRequest.php
+++ b/src/Service/Iam/src/Input/CreateUserRequest.php
@@ -76,6 +76,7 @@ final class CreateUserRequest extends Input
      *   PermissionsBoundary?: string|null,
      *   Tags?: array<Tag|array>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -94,6 +95,7 @@ final class CreateUserRequest extends Input
      *   PermissionsBoundary?: string|null,
      *   Tags?: array<Tag|array>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateUserRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iam/src/Input/DeleteAccessKeyRequest.php
+++ b/src/Service/Iam/src/Input/DeleteAccessKeyRequest.php
@@ -40,6 +40,7 @@ final class DeleteAccessKeyRequest extends Input
      *   UserName?: string|null,
      *   AccessKeyId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -54,6 +55,7 @@ final class DeleteAccessKeyRequest extends Input
      *   UserName?: string|null,
      *   AccessKeyId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteAccessKeyRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iam/src/Input/DeleteServiceSpecificCredentialRequest.php
+++ b/src/Service/Iam/src/Input/DeleteServiceSpecificCredentialRequest.php
@@ -43,6 +43,7 @@ final class DeleteServiceSpecificCredentialRequest extends Input
      *   UserName?: string|null,
      *   ServiceSpecificCredentialId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -57,6 +58,7 @@ final class DeleteServiceSpecificCredentialRequest extends Input
      *   UserName?: string|null,
      *   ServiceSpecificCredentialId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteServiceSpecificCredentialRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iam/src/Input/DeleteUserPolicyRequest.php
+++ b/src/Service/Iam/src/Input/DeleteUserPolicyRequest.php
@@ -42,6 +42,7 @@ final class DeleteUserPolicyRequest extends Input
      *   UserName?: string,
      *   PolicyName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -56,6 +57,7 @@ final class DeleteUserPolicyRequest extends Input
      *   UserName?: string,
      *   PolicyName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteUserPolicyRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iam/src/Input/DeleteUserRequest.php
+++ b/src/Service/Iam/src/Input/DeleteUserRequest.php
@@ -27,6 +27,7 @@ final class DeleteUserRequest extends Input
      * @param array{
      *   UserName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -39,6 +40,7 @@ final class DeleteUserRequest extends Input
      * @param array{
      *   UserName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteUserRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iam/src/Input/GetUserRequest.php
+++ b/src/Service/Iam/src/Input/GetUserRequest.php
@@ -25,6 +25,7 @@ final class GetUserRequest extends Input
      * @param array{
      *   UserName?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -37,6 +38,7 @@ final class GetUserRequest extends Input
      * @param array{
      *   UserName?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetUserRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iam/src/Input/ListServiceSpecificCredentialsRequest.php
+++ b/src/Service/Iam/src/Input/ListServiceSpecificCredentialsRequest.php
@@ -62,6 +62,7 @@ final class ListServiceSpecificCredentialsRequest extends Input
      *   Marker?: string|null,
      *   MaxItems?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -82,6 +83,7 @@ final class ListServiceSpecificCredentialsRequest extends Input
      *   Marker?: string|null,
      *   MaxItems?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListServiceSpecificCredentialsRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iam/src/Input/ListUsersRequest.php
+++ b/src/Service/Iam/src/Input/ListUsersRequest.php
@@ -51,6 +51,7 @@ final class ListUsersRequest extends Input
      *   Marker?: string|null,
      *   MaxItems?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -67,6 +68,7 @@ final class ListUsersRequest extends Input
      *   Marker?: string|null,
      *   MaxItems?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListUsersRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iam/src/Input/PutUserPolicyRequest.php
+++ b/src/Service/Iam/src/Input/PutUserPolicyRequest.php
@@ -65,6 +65,7 @@ final class PutUserPolicyRequest extends Input
      *   PolicyName?: string,
      *   PolicyDocument?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -81,6 +82,7 @@ final class PutUserPolicyRequest extends Input
      *   PolicyName?: string,
      *   PolicyDocument?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutUserPolicyRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iam/src/Input/UpdateUserRequest.php
+++ b/src/Service/Iam/src/Input/UpdateUserRequest.php
@@ -53,6 +53,7 @@ final class UpdateUserRequest extends Input
      *   NewPath?: string|null,
      *   NewUserName?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -69,6 +70,7 @@ final class UpdateUserRequest extends Input
      *   NewPath?: string|null,
      *   NewUserName?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|UpdateUserRequest $input
      */
     public static function create($input): self

--- a/src/Service/ImageBuilder/composer.json
+++ b/src/Service/ImageBuilder/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.9",
+        "async-aws/core": "^1.30",
         "symfony/polyfill-uuid": "^1.13.1"
     },
     "require-dev": {

--- a/src/Service/ImageBuilder/src/Input/DeleteImageRequest.php
+++ b/src/Service/ImageBuilder/src/Input/DeleteImageRequest.php
@@ -22,6 +22,7 @@ final class DeleteImageRequest extends Input
      * @param array{
      *   imageBuildVersionArn?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class DeleteImageRequest extends Input
      * @param array{
      *   imageBuildVersionArn?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteImageRequest $input
      */
     public static function create($input): self

--- a/src/Service/ImageBuilder/src/Input/GetImageRequest.php
+++ b/src/Service/ImageBuilder/src/Input/GetImageRequest.php
@@ -22,6 +22,7 @@ final class GetImageRequest extends Input
      * @param array{
      *   imageBuildVersionArn?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class GetImageRequest extends Input
      * @param array{
      *   imageBuildVersionArn?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetImageRequest $input
      */
     public static function create($input): self

--- a/src/Service/ImageBuilder/src/Input/ListImageBuildVersionsRequest.php
+++ b/src/Service/ImageBuilder/src/Input/ListImageBuildVersionsRequest.php
@@ -50,6 +50,7 @@ final class ListImageBuildVersionsRequest extends Input
      *   maxResults?: int|null,
      *   nextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -68,6 +69,7 @@ final class ListImageBuildVersionsRequest extends Input
      *   maxResults?: int|null,
      *   nextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListImageBuildVersionsRequest $input
      */
     public static function create($input): self

--- a/src/Service/ImageBuilder/src/Input/ListImagesRequest.php
+++ b/src/Service/ImageBuilder/src/Input/ListImagesRequest.php
@@ -70,6 +70,7 @@ final class ListImagesRequest extends Input
      *   nextToken?: string|null,
      *   includeDeprecated?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -92,6 +93,7 @@ final class ListImagesRequest extends Input
      *   nextToken?: string|null,
      *   includeDeprecated?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListImagesRequest $input
      */
     public static function create($input): self

--- a/src/Service/ImageBuilder/src/Input/StartImagePipelineExecutionRequest.php
+++ b/src/Service/ImageBuilder/src/Input/StartImagePipelineExecutionRequest.php
@@ -43,6 +43,7 @@ final class StartImagePipelineExecutionRequest extends Input
      *   clientToken?: string,
      *   tags?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -59,6 +60,7 @@ final class StartImagePipelineExecutionRequest extends Input
      *   clientToken?: string,
      *   tags?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|StartImagePipelineExecutionRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iot/composer.json
+++ b/src/Service/Iot/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/Iot/src/Input/AddThingToThingGroupRequest.php
+++ b/src/Service/Iot/src/Input/AddThingToThingGroupRequest.php
@@ -53,6 +53,7 @@ final class AddThingToThingGroupRequest extends Input
      *   thingArn?: string|null,
      *   overrideDynamicGroups?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -73,6 +74,7 @@ final class AddThingToThingGroupRequest extends Input
      *   thingArn?: string|null,
      *   overrideDynamicGroups?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AddThingToThingGroupRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iot/src/Input/CreateThingGroupRequest.php
+++ b/src/Service/Iot/src/Input/CreateThingGroupRequest.php
@@ -48,6 +48,7 @@ final class CreateThingGroupRequest extends Input
      *   thingGroupProperties?: ThingGroupProperties|array|null,
      *   tags?: array<Tag|array>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -66,6 +67,7 @@ final class CreateThingGroupRequest extends Input
      *   thingGroupProperties?: ThingGroupProperties|array|null,
      *   tags?: array<Tag|array>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateThingGroupRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iot/src/Input/CreateThingRequest.php
+++ b/src/Service/Iot/src/Input/CreateThingRequest.php
@@ -55,6 +55,7 @@ final class CreateThingRequest extends Input
      *   attributePayload?: AttributePayload|array|null,
      *   billingGroupName?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -73,6 +74,7 @@ final class CreateThingRequest extends Input
      *   attributePayload?: AttributePayload|array|null,
      *   billingGroupName?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateThingRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iot/src/Input/CreateThingTypeRequest.php
+++ b/src/Service/Iot/src/Input/CreateThingTypeRequest.php
@@ -44,6 +44,7 @@ final class CreateThingTypeRequest extends Input
      *   thingTypeProperties?: ThingTypeProperties|array|null,
      *   tags?: array<Tag|array>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -60,6 +61,7 @@ final class CreateThingTypeRequest extends Input
      *   thingTypeProperties?: ThingTypeProperties|array|null,
      *   tags?: array<Tag|array>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateThingTypeRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iot/src/Input/DeleteThingGroupRequest.php
+++ b/src/Service/Iot/src/Input/DeleteThingGroupRequest.php
@@ -30,6 +30,7 @@ final class DeleteThingGroupRequest extends Input
      *   thingGroupName?: string,
      *   expectedVersion?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -44,6 +45,7 @@ final class DeleteThingGroupRequest extends Input
      *   thingGroupName?: string,
      *   expectedVersion?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteThingGroupRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iot/src/Input/DeleteThingRequest.php
+++ b/src/Service/Iot/src/Input/DeleteThingRequest.php
@@ -35,6 +35,7 @@ final class DeleteThingRequest extends Input
      *   thingName?: string,
      *   expectedVersion?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -49,6 +50,7 @@ final class DeleteThingRequest extends Input
      *   thingName?: string,
      *   expectedVersion?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteThingRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iot/src/Input/DeleteThingTypeRequest.php
+++ b/src/Service/Iot/src/Input/DeleteThingTypeRequest.php
@@ -25,6 +25,7 @@ final class DeleteThingTypeRequest extends Input
      * @param array{
      *   thingTypeName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -37,6 +38,7 @@ final class DeleteThingTypeRequest extends Input
      * @param array{
      *   thingTypeName?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteThingTypeRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iot/src/Input/ListThingGroupsForThingRequest.php
+++ b/src/Service/Iot/src/Input/ListThingGroupsForThingRequest.php
@@ -39,6 +39,7 @@ final class ListThingGroupsForThingRequest extends Input
      *   nextToken?: string|null,
      *   maxResults?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -55,6 +56,7 @@ final class ListThingGroupsForThingRequest extends Input
      *   nextToken?: string|null,
      *   maxResults?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListThingGroupsForThingRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iot/src/Input/ListThingGroupsRequest.php
+++ b/src/Service/Iot/src/Input/ListThingGroupsRequest.php
@@ -52,6 +52,7 @@ final class ListThingGroupsRequest extends Input
      *   namePrefixFilter?: string|null,
      *   recursive?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -72,6 +73,7 @@ final class ListThingGroupsRequest extends Input
      *   namePrefixFilter?: string|null,
      *   recursive?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListThingGroupsRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iot/src/Input/ListThingTypesRequest.php
+++ b/src/Service/Iot/src/Input/ListThingTypesRequest.php
@@ -39,6 +39,7 @@ final class ListThingTypesRequest extends Input
      *   maxResults?: int|null,
      *   thingTypeName?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -55,6 +56,7 @@ final class ListThingTypesRequest extends Input
      *   maxResults?: int|null,
      *   thingTypeName?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListThingTypesRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iot/src/Input/ListThingsInThingGroupRequest.php
+++ b/src/Service/Iot/src/Input/ListThingsInThingGroupRequest.php
@@ -47,6 +47,7 @@ final class ListThingsInThingGroupRequest extends Input
      *   nextToken?: string|null,
      *   maxResults?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -65,6 +66,7 @@ final class ListThingsInThingGroupRequest extends Input
      *   nextToken?: string|null,
      *   maxResults?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListThingsInThingGroupRequest $input
      */
     public static function create($input): self

--- a/src/Service/Iot/src/Input/ListThingsRequest.php
+++ b/src/Service/Iot/src/Input/ListThingsRequest.php
@@ -67,6 +67,7 @@ final class ListThingsRequest extends Input
      *   thingTypeName?: string|null,
      *   usePrefixAttributeValue?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -89,6 +90,7 @@ final class ListThingsRequest extends Input
      *   thingTypeName?: string|null,
      *   usePrefixAttributeValue?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListThingsRequest $input
      */
     public static function create($input): self

--- a/src/Service/IotData/composer.json
+++ b/src/Service/IotData/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/IotData/src/Input/GetThingShadowRequest.php
+++ b/src/Service/IotData/src/Input/GetThingShadowRequest.php
@@ -33,6 +33,7 @@ final class GetThingShadowRequest extends Input
      *   thingName?: string,
      *   shadowName?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -47,6 +48,7 @@ final class GetThingShadowRequest extends Input
      *   thingName?: string,
      *   shadowName?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetThingShadowRequest $input
      */
     public static function create($input): self

--- a/src/Service/IotData/src/Input/UpdateThingShadowRequest.php
+++ b/src/Service/IotData/src/Input/UpdateThingShadowRequest.php
@@ -43,6 +43,7 @@ final class UpdateThingShadowRequest extends Input
      *   shadowName?: string|null,
      *   payload?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -59,6 +60,7 @@ final class UpdateThingShadowRequest extends Input
      *   shadowName?: string|null,
      *   payload?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|UpdateThingShadowRequest $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/composer.json
+++ b/src/Service/Kinesis/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/Kinesis/src/Input/AddTagsToStreamInput.php
+++ b/src/Service/Kinesis/src/Input/AddTagsToStreamInput.php
@@ -50,6 +50,7 @@ final class AddTagsToStreamInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -68,6 +69,7 @@ final class AddTagsToStreamInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AddTagsToStreamInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/CreateStreamInput.php
+++ b/src/Service/Kinesis/src/Input/CreateStreamInput.php
@@ -72,6 +72,7 @@ final class CreateStreamInput extends Input
      *   WarmThroughputMiBps?: int|null,
      *   MaxRecordSizeInKiB?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -94,6 +95,7 @@ final class CreateStreamInput extends Input
      *   WarmThroughputMiBps?: int|null,
      *   MaxRecordSizeInKiB?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateStreamInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/DecreaseStreamRetentionPeriodInput.php
+++ b/src/Service/Kinesis/src/Input/DecreaseStreamRetentionPeriodInput.php
@@ -49,6 +49,7 @@ final class DecreaseStreamRetentionPeriodInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -67,6 +68,7 @@ final class DecreaseStreamRetentionPeriodInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DecreaseStreamRetentionPeriodInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/DeleteStreamInput.php
+++ b/src/Service/Kinesis/src/Input/DeleteStreamInput.php
@@ -47,6 +47,7 @@ final class DeleteStreamInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -65,6 +66,7 @@ final class DeleteStreamInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteStreamInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/DeregisterStreamConsumerInput.php
+++ b/src/Service/Kinesis/src/Input/DeregisterStreamConsumerInput.php
@@ -48,6 +48,7 @@ final class DeregisterStreamConsumerInput extends Input
      *   ConsumerARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -66,6 +67,7 @@ final class DeregisterStreamConsumerInput extends Input
      *   ConsumerARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeregisterStreamConsumerInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/DescribeLimitsInput.php
+++ b/src/Service/Kinesis/src/Input/DescribeLimitsInput.php
@@ -11,6 +11,7 @@ final class DescribeLimitsInput extends Input
     /**
      * @param array{
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -21,6 +22,7 @@ final class DescribeLimitsInput extends Input
     /**
      * @param array{
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DescribeLimitsInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/DescribeStreamConsumerInput.php
+++ b/src/Service/Kinesis/src/Input/DescribeStreamConsumerInput.php
@@ -46,6 +46,7 @@ final class DescribeStreamConsumerInput extends Input
      *   ConsumerARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -64,6 +65,7 @@ final class DescribeStreamConsumerInput extends Input
      *   ConsumerARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DescribeStreamConsumerInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/DescribeStreamInput.php
+++ b/src/Service/Kinesis/src/Input/DescribeStreamInput.php
@@ -61,6 +61,7 @@ final class DescribeStreamInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -81,6 +82,7 @@ final class DescribeStreamInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DescribeStreamInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/DescribeStreamSummaryInput.php
+++ b/src/Service/Kinesis/src/Input/DescribeStreamSummaryInput.php
@@ -35,6 +35,7 @@ final class DescribeStreamSummaryInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -51,6 +52,7 @@ final class DescribeStreamSummaryInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DescribeStreamSummaryInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/DisableEnhancedMonitoringInput.php
+++ b/src/Service/Kinesis/src/Input/DisableEnhancedMonitoringInput.php
@@ -66,6 +66,7 @@ final class DisableEnhancedMonitoringInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -84,6 +85,7 @@ final class DisableEnhancedMonitoringInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DisableEnhancedMonitoringInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/EnableEnhancedMonitoringInput.php
+++ b/src/Service/Kinesis/src/Input/EnableEnhancedMonitoringInput.php
@@ -66,6 +66,7 @@ final class EnableEnhancedMonitoringInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -84,6 +85,7 @@ final class EnableEnhancedMonitoringInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|EnableEnhancedMonitoringInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/GetRecordsInput.php
+++ b/src/Service/Kinesis/src/Input/GetRecordsInput.php
@@ -51,6 +51,7 @@ final class GetRecordsInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -69,6 +70,7 @@ final class GetRecordsInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetRecordsInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/GetShardIteratorInput.php
+++ b/src/Service/Kinesis/src/Input/GetShardIteratorInput.php
@@ -93,6 +93,7 @@ final class GetShardIteratorInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -117,6 +118,7 @@ final class GetShardIteratorInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetShardIteratorInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/IncreaseStreamRetentionPeriodInput.php
+++ b/src/Service/Kinesis/src/Input/IncreaseStreamRetentionPeriodInput.php
@@ -49,6 +49,7 @@ final class IncreaseStreamRetentionPeriodInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -67,6 +68,7 @@ final class IncreaseStreamRetentionPeriodInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|IncreaseStreamRetentionPeriodInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/ListShardsInput.php
+++ b/src/Service/Kinesis/src/Input/ListShardsInput.php
@@ -121,6 +121,7 @@ final class ListShardsInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -147,6 +148,7 @@ final class ListShardsInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListShardsInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/ListStreamConsumersInput.php
+++ b/src/Service/Kinesis/src/Input/ListStreamConsumersInput.php
@@ -78,6 +78,7 @@ final class ListStreamConsumersInput extends Input
      *   StreamCreationTimestamp?: \DateTimeImmutable|string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -98,6 +99,7 @@ final class ListStreamConsumersInput extends Input
      *   StreamCreationTimestamp?: \DateTimeImmutable|string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListStreamConsumersInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/ListStreamsInput.php
+++ b/src/Service/Kinesis/src/Input/ListStreamsInput.php
@@ -37,6 +37,7 @@ final class ListStreamsInput extends Input
      *   ExclusiveStartStreamName?: string|null,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -53,6 +54,7 @@ final class ListStreamsInput extends Input
      *   ExclusiveStartStreamName?: string|null,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListStreamsInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/ListTagsForStreamInput.php
+++ b/src/Service/Kinesis/src/Input/ListTagsForStreamInput.php
@@ -56,6 +56,7 @@ final class ListTagsForStreamInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -76,6 +77,7 @@ final class ListTagsForStreamInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListTagsForStreamInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/MergeShardsInput.php
+++ b/src/Service/Kinesis/src/Input/MergeShardsInput.php
@@ -59,6 +59,7 @@ final class MergeShardsInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -79,6 +80,7 @@ final class MergeShardsInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|MergeShardsInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/PutRecordInput.php
+++ b/src/Service/Kinesis/src/Input/PutRecordInput.php
@@ -84,6 +84,7 @@ final class PutRecordInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -108,6 +109,7 @@ final class PutRecordInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutRecordInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/PutRecordsInput.php
+++ b/src/Service/Kinesis/src/Input/PutRecordsInput.php
@@ -50,6 +50,7 @@ final class PutRecordsInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -68,6 +69,7 @@ final class PutRecordsInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutRecordsInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/RegisterStreamConsumerInput.php
+++ b/src/Service/Kinesis/src/Input/RegisterStreamConsumerInput.php
@@ -52,6 +52,7 @@ final class RegisterStreamConsumerInput extends Input
      *   StreamId?: string|null,
      *   Tags?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -70,6 +71,7 @@ final class RegisterStreamConsumerInput extends Input
      *   StreamId?: string|null,
      *   Tags?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|RegisterStreamConsumerInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/RemoveTagsFromStreamInput.php
+++ b/src/Service/Kinesis/src/Input/RemoveTagsFromStreamInput.php
@@ -49,6 +49,7 @@ final class RemoveTagsFromStreamInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -67,6 +68,7 @@ final class RemoveTagsFromStreamInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|RemoveTagsFromStreamInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/SplitShardInput.php
+++ b/src/Service/Kinesis/src/Input/SplitShardInput.php
@@ -63,6 +63,7 @@ final class SplitShardInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -83,6 +84,7 @@ final class SplitShardInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|SplitShardInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/StartStreamEncryptionInput.php
+++ b/src/Service/Kinesis/src/Input/StartStreamEncryptionInput.php
@@ -66,6 +66,7 @@ final class StartStreamEncryptionInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -86,6 +87,7 @@ final class StartStreamEncryptionInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|StartStreamEncryptionInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/StopStreamEncryptionInput.php
+++ b/src/Service/Kinesis/src/Input/StopStreamEncryptionInput.php
@@ -66,6 +66,7 @@ final class StopStreamEncryptionInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -86,6 +87,7 @@ final class StopStreamEncryptionInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|StopStreamEncryptionInput $input
      */
     public static function create($input): self

--- a/src/Service/Kinesis/src/Input/UpdateShardCountInput.php
+++ b/src/Service/Kinesis/src/Input/UpdateShardCountInput.php
@@ -63,6 +63,7 @@ final class UpdateShardCountInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -83,6 +84,7 @@ final class UpdateShardCountInput extends Input
      *   StreamARN?: string|null,
      *   StreamId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|UpdateShardCountInput $input
      */
     public static function create($input): self

--- a/src/Service/Kms/composer.json
+++ b/src/Service/Kms/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/Kms/src/Input/CreateAliasRequest.php
+++ b/src/Service/Kms/src/Input/CreateAliasRequest.php
@@ -59,6 +59,7 @@ final class CreateAliasRequest extends Input
      *   AliasName?: string,
      *   TargetKeyId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -73,6 +74,7 @@ final class CreateAliasRequest extends Input
      *   AliasName?: string,
      *   TargetKeyId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateAliasRequest $input
      */
     public static function create($input): self

--- a/src/Service/Kms/src/Input/CreateKeyRequest.php
+++ b/src/Service/Kms/src/Input/CreateKeyRequest.php
@@ -332,6 +332,7 @@ final class CreateKeyRequest extends Input
      *   MultiRegion?: bool|null,
      *   XksKeyId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -364,6 +365,7 @@ final class CreateKeyRequest extends Input
      *   MultiRegion?: bool|null,
      *   XksKeyId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateKeyRequest $input
      */
     public static function create($input): self

--- a/src/Service/Kms/src/Input/DecryptRequest.php
+++ b/src/Service/Kms/src/Input/DecryptRequest.php
@@ -158,6 +158,7 @@ final class DecryptRequest extends Input
      *   DryRun?: bool|null,
      *   DryRunModifiers?: array<DryRunModifierType::*>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -184,6 +185,7 @@ final class DecryptRequest extends Input
      *   DryRun?: bool|null,
      *   DryRunModifiers?: array<DryRunModifierType::*>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DecryptRequest $input
      */
     public static function create($input): self

--- a/src/Service/Kms/src/Input/EncryptRequest.php
+++ b/src/Service/Kms/src/Input/EncryptRequest.php
@@ -113,6 +113,7 @@ final class EncryptRequest extends Input
      *   EncryptionAlgorithm?: EncryptionAlgorithmSpec::*|null,
      *   DryRun?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -135,6 +136,7 @@ final class EncryptRequest extends Input
      *   EncryptionAlgorithm?: EncryptionAlgorithmSpec::*|null,
      *   DryRun?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|EncryptRequest $input
      */
     public static function create($input): self

--- a/src/Service/Kms/src/Input/GenerateDataKeyRequest.php
+++ b/src/Service/Kms/src/Input/GenerateDataKeyRequest.php
@@ -137,6 +137,7 @@ final class GenerateDataKeyRequest extends Input
      *   Recipient?: RecipientInfo|array|null,
      *   DryRun?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -161,6 +162,7 @@ final class GenerateDataKeyRequest extends Input
      *   Recipient?: RecipientInfo|array|null,
      *   DryRun?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GenerateDataKeyRequest $input
      */
     public static function create($input): self

--- a/src/Service/Kms/src/Input/GetPublicKeyRequest.php
+++ b/src/Service/Kms/src/Input/GetPublicKeyRequest.php
@@ -50,6 +50,7 @@ final class GetPublicKeyRequest extends Input
      *   KeyId?: string,
      *   GrantTokens?: string[]|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -64,6 +65,7 @@ final class GetPublicKeyRequest extends Input
      *   KeyId?: string,
      *   GrantTokens?: string[]|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetPublicKeyRequest $input
      */
     public static function create($input): self

--- a/src/Service/Kms/src/Input/ListAliasesRequest.php
+++ b/src/Service/Kms/src/Input/ListAliasesRequest.php
@@ -52,6 +52,7 @@ final class ListAliasesRequest extends Input
      *   Limit?: int|null,
      *   Marker?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -68,6 +69,7 @@ final class ListAliasesRequest extends Input
      *   Limit?: int|null,
      *   Marker?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListAliasesRequest $input
      */
     public static function create($input): self

--- a/src/Service/Kms/src/Input/SignRequest.php
+++ b/src/Service/Kms/src/Input/SignRequest.php
@@ -140,6 +140,7 @@ final class SignRequest extends Input
      *   SigningAlgorithm?: SigningAlgorithmSpec::*,
      *   DryRun?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -162,6 +163,7 @@ final class SignRequest extends Input
      *   SigningAlgorithm?: SigningAlgorithmSpec::*,
      *   DryRun?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|SignRequest $input
      */
     public static function create($input): self

--- a/src/Service/Kms/src/Input/VerifyRequest.php
+++ b/src/Service/Kms/src/Input/VerifyRequest.php
@@ -147,6 +147,7 @@ final class VerifyRequest extends Input
      *   GrantTokens?: string[]|null,
      *   DryRun?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -171,6 +172,7 @@ final class VerifyRequest extends Input
      *   GrantTokens?: string[]|null,
      *   DryRun?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|VerifyRequest $input
      */
     public static function create($input): self

--- a/src/Service/Lambda/composer.json
+++ b/src/Service/Lambda/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/Lambda/src/Input/AddLayerVersionPermissionRequest.php
+++ b/src/Service/Lambda/src/Input/AddLayerVersionPermissionRequest.php
@@ -81,6 +81,7 @@ final class AddLayerVersionPermissionRequest extends Input
      *   OrganizationId?: string|null,
      *   RevisionId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -105,6 +106,7 @@ final class AddLayerVersionPermissionRequest extends Input
      *   OrganizationId?: string|null,
      *   RevisionId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AddLayerVersionPermissionRequest $input
      */
     public static function create($input): self

--- a/src/Service/Lambda/src/Input/DeleteFunctionRequest.php
+++ b/src/Service/Lambda/src/Input/DeleteFunctionRequest.php
@@ -39,6 +39,7 @@ final class DeleteFunctionRequest extends Input
      *   FunctionName?: string,
      *   Qualifier?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -53,6 +54,7 @@ final class DeleteFunctionRequest extends Input
      *   FunctionName?: string,
      *   Qualifier?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteFunctionRequest $input
      */
     public static function create($input): self

--- a/src/Service/Lambda/src/Input/GetAliasRequest.php
+++ b/src/Service/Lambda/src/Input/GetAliasRequest.php
@@ -41,6 +41,7 @@ final class GetAliasRequest extends Input
      *   FunctionName?: string,
      *   Name?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -55,6 +56,7 @@ final class GetAliasRequest extends Input
      *   FunctionName?: string,
      *   Name?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetAliasRequest $input
      */
     public static function create($input): self

--- a/src/Service/Lambda/src/Input/GetFunctionConfigurationRequest.php
+++ b/src/Service/Lambda/src/Input/GetFunctionConfigurationRequest.php
@@ -39,6 +39,7 @@ final class GetFunctionConfigurationRequest extends Input
      *   FunctionName?: string,
      *   Qualifier?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -53,6 +54,7 @@ final class GetFunctionConfigurationRequest extends Input
      *   FunctionName?: string,
      *   Qualifier?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetFunctionConfigurationRequest $input
      */
     public static function create($input): self

--- a/src/Service/Lambda/src/Input/InvocationRequest.php
+++ b/src/Service/Lambda/src/Input/InvocationRequest.php
@@ -101,6 +101,7 @@ final class InvocationRequest extends Input
      *   Qualifier?: string|null,
      *   TenantId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -127,6 +128,7 @@ final class InvocationRequest extends Input
      *   Qualifier?: string|null,
      *   TenantId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|InvocationRequest $input
      */
     public static function create($input): self

--- a/src/Service/Lambda/src/Input/ListAliasesRequest.php
+++ b/src/Service/Lambda/src/Input/ListAliasesRequest.php
@@ -55,6 +55,7 @@ final class ListAliasesRequest extends Input
      *   Marker?: string|null,
      *   MaxItems?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -73,6 +74,7 @@ final class ListAliasesRequest extends Input
      *   Marker?: string|null,
      *   MaxItems?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListAliasesRequest $input
      */
     public static function create($input): self

--- a/src/Service/Lambda/src/Input/ListEventSourceMappingsRequest.php
+++ b/src/Service/Lambda/src/Input/ListEventSourceMappingsRequest.php
@@ -64,6 +64,7 @@ final class ListEventSourceMappingsRequest extends Input
      *   Marker?: string|null,
      *   MaxItems?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -82,6 +83,7 @@ final class ListEventSourceMappingsRequest extends Input
      *   Marker?: string|null,
      *   MaxItems?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListEventSourceMappingsRequest $input
      */
     public static function create($input): self

--- a/src/Service/Lambda/src/Input/ListFunctionsRequest.php
+++ b/src/Service/Lambda/src/Input/ListFunctionsRequest.php
@@ -48,6 +48,7 @@ final class ListFunctionsRequest extends Input
      *   Marker?: string|null,
      *   MaxItems?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -66,6 +67,7 @@ final class ListFunctionsRequest extends Input
      *   Marker?: string|null,
      *   MaxItems?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListFunctionsRequest $input
      */
     public static function create($input): self

--- a/src/Service/Lambda/src/Input/ListLayerVersionsRequest.php
+++ b/src/Service/Lambda/src/Input/ListLayerVersionsRequest.php
@@ -65,6 +65,7 @@ final class ListLayerVersionsRequest extends Input
      *   MaxItems?: int|null,
      *   CompatibleArchitecture?: Architecture::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -85,6 +86,7 @@ final class ListLayerVersionsRequest extends Input
      *   MaxItems?: int|null,
      *   CompatibleArchitecture?: Architecture::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListLayerVersionsRequest $input
      */
     public static function create($input): self

--- a/src/Service/Lambda/src/Input/ListVersionsByFunctionRequest.php
+++ b/src/Service/Lambda/src/Input/ListVersionsByFunctionRequest.php
@@ -48,6 +48,7 @@ final class ListVersionsByFunctionRequest extends Input
      *   Marker?: string|null,
      *   MaxItems?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -64,6 +65,7 @@ final class ListVersionsByFunctionRequest extends Input
      *   Marker?: string|null,
      *   MaxItems?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListVersionsByFunctionRequest $input
      */
     public static function create($input): self

--- a/src/Service/Lambda/src/Input/PublishLayerVersionRequest.php
+++ b/src/Service/Lambda/src/Input/PublishLayerVersionRequest.php
@@ -80,6 +80,7 @@ final class PublishLayerVersionRequest extends Input
      *   LicenseInfo?: string|null,
      *   CompatibleArchitectures?: array<Architecture::*>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -102,6 +103,7 @@ final class PublishLayerVersionRequest extends Input
      *   LicenseInfo?: string|null,
      *   CompatibleArchitectures?: array<Architecture::*>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PublishLayerVersionRequest $input
      */
     public static function create($input): self

--- a/src/Service/Lambda/src/Input/PutFunctionConcurrencyRequest.php
+++ b/src/Service/Lambda/src/Input/PutFunctionConcurrencyRequest.php
@@ -41,6 +41,7 @@ final class PutFunctionConcurrencyRequest extends Input
      *   FunctionName?: string,
      *   ReservedConcurrentExecutions?: int,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -55,6 +56,7 @@ final class PutFunctionConcurrencyRequest extends Input
      *   FunctionName?: string,
      *   ReservedConcurrentExecutions?: int,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutFunctionConcurrencyRequest $input
      */
     public static function create($input): self

--- a/src/Service/Lambda/src/Input/UpdateFunctionConfigurationRequest.php
+++ b/src/Service/Lambda/src/Input/UpdateFunctionConfigurationRequest.php
@@ -262,6 +262,7 @@ final class UpdateFunctionConfigurationRequest extends Input
      *   CapacityProviderConfig?: CapacityProviderConfig|array|null,
      *   DurableConfig?: DurableConfig|array|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -314,6 +315,7 @@ final class UpdateFunctionConfigurationRequest extends Input
      *   CapacityProviderConfig?: CapacityProviderConfig|array|null,
      *   DurableConfig?: DurableConfig|array|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|UpdateFunctionConfigurationRequest $input
      */
     public static function create($input): self

--- a/src/Service/LocationService/composer.json
+++ b/src/Service/LocationService/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.20"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/LocationService/src/Input/CalculateRouteMatrixRequest.php
+++ b/src/Service/LocationService/src/Input/CalculateRouteMatrixRequest.php
@@ -170,6 +170,7 @@ final class CalculateRouteMatrixRequest extends Input
      *   TruckModeOptions?: CalculateRouteTruckModeOptions|array|null,
      *   Key?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -200,6 +201,7 @@ final class CalculateRouteMatrixRequest extends Input
      *   TruckModeOptions?: CalculateRouteTruckModeOptions|array|null,
      *   Key?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CalculateRouteMatrixRequest $input
      */
     public static function create($input): self

--- a/src/Service/LocationService/src/Input/CalculateRouteRequest.php
+++ b/src/Service/LocationService/src/Input/CalculateRouteRequest.php
@@ -215,6 +215,7 @@ final class CalculateRouteRequest extends Input
      *   OptimizeFor?: OptimizationMode::*|null,
      *   Key?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -253,6 +254,7 @@ final class CalculateRouteRequest extends Input
      *   OptimizeFor?: OptimizationMode::*|null,
      *   Key?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CalculateRouteRequest $input
      */
     public static function create($input): self

--- a/src/Service/LocationService/src/Input/SearchPlaceIndexForPositionRequest.php
+++ b/src/Service/LocationService/src/Input/SearchPlaceIndexForPositionRequest.php
@@ -80,6 +80,7 @@ final class SearchPlaceIndexForPositionRequest extends Input
      *   Language?: string|null,
      *   Key?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -100,6 +101,7 @@ final class SearchPlaceIndexForPositionRequest extends Input
      *   Language?: string|null,
      *   Key?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|SearchPlaceIndexForPositionRequest $input
      */
     public static function create($input): self

--- a/src/Service/LocationService/src/Input/SearchPlaceIndexForTextRequest.php
+++ b/src/Service/LocationService/src/Input/SearchPlaceIndexForTextRequest.php
@@ -138,6 +138,7 @@ final class SearchPlaceIndexForTextRequest extends Input
      *   FilterCategories?: string[]|null,
      *   Key?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -166,6 +167,7 @@ final class SearchPlaceIndexForTextRequest extends Input
      *   FilterCategories?: string[]|null,
      *   Key?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|SearchPlaceIndexForTextRequest $input
      */
     public static function create($input): self

--- a/src/Service/MediaConvert/composer.json
+++ b/src/Service/MediaConvert/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.9",
+        "async-aws/core": "^1.30",
         "symfony/polyfill-uuid": "^1.13.1"
     },
     "require-dev": {

--- a/src/Service/MediaConvert/src/Input/CancelJobRequest.php
+++ b/src/Service/MediaConvert/src/Input/CancelJobRequest.php
@@ -25,6 +25,7 @@ final class CancelJobRequest extends Input
      * @param array{
      *   Id?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -37,6 +38,7 @@ final class CancelJobRequest extends Input
      * @param array{
      *   Id?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CancelJobRequest $input
      */
     public static function create($input): self

--- a/src/Service/MediaConvert/src/Input/CreateJobRequest.php
+++ b/src/Service/MediaConvert/src/Input/CreateJobRequest.php
@@ -163,6 +163,7 @@ final class CreateJobRequest extends Input
      *   Tags?: array<string, string>|null,
      *   UserMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -201,6 +202,7 @@ final class CreateJobRequest extends Input
      *   Tags?: array<string, string>|null,
      *   UserMetadata?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateJobRequest $input
      */
     public static function create($input): self

--- a/src/Service/MediaConvert/src/Input/DescribeEndpointsRequest.php
+++ b/src/Service/MediaConvert/src/Input/DescribeEndpointsRequest.php
@@ -44,6 +44,7 @@ final class DescribeEndpointsRequest extends Input
      *   Mode?: DescribeEndpointsMode::*|null,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -60,6 +61,7 @@ final class DescribeEndpointsRequest extends Input
      *   Mode?: DescribeEndpointsMode::*|null,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DescribeEndpointsRequest $input
      */
     public static function create($input): self

--- a/src/Service/MediaConvert/src/Input/GetJobRequest.php
+++ b/src/Service/MediaConvert/src/Input/GetJobRequest.php
@@ -25,6 +25,7 @@ final class GetJobRequest extends Input
      * @param array{
      *   Id?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -37,6 +38,7 @@ final class GetJobRequest extends Input
      * @param array{
      *   Id?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetJobRequest $input
      */
     public static function create($input): self

--- a/src/Service/MediaConvert/src/Input/ListJobsRequest.php
+++ b/src/Service/MediaConvert/src/Input/ListJobsRequest.php
@@ -60,6 +60,7 @@ final class ListJobsRequest extends Input
      *   Queue?: string|null,
      *   Status?: JobStatus::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -80,6 +81,7 @@ final class ListJobsRequest extends Input
      *   Queue?: string|null,
      *   Status?: JobStatus::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListJobsRequest $input
      */
     public static function create($input): self

--- a/src/Service/RdsDataService/composer.json
+++ b/src/Service/RdsDataService/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/RdsDataService/src/Input/BatchExecuteStatementRequest.php
+++ b/src/Service/RdsDataService/src/Input/BatchExecuteStatementRequest.php
@@ -96,6 +96,7 @@ final class BatchExecuteStatementRequest extends Input
      *   parameterSets?: array[]|null,
      *   transactionId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -122,6 +123,7 @@ final class BatchExecuteStatementRequest extends Input
      *   parameterSets?: array[]|null,
      *   transactionId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|BatchExecuteStatementRequest $input
      */
     public static function create($input): self

--- a/src/Service/RdsDataService/src/Input/BeginTransactionRequest.php
+++ b/src/Service/RdsDataService/src/Input/BeginTransactionRequest.php
@@ -51,6 +51,7 @@ final class BeginTransactionRequest extends Input
      *   database?: string|null,
      *   schema?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -69,6 +70,7 @@ final class BeginTransactionRequest extends Input
      *   database?: string|null,
      *   schema?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|BeginTransactionRequest $input
      */
     public static function create($input): self

--- a/src/Service/RdsDataService/src/Input/CommitTransactionRequest.php
+++ b/src/Service/RdsDataService/src/Input/CommitTransactionRequest.php
@@ -45,6 +45,7 @@ final class CommitTransactionRequest extends Input
      *   secretArn?: string,
      *   transactionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -61,6 +62,7 @@ final class CommitTransactionRequest extends Input
      *   secretArn?: string,
      *   transactionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CommitTransactionRequest $input
      */
     public static function create($input): self

--- a/src/Service/RdsDataService/src/Input/ExecuteStatementRequest.php
+++ b/src/Service/RdsDataService/src/Input/ExecuteStatementRequest.php
@@ -135,6 +135,7 @@ final class ExecuteStatementRequest extends Input
      *   resultSetOptions?: ResultSetOptions|array|null,
      *   formatRecordsAs?: RecordsFormatType::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -167,6 +168,7 @@ final class ExecuteStatementRequest extends Input
      *   resultSetOptions?: ResultSetOptions|array|null,
      *   formatRecordsAs?: RecordsFormatType::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ExecuteStatementRequest $input
      */
     public static function create($input): self

--- a/src/Service/RdsDataService/src/Input/RollbackTransactionRequest.php
+++ b/src/Service/RdsDataService/src/Input/RollbackTransactionRequest.php
@@ -45,6 +45,7 @@ final class RollbackTransactionRequest extends Input
      *   secretArn?: string,
      *   transactionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -61,6 +62,7 @@ final class RollbackTransactionRequest extends Input
      *   secretArn?: string,
      *   transactionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|RollbackTransactionRequest $input
      */
     public static function create($input): self

--- a/src/Service/Rekognition/composer.json
+++ b/src/Service/Rekognition/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/Rekognition/src/Input/CreateCollectionRequest.php
+++ b/src/Service/Rekognition/src/Input/CreateCollectionRequest.php
@@ -30,6 +30,7 @@ final class CreateCollectionRequest extends Input
      *   CollectionId?: string,
      *   Tags?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -44,6 +45,7 @@ final class CreateCollectionRequest extends Input
      *   CollectionId?: string,
      *   Tags?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateCollectionRequest $input
      */
     public static function create($input): self

--- a/src/Service/Rekognition/src/Input/CreateProjectRequest.php
+++ b/src/Service/Rekognition/src/Input/CreateProjectRequest.php
@@ -49,6 +49,7 @@ final class CreateProjectRequest extends Input
      *   AutoUpdate?: ProjectAutoUpdate::*|null,
      *   Tags?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -67,6 +68,7 @@ final class CreateProjectRequest extends Input
      *   AutoUpdate?: ProjectAutoUpdate::*|null,
      *   Tags?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateProjectRequest $input
      */
     public static function create($input): self

--- a/src/Service/Rekognition/src/Input/DeleteCollectionRequest.php
+++ b/src/Service/Rekognition/src/Input/DeleteCollectionRequest.php
@@ -22,6 +22,7 @@ final class DeleteCollectionRequest extends Input
      * @param array{
      *   CollectionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class DeleteCollectionRequest extends Input
      * @param array{
      *   CollectionId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteCollectionRequest $input
      */
     public static function create($input): self

--- a/src/Service/Rekognition/src/Input/DeleteProjectRequest.php
+++ b/src/Service/Rekognition/src/Input/DeleteProjectRequest.php
@@ -22,6 +22,7 @@ final class DeleteProjectRequest extends Input
      * @param array{
      *   ProjectArn?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class DeleteProjectRequest extends Input
      * @param array{
      *   ProjectArn?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteProjectRequest $input
      */
     public static function create($input): self

--- a/src/Service/Rekognition/src/Input/DetectFacesRequest.php
+++ b/src/Service/Rekognition/src/Input/DetectFacesRequest.php
@@ -45,6 +45,7 @@ final class DetectFacesRequest extends Input
      *   Image?: Image|array,
      *   Attributes?: array<Attribute::*>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -59,6 +60,7 @@ final class DetectFacesRequest extends Input
      *   Image?: Image|array,
      *   Attributes?: array<Attribute::*>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DetectFacesRequest $input
      */
     public static function create($input): self

--- a/src/Service/Rekognition/src/Input/DetectModerationLabelsRequest.php
+++ b/src/Service/Rekognition/src/Input/DetectModerationLabelsRequest.php
@@ -57,6 +57,7 @@ final class DetectModerationLabelsRequest extends Input
      *   HumanLoopConfig?: HumanLoopConfig|array|null,
      *   ProjectVersion?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -75,6 +76,7 @@ final class DetectModerationLabelsRequest extends Input
      *   HumanLoopConfig?: HumanLoopConfig|array|null,
      *   ProjectVersion?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DetectModerationLabelsRequest $input
      */
     public static function create($input): self

--- a/src/Service/Rekognition/src/Input/GetCelebrityInfoRequest.php
+++ b/src/Service/Rekognition/src/Input/GetCelebrityInfoRequest.php
@@ -23,6 +23,7 @@ final class GetCelebrityInfoRequest extends Input
      * @param array{
      *   Id?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -35,6 +36,7 @@ final class GetCelebrityInfoRequest extends Input
      * @param array{
      *   Id?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetCelebrityInfoRequest $input
      */
     public static function create($input): self

--- a/src/Service/Rekognition/src/Input/IndexFacesRequest.php
+++ b/src/Service/Rekognition/src/Input/IndexFacesRequest.php
@@ -95,6 +95,7 @@ final class IndexFacesRequest extends Input
      *   MaxFaces?: int|null,
      *   QualityFilter?: QualityFilter::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -117,6 +118,7 @@ final class IndexFacesRequest extends Input
      *   MaxFaces?: int|null,
      *   QualityFilter?: QualityFilter::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|IndexFacesRequest $input
      */
     public static function create($input): self

--- a/src/Service/Rekognition/src/Input/ListCollectionsRequest.php
+++ b/src/Service/Rekognition/src/Input/ListCollectionsRequest.php
@@ -27,6 +27,7 @@ final class ListCollectionsRequest extends Input
      *   NextToken?: string|null,
      *   MaxResults?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -41,6 +42,7 @@ final class ListCollectionsRequest extends Input
      *   NextToken?: string|null,
      *   MaxResults?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListCollectionsRequest $input
      */
     public static function create($input): self

--- a/src/Service/Rekognition/src/Input/RecognizeCelebritiesRequest.php
+++ b/src/Service/Rekognition/src/Input/RecognizeCelebritiesRequest.php
@@ -27,6 +27,7 @@ final class RecognizeCelebritiesRequest extends Input
      * @param array{
      *   Image?: Image|array,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -39,6 +40,7 @@ final class RecognizeCelebritiesRequest extends Input
      * @param array{
      *   Image?: Image|array,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|RecognizeCelebritiesRequest $input
      */
     public static function create($input): self

--- a/src/Service/Rekognition/src/Input/SearchFacesByImageRequest.php
+++ b/src/Service/Rekognition/src/Input/SearchFacesByImageRequest.php
@@ -71,6 +71,7 @@ final class SearchFacesByImageRequest extends Input
      *   FaceMatchThreshold?: float|null,
      *   QualityFilter?: QualityFilter::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -91,6 +92,7 @@ final class SearchFacesByImageRequest extends Input
      *   FaceMatchThreshold?: float|null,
      *   QualityFilter?: QualityFilter::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|SearchFacesByImageRequest $input
      */
     public static function create($input): self

--- a/src/Service/Route53/composer.json
+++ b/src/Service/Route53/composer.json
@@ -15,7 +15,7 @@
         "ext-dom": "*",
         "ext-filter": "*",
         "ext-simplexml": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/Route53/src/Input/ChangeResourceRecordSetsRequest.php
+++ b/src/Service/Route53/src/Input/ChangeResourceRecordSetsRequest.php
@@ -36,6 +36,7 @@ final class ChangeResourceRecordSetsRequest extends Input
      *   HostedZoneId?: string,
      *   ChangeBatch?: ChangeBatch|array,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -50,6 +51,7 @@ final class ChangeResourceRecordSetsRequest extends Input
      *   HostedZoneId?: string,
      *   ChangeBatch?: ChangeBatch|array,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ChangeResourceRecordSetsRequest $input
      */
     public static function create($input): self

--- a/src/Service/Route53/src/Input/CreateHostedZoneRequest.php
+++ b/src/Service/Route53/src/Input/CreateHostedZoneRequest.php
@@ -91,6 +91,7 @@ final class CreateHostedZoneRequest extends Input
      *   HostedZoneConfig?: HostedZoneConfig|array|null,
      *   DelegationSetId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -111,6 +112,7 @@ final class CreateHostedZoneRequest extends Input
      *   HostedZoneConfig?: HostedZoneConfig|array|null,
      *   DelegationSetId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateHostedZoneRequest $input
      */
     public static function create($input): self

--- a/src/Service/Route53/src/Input/DeleteHostedZoneRequest.php
+++ b/src/Service/Route53/src/Input/DeleteHostedZoneRequest.php
@@ -25,6 +25,7 @@ final class DeleteHostedZoneRequest extends Input
      * @param array{
      *   Id?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -37,6 +38,7 @@ final class DeleteHostedZoneRequest extends Input
      * @param array{
      *   Id?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteHostedZoneRequest $input
      */
     public static function create($input): self

--- a/src/Service/Route53/src/Input/GetChangeRequest.php
+++ b/src/Service/Route53/src/Input/GetChangeRequest.php
@@ -26,6 +26,7 @@ final class GetChangeRequest extends Input
      * @param array{
      *   Id?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -38,6 +39,7 @@ final class GetChangeRequest extends Input
      * @param array{
      *   Id?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetChangeRequest $input
      */
     public static function create($input): self

--- a/src/Service/Route53/src/Input/ListHostedZonesByNameRequest.php
+++ b/src/Service/Route53/src/Input/ListHostedZonesByNameRequest.php
@@ -50,6 +50,7 @@ final class ListHostedZonesByNameRequest extends Input
      *   HostedZoneId?: string|null,
      *   MaxItems?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -66,6 +67,7 @@ final class ListHostedZonesByNameRequest extends Input
      *   HostedZoneId?: string|null,
      *   MaxItems?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListHostedZonesByNameRequest $input
      */
     public static function create($input): self

--- a/src/Service/Route53/src/Input/ListHostedZonesRequest.php
+++ b/src/Service/Route53/src/Input/ListHostedZonesRequest.php
@@ -58,6 +58,7 @@ final class ListHostedZonesRequest extends Input
      *   DelegationSetId?: string|null,
      *   HostedZoneType?: HostedZoneType::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -76,6 +77,7 @@ final class ListHostedZonesRequest extends Input
      *   DelegationSetId?: string|null,
      *   HostedZoneType?: HostedZoneType::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListHostedZonesRequest $input
      */
     public static function create($input): self

--- a/src/Service/Route53/src/Input/ListResourceRecordSetsRequest.php
+++ b/src/Service/Route53/src/Input/ListResourceRecordSetsRequest.php
@@ -83,6 +83,7 @@ final class ListResourceRecordSetsRequest extends Input
      *   StartRecordIdentifier?: string|null,
      *   MaxItems?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -103,6 +104,7 @@ final class ListResourceRecordSetsRequest extends Input
      *   StartRecordIdentifier?: string|null,
      *   MaxItems?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListResourceRecordSetsRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/composer.json
+++ b/src/Service/S3/composer.json
@@ -16,7 +16,7 @@
         "ext-filter": "*",
         "ext-hash": "*",
         "ext-simplexml": "*",
-        "async-aws/core": "^1.22"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/S3/src/Input/AbortMultipartUploadRequest.php
+++ b/src/Service/S3/src/Input/AbortMultipartUploadRequest.php
@@ -98,6 +98,7 @@ final class AbortMultipartUploadRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   IfMatchInitiatedTime?: \DateTimeImmutable|string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -120,6 +121,7 @@ final class AbortMultipartUploadRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   IfMatchInitiatedTime?: \DateTimeImmutable|string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AbortMultipartUploadRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/CompleteMultipartUploadRequest.php
+++ b/src/Service/S3/src/Input/CompleteMultipartUploadRequest.php
@@ -320,6 +320,7 @@ final class CompleteMultipartUploadRequest extends Input
      *   SSECustomerKey?: string|null,
      *   SSECustomerKeyMD5?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -376,6 +377,7 @@ final class CompleteMultipartUploadRequest extends Input
      *   SSECustomerKey?: string|null,
      *   SSECustomerKeyMD5?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CompleteMultipartUploadRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/CopyObjectRequest.php
+++ b/src/Service/S3/src/Input/CopyObjectRequest.php
@@ -775,6 +775,7 @@ final class CopyObjectRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   ExpectedSourceBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -871,6 +872,7 @@ final class CopyObjectRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   ExpectedSourceBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CopyObjectRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/CreateBucketRequest.php
+++ b/src/Service/S3/src/Input/CreateBucketRequest.php
@@ -149,6 +149,7 @@ final class CreateBucketRequest extends Input
      *   ObjectOwnership?: ObjectOwnership::*|null,
      *   BucketNamespace?: BucketNamespace::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -181,6 +182,7 @@ final class CreateBucketRequest extends Input
      *   ObjectOwnership?: ObjectOwnership::*|null,
      *   BucketNamespace?: BucketNamespace::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateBucketRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/CreateMultipartUploadRequest.php
+++ b/src/Service/S3/src/Input/CreateMultipartUploadRequest.php
@@ -577,6 +577,7 @@ final class CreateMultipartUploadRequest extends Input
      *   ChecksumAlgorithm?: ChecksumAlgorithm::*|null,
      *   ChecksumType?: ChecksumType::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -649,6 +650,7 @@ final class CreateMultipartUploadRequest extends Input
      *   ChecksumAlgorithm?: ChecksumAlgorithm::*|null,
      *   ChecksumType?: ChecksumType::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateMultipartUploadRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/DeleteBucketCorsRequest.php
+++ b/src/Service/S3/src/Input/DeleteBucketCorsRequest.php
@@ -31,6 +31,7 @@ final class DeleteBucketCorsRequest extends Input
      *   Bucket?: string,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -45,6 +46,7 @@ final class DeleteBucketCorsRequest extends Input
      *   Bucket?: string,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteBucketCorsRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/DeleteBucketRequest.php
+++ b/src/Service/S3/src/Input/DeleteBucketRequest.php
@@ -43,6 +43,7 @@ final class DeleteBucketRequest extends Input
      *   Bucket?: string,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -57,6 +58,7 @@ final class DeleteBucketRequest extends Input
      *   Bucket?: string,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteBucketRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/DeleteObjectRequest.php
+++ b/src/Service/S3/src/Input/DeleteObjectRequest.php
@@ -151,6 +151,7 @@ final class DeleteObjectRequest extends Input
      *   IfMatchLastModifiedTime?: \DateTimeImmutable|string|null,
      *   IfMatchSize?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -181,6 +182,7 @@ final class DeleteObjectRequest extends Input
      *   IfMatchLastModifiedTime?: \DateTimeImmutable|string|null,
      *   IfMatchSize?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteObjectRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/DeleteObjectTaggingRequest.php
+++ b/src/Service/S3/src/Input/DeleteObjectTaggingRequest.php
@@ -66,6 +66,7 @@ final class DeleteObjectTaggingRequest extends Input
      *   VersionId?: string|null,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -84,6 +85,7 @@ final class DeleteObjectTaggingRequest extends Input
      *   VersionId?: string|null,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteObjectTaggingRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/DeleteObjectsRequest.php
+++ b/src/Service/S3/src/Input/DeleteObjectsRequest.php
@@ -142,6 +142,7 @@ final class DeleteObjectsRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   ChecksumAlgorithm?: ChecksumAlgorithm::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -166,6 +167,7 @@ final class DeleteObjectsRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   ChecksumAlgorithm?: ChecksumAlgorithm::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteObjectsRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/GetBucketCorsRequest.php
+++ b/src/Service/S3/src/Input/GetBucketCorsRequest.php
@@ -41,6 +41,7 @@ final class GetBucketCorsRequest extends Input
      *   Bucket?: string,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -55,6 +56,7 @@ final class GetBucketCorsRequest extends Input
      *   Bucket?: string,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetBucketCorsRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/GetBucketEncryptionRequest.php
+++ b/src/Service/S3/src/Input/GetBucketEncryptionRequest.php
@@ -43,6 +43,7 @@ final class GetBucketEncryptionRequest extends Input
      *   Bucket?: string,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -57,6 +58,7 @@ final class GetBucketEncryptionRequest extends Input
      *   Bucket?: string,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetBucketEncryptionRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/GetBucketLifecycleConfigurationRequest.php
+++ b/src/Service/S3/src/Input/GetBucketLifecycleConfigurationRequest.php
@@ -34,6 +34,7 @@ final class GetBucketLifecycleConfigurationRequest extends Input
      *   Bucket?: string,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -48,6 +49,7 @@ final class GetBucketLifecycleConfigurationRequest extends Input
      *   Bucket?: string,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetBucketLifecycleConfigurationRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/GetBucketVersioningRequest.php
+++ b/src/Service/S3/src/Input/GetBucketVersioningRequest.php
@@ -31,6 +31,7 @@ final class GetBucketVersioningRequest extends Input
      *   Bucket?: string,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -45,6 +46,7 @@ final class GetBucketVersioningRequest extends Input
      *   Bucket?: string,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetBucketVersioningRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/GetObjectAclRequest.php
+++ b/src/Service/S3/src/Input/GetObjectAclRequest.php
@@ -68,6 +68,7 @@ final class GetObjectAclRequest extends Input
      *   RequestPayer?: RequestPayer::*|null,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -88,6 +89,7 @@ final class GetObjectAclRequest extends Input
      *   RequestPayer?: RequestPayer::*|null,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetObjectAclRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/GetObjectRequest.php
+++ b/src/Service/S3/src/Input/GetObjectRequest.php
@@ -320,6 +320,7 @@ final class GetObjectRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   ChecksumMode?: ChecksumMode::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -372,6 +373,7 @@ final class GetObjectRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   ChecksumMode?: ChecksumMode::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetObjectRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/GetObjectTaggingRequest.php
+++ b/src/Service/S3/src/Input/GetObjectTaggingRequest.php
@@ -73,6 +73,7 @@ final class GetObjectTaggingRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   RequestPayer?: RequestPayer::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -93,6 +94,7 @@ final class GetObjectTaggingRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   RequestPayer?: RequestPayer::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetObjectTaggingRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/HeadBucketRequest.php
+++ b/src/Service/S3/src/Input/HeadBucketRequest.php
@@ -64,6 +64,7 @@ final class HeadBucketRequest extends Input
      *   Bucket?: string,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -78,6 +79,7 @@ final class HeadBucketRequest extends Input
      *   Bucket?: string,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|HeadBucketRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/HeadObjectRequest.php
+++ b/src/Service/S3/src/Input/HeadObjectRequest.php
@@ -285,6 +285,7 @@ final class HeadObjectRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   ChecksumMode?: ChecksumMode::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -337,6 +338,7 @@ final class HeadObjectRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   ChecksumMode?: ChecksumMode::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|HeadObjectRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/ListBucketsRequest.php
+++ b/src/Service/S3/src/Input/ListBucketsRequest.php
@@ -63,6 +63,7 @@ final class ListBucketsRequest extends Input
      *   Prefix?: string|null,
      *   BucketRegion?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -81,6 +82,7 @@ final class ListBucketsRequest extends Input
      *   Prefix?: string|null,
      *   BucketRegion?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListBucketsRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/ListMultipartUploadsRequest.php
+++ b/src/Service/S3/src/Input/ListMultipartUploadsRequest.php
@@ -148,6 +148,7 @@ final class ListMultipartUploadsRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   RequestPayer?: RequestPayer::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -176,6 +177,7 @@ final class ListMultipartUploadsRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   RequestPayer?: RequestPayer::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListMultipartUploadsRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/ListObjectVersionsRequest.php
+++ b/src/Service/S3/src/Input/ListObjectVersionsRequest.php
@@ -106,6 +106,7 @@ final class ListObjectVersionsRequest extends Input
      *   RequestPayer?: RequestPayer::*|null,
      *   OptionalObjectAttributes?: array<OptionalObjectAttributes::*>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -136,6 +137,7 @@ final class ListObjectVersionsRequest extends Input
      *   RequestPayer?: RequestPayer::*|null,
      *   OptionalObjectAttributes?: array<OptionalObjectAttributes::*>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListObjectVersionsRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/ListObjectsV2Request.php
+++ b/src/Service/S3/src/Input/ListObjectsV2Request.php
@@ -170,6 +170,7 @@ final class ListObjectsV2Request extends Input
      *   ExpectedBucketOwner?: string|null,
      *   OptionalObjectAttributes?: array<OptionalObjectAttributes::*>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -202,6 +203,7 @@ final class ListObjectsV2Request extends Input
      *   ExpectedBucketOwner?: string|null,
      *   OptionalObjectAttributes?: array<OptionalObjectAttributes::*>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListObjectsV2Request $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/ListPartsRequest.php
+++ b/src/Service/S3/src/Input/ListPartsRequest.php
@@ -143,6 +143,7 @@ final class ListPartsRequest extends Input
      *   SSECustomerKey?: string|null,
      *   SSECustomerKeyMD5?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -173,6 +174,7 @@ final class ListPartsRequest extends Input
      *   SSECustomerKey?: string|null,
      *   SSECustomerKeyMD5?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListPartsRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/PutBucketCorsRequest.php
+++ b/src/Service/S3/src/Input/PutBucketCorsRequest.php
@@ -76,6 +76,7 @@ final class PutBucketCorsRequest extends Input
      *   ChecksumAlgorithm?: ChecksumAlgorithm::*|null,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -96,6 +97,7 @@ final class PutBucketCorsRequest extends Input
      *   ChecksumAlgorithm?: ChecksumAlgorithm::*|null,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutBucketCorsRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/PutBucketLifecycleConfigurationRequest.php
+++ b/src/Service/S3/src/Input/PutBucketLifecycleConfigurationRequest.php
@@ -80,6 +80,7 @@ final class PutBucketLifecycleConfigurationRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   TransitionDefaultMinimumObjectSize?: TransitionDefaultMinimumObjectSize::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -100,6 +101,7 @@ final class PutBucketLifecycleConfigurationRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   TransitionDefaultMinimumObjectSize?: TransitionDefaultMinimumObjectSize::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutBucketLifecycleConfigurationRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/PutBucketNotificationConfigurationRequest.php
+++ b/src/Service/S3/src/Input/PutBucketNotificationConfigurationRequest.php
@@ -48,6 +48,7 @@ final class PutBucketNotificationConfigurationRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   SkipDestinationValidation?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -66,6 +67,7 @@ final class PutBucketNotificationConfigurationRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   SkipDestinationValidation?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutBucketNotificationConfigurationRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/PutBucketTaggingRequest.php
+++ b/src/Service/S3/src/Input/PutBucketTaggingRequest.php
@@ -73,6 +73,7 @@ final class PutBucketTaggingRequest extends Input
      *   Tagging?: Tagging|array,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -93,6 +94,7 @@ final class PutBucketTaggingRequest extends Input
      *   Tagging?: Tagging|array,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutBucketTaggingRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/PutBucketVersioningRequest.php
+++ b/src/Service/S3/src/Input/PutBucketVersioningRequest.php
@@ -88,6 +88,7 @@ final class PutBucketVersioningRequest extends Input
      *   VersioningConfiguration?: VersioningConfiguration|array,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -110,6 +111,7 @@ final class PutBucketVersioningRequest extends Input
      *   VersioningConfiguration?: VersioningConfiguration|array,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutBucketVersioningRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/PutObjectAclRequest.php
+++ b/src/Service/S3/src/Input/PutObjectAclRequest.php
@@ -175,6 +175,7 @@ final class PutObjectAclRequest extends Input
      *   VersionId?: string|null,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -213,6 +214,7 @@ final class PutObjectAclRequest extends Input
      *   VersionId?: string|null,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutObjectAclRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/PutObjectRequest.php
+++ b/src/Service/S3/src/Input/PutObjectRequest.php
@@ -724,6 +724,7 @@ final class PutObjectRequest extends Input
      *   ObjectLockLegalHoldStatus?: ObjectLockLegalHoldStatus::*|null,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -826,6 +827,7 @@ final class PutObjectRequest extends Input
      *   ObjectLockLegalHoldStatus?: ObjectLockLegalHoldStatus::*|null,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutObjectRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/PutObjectTaggingRequest.php
+++ b/src/Service/S3/src/Input/PutObjectTaggingRequest.php
@@ -114,6 +114,7 @@ final class PutObjectTaggingRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   RequestPayer?: RequestPayer::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -140,6 +141,7 @@ final class PutObjectTaggingRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   RequestPayer?: RequestPayer::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutObjectTaggingRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/PutPublicAccessBlockRequest.php
+++ b/src/Service/S3/src/Input/PutPublicAccessBlockRequest.php
@@ -73,6 +73,7 @@ final class PutPublicAccessBlockRequest extends Input
      *   PublicAccessBlockConfiguration?: PublicAccessBlockConfiguration|array,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -93,6 +94,7 @@ final class PutPublicAccessBlockRequest extends Input
      *   PublicAccessBlockConfiguration?: PublicAccessBlockConfiguration|array,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutPublicAccessBlockRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/UploadPartCopyRequest.php
+++ b/src/Service/S3/src/Input/UploadPartCopyRequest.php
@@ -300,6 +300,7 @@ final class UploadPartCopyRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   ExpectedSourceBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -348,6 +349,7 @@ final class UploadPartCopyRequest extends Input
      *   ExpectedBucketOwner?: string|null,
      *   ExpectedSourceBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|UploadPartCopyRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/Input/UploadPartRequest.php
+++ b/src/Service/S3/src/Input/UploadPartRequest.php
@@ -295,6 +295,7 @@ final class UploadPartRequest extends Input
      *   RequestPayer?: RequestPayer::*|null,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -351,6 +352,7 @@ final class UploadPartRequest extends Input
      *   RequestPayer?: RequestPayer::*|null,
      *   ExpectedBucketOwner?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|UploadPartRequest $input
      */
     public static function create($input): self

--- a/src/Service/S3/src/S3Client.php
+++ b/src/Service/S3/src/S3Client.php
@@ -1740,6 +1740,7 @@ class S3Client extends AbstractApi
      *   ExpectedBucketOwner?: string|null,
      *   ChecksumMode?: ChecksumMode::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetObjectRequest $input
      *
      * @throws InvalidObjectStateException
@@ -1751,7 +1752,7 @@ class S3Client extends AbstractApi
         $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'GetObject', 'region' => $input->getRegion(), 'exceptionMapping' => [
             'InvalidObjectState' => InvalidObjectStateException::class,
             'NoSuchKey' => NoSuchKeyException::class,
-        ]]));
+        ], 'responseBuffer' => $input->shouldBufferResponse()]));
 
         return new GetObjectOutput($response);
     }

--- a/src/Service/S3/tests/Unit/Result/GetObjectOutputTest.php
+++ b/src/Service/S3/tests/Unit/Result/GetObjectOutputTest.php
@@ -3,6 +3,7 @@
 namespace AsyncAws\S3\Tests\Unit\Result;
 
 use AsyncAws\Core\Response;
+use AsyncAws\Core\Stream\ResponseBodyNonBufferedStream;
 use AsyncAws\Core\Test\Http\SimpleMockedResponse;
 use AsyncAws\S3\Result\GetObjectOutput;
 use PHPUnit\Framework\TestCase;
@@ -60,5 +61,24 @@ class GetObjectOutputTest extends TestCase
         self::assertArrayNotHasKey('x-amz-meta-tobias', $metadata);
         self::assertArrayHasKey('tobias', $metadata);
         self::assertEquals('nyholm', $metadata['tobias']);
+    }
+
+    public function testNonBufferedBodyStillPopulatesHeadersAndMetadata(): void
+    {
+        $headers = [
+            'last-modified' => 'Sat, 08 Feb 2020 15:55:28 GMT',
+            'etag' => '"9a0364b9e99bb480dd25e1f0284c8555"',
+            'x-amz-meta-tobias' => 'nyholm',
+            'content-type' => 'text/plain',
+            'content-length' => '7',
+        ];
+        $response = new SimpleMockedResponse('content', $headers);
+        $client = new MockHttpClient($response);
+        $result = new GetObjectOutput(new Response($client->request('POST', 'http://localhost'), $client, new NullLogger(), null, null, null, false, [], false));
+
+        self::assertEquals('"9a0364b9e99bb480dd25e1f0284c8555"', $result->getETag());
+        self::assertEquals('nyholm', $result->getMetadata()['tobias']);
+        self::assertInstanceOf(ResponseBodyNonBufferedStream::class, $result->getBody());
+        self::assertSame('content', $result->getBody()->getContentAsString());
     }
 }

--- a/src/Service/S3/tests/Unit/S3ClientTest.php
+++ b/src/Service/S3/tests/Unit/S3ClientTest.php
@@ -82,6 +82,7 @@ use AsyncAws\S3\ValueObject\Tagging;
 use AsyncAws\S3\ValueObject\TopicConfiguration;
 use AsyncAws\S3\ValueObject\VersioningConfiguration;
 use Symfony\Component\HttpClient\MockHttpClient;
+use Symfony\Contracts\HttpClient\ResponseInterface;
 
 class S3ClientTest extends TestCase
 {
@@ -342,6 +343,43 @@ class S3ClientTest extends TestCase
 
         self::assertInstanceOf(GetObjectOutput::class, $result);
         self::assertFalse($result->info()['resolved']);
+    }
+
+    public function testGetObjectDoesNotDisableResponseBufferingByDefault(): void
+    {
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {
+            self::assertSame('GET', $method);
+            self::assertNotSame(false, $options['buffer'] ?? null);
+
+            return new SimpleMockedResponse('content');
+        });
+        $client = new S3Client([], new NullProvider(), $httpClient);
+
+        $result = $client->getObject([
+            'Bucket' => 'example-bucket',
+            'Key' => 'file.png',
+        ]);
+
+        self::assertSame('content', $result->getBody()->getContentAsString());
+    }
+
+    public function testGetObjectCanDisableResponseBuffering(): void
+    {
+        $httpClient = new MockHttpClient(static function (string $method, string $url, array $options): ResponseInterface {
+            self::assertSame('GET', $method);
+            self::assertSame(false, $options['buffer'] ?? null);
+
+            return new SimpleMockedResponse('content');
+        });
+        $client = new S3Client([], new NullProvider(), $httpClient);
+
+        $result = $client->getObject([
+            'Bucket' => 'example-bucket',
+            'Key' => 'file.png',
+            '@responseBuffer' => false,
+        ]);
+
+        self::assertSame('content', $result->getBody()->getContentAsString());
     }
 
     public function testGetObjectAcl(): void

--- a/src/Service/S3Vectors/composer.json
+++ b/src/Service/S3Vectors/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/S3Vectors/src/Input/CreateIndexInput.php
+++ b/src/Service/S3Vectors/src/Input/CreateIndexInput.php
@@ -104,6 +104,7 @@ final class CreateIndexInput extends Input
      *   encryptionConfiguration?: EncryptionConfiguration|array|null,
      *   tags?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -132,6 +133,7 @@ final class CreateIndexInput extends Input
      *   encryptionConfiguration?: EncryptionConfiguration|array|null,
      *   tags?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateIndexInput $input
      */
     public static function create($input): self

--- a/src/Service/S3Vectors/src/Input/CreateVectorBucketInput.php
+++ b/src/Service/S3Vectors/src/Input/CreateVectorBucketInput.php
@@ -47,6 +47,7 @@ final class CreateVectorBucketInput extends Input
      *   encryptionConfiguration?: EncryptionConfiguration|array|null,
      *   tags?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -63,6 +64,7 @@ final class CreateVectorBucketInput extends Input
      *   encryptionConfiguration?: EncryptionConfiguration|array|null,
      *   tags?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateVectorBucketInput $input
      */
     public static function create($input): self

--- a/src/Service/S3Vectors/src/Input/DeleteIndexInput.php
+++ b/src/Service/S3Vectors/src/Input/DeleteIndexInput.php
@@ -35,6 +35,7 @@ final class DeleteIndexInput extends Input
      *   indexName?: string|null,
      *   indexArn?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -51,6 +52,7 @@ final class DeleteIndexInput extends Input
      *   indexName?: string|null,
      *   indexArn?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteIndexInput $input
      */
     public static function create($input): self

--- a/src/Service/S3Vectors/src/Input/DeleteVectorBucketInput.php
+++ b/src/Service/S3Vectors/src/Input/DeleteVectorBucketInput.php
@@ -27,6 +27,7 @@ final class DeleteVectorBucketInput extends Input
      *   vectorBucketName?: string|null,
      *   vectorBucketArn?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -41,6 +42,7 @@ final class DeleteVectorBucketInput extends Input
      *   vectorBucketName?: string|null,
      *   vectorBucketArn?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteVectorBucketInput $input
      */
     public static function create($input): self

--- a/src/Service/S3Vectors/src/Input/DeleteVectorsInput.php
+++ b/src/Service/S3Vectors/src/Input/DeleteVectorsInput.php
@@ -46,6 +46,7 @@ final class DeleteVectorsInput extends Input
      *   indexArn?: string|null,
      *   keys?: string[],
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -64,6 +65,7 @@ final class DeleteVectorsInput extends Input
      *   indexArn?: string|null,
      *   keys?: string[],
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteVectorsInput $input
      */
     public static function create($input): self

--- a/src/Service/S3Vectors/src/Input/GetIndexInput.php
+++ b/src/Service/S3Vectors/src/Input/GetIndexInput.php
@@ -35,6 +35,7 @@ final class GetIndexInput extends Input
      *   indexName?: string|null,
      *   indexArn?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -51,6 +52,7 @@ final class GetIndexInput extends Input
      *   indexName?: string|null,
      *   indexArn?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetIndexInput $input
      */
     public static function create($input): self

--- a/src/Service/S3Vectors/src/Input/GetVectorBucketInput.php
+++ b/src/Service/S3Vectors/src/Input/GetVectorBucketInput.php
@@ -27,6 +27,7 @@ final class GetVectorBucketInput extends Input
      *   vectorBucketName?: string|null,
      *   vectorBucketArn?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -41,6 +42,7 @@ final class GetVectorBucketInput extends Input
      *   vectorBucketName?: string|null,
      *   vectorBucketArn?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetVectorBucketInput $input
      */
     public static function create($input): self

--- a/src/Service/S3Vectors/src/Input/GetVectorsInput.php
+++ b/src/Service/S3Vectors/src/Input/GetVectorsInput.php
@@ -62,6 +62,7 @@ final class GetVectorsInput extends Input
      *   returnData?: bool|null,
      *   returnMetadata?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -84,6 +85,7 @@ final class GetVectorsInput extends Input
      *   returnData?: bool|null,
      *   returnMetadata?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetVectorsInput $input
      */
     public static function create($input): self

--- a/src/Service/S3Vectors/src/Input/ListIndexesInput.php
+++ b/src/Service/S3Vectors/src/Input/ListIndexesInput.php
@@ -51,6 +51,7 @@ final class ListIndexesInput extends Input
      *   nextToken?: string|null,
      *   prefix?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -71,6 +72,7 @@ final class ListIndexesInput extends Input
      *   nextToken?: string|null,
      *   prefix?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListIndexesInput $input
      */
     public static function create($input): self

--- a/src/Service/S3Vectors/src/Input/ListVectorBucketsInput.php
+++ b/src/Service/S3Vectors/src/Input/ListVectorBucketsInput.php
@@ -35,6 +35,7 @@ final class ListVectorBucketsInput extends Input
      *   nextToken?: string|null,
      *   prefix?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -51,6 +52,7 @@ final class ListVectorBucketsInput extends Input
      *   nextToken?: string|null,
      *   prefix?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListVectorBucketsInput $input
      */
     public static function create($input): self

--- a/src/Service/S3Vectors/src/Input/ListVectorsInput.php
+++ b/src/Service/S3Vectors/src/Input/ListVectorsInput.php
@@ -105,6 +105,7 @@ final class ListVectorsInput extends Input
      *   returnData?: bool|null,
      *   returnMetadata?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -133,6 +134,7 @@ final class ListVectorsInput extends Input
      *   returnData?: bool|null,
      *   returnMetadata?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListVectorsInput $input
      */
     public static function create($input): self

--- a/src/Service/S3Vectors/src/Input/PutVectorsInput.php
+++ b/src/Service/S3Vectors/src/Input/PutVectorsInput.php
@@ -49,6 +49,7 @@ final class PutVectorsInput extends Input
      *   indexArn?: string|null,
      *   vectors?: array<PutInputVector|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -67,6 +68,7 @@ final class PutVectorsInput extends Input
      *   indexArn?: string|null,
      *   vectors?: array<PutInputVector|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutVectorsInput $input
      */
     public static function create($input): self

--- a/src/Service/S3Vectors/src/Input/QueryVectorsInput.php
+++ b/src/Service/S3Vectors/src/Input/QueryVectorsInput.php
@@ -86,6 +86,7 @@ final class QueryVectorsInput extends Input
      *   returnMetadata?: bool|null,
      *   returnDistance?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -112,6 +113,7 @@ final class QueryVectorsInput extends Input
      *   returnMetadata?: bool|null,
      *   returnDistance?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|QueryVectorsInput $input
      */
     public static function create($input): self

--- a/src/Service/Scheduler/composer.json
+++ b/src/Service/Scheduler/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.9",
+        "async-aws/core": "^1.30",
         "symfony/polyfill-uuid": "^1.13.1"
     },
     "require-dev": {

--- a/src/Service/Scheduler/src/Input/CreateScheduleGroupInput.php
+++ b/src/Service/Scheduler/src/Input/CreateScheduleGroupInput.php
@@ -40,6 +40,7 @@ final class CreateScheduleGroupInput extends Input
      *   Name?: string,
      *   Tags?: array<Tag|array>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -56,6 +57,7 @@ final class CreateScheduleGroupInput extends Input
      *   Name?: string,
      *   Tags?: array<Tag|array>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateScheduleGroupInput $input
      */
     public static function create($input): self

--- a/src/Service/Scheduler/src/Input/CreateScheduleInput.php
+++ b/src/Service/Scheduler/src/Input/CreateScheduleInput.php
@@ -156,6 +156,7 @@ final class CreateScheduleInput extends Input
      *   State?: ScheduleState::*|null,
      *   Target?: Target|array,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -192,6 +193,7 @@ final class CreateScheduleInput extends Input
      *   State?: ScheduleState::*|null,
      *   Target?: Target|array,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateScheduleInput $input
      */
     public static function create($input): self

--- a/src/Service/Scheduler/src/Input/DeleteScheduleGroupInput.php
+++ b/src/Service/Scheduler/src/Input/DeleteScheduleGroupInput.php
@@ -31,6 +31,7 @@ final class DeleteScheduleGroupInput extends Input
      *   ClientToken?: string|null,
      *   Name?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -45,6 +46,7 @@ final class DeleteScheduleGroupInput extends Input
      *   ClientToken?: string|null,
      *   Name?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteScheduleGroupInput $input
      */
     public static function create($input): self

--- a/src/Service/Scheduler/src/Input/DeleteScheduleInput.php
+++ b/src/Service/Scheduler/src/Input/DeleteScheduleInput.php
@@ -39,6 +39,7 @@ final class DeleteScheduleInput extends Input
      *   GroupName?: string|null,
      *   Name?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -55,6 +56,7 @@ final class DeleteScheduleInput extends Input
      *   GroupName?: string|null,
      *   Name?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteScheduleInput $input
      */
     public static function create($input): self

--- a/src/Service/Scheduler/src/Input/GetScheduleGroupInput.php
+++ b/src/Service/Scheduler/src/Input/GetScheduleGroupInput.php
@@ -22,6 +22,7 @@ final class GetScheduleGroupInput extends Input
      * @param array{
      *   Name?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class GetScheduleGroupInput extends Input
      * @param array{
      *   Name?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetScheduleGroupInput $input
      */
     public static function create($input): self

--- a/src/Service/Scheduler/src/Input/GetScheduleInput.php
+++ b/src/Service/Scheduler/src/Input/GetScheduleInput.php
@@ -31,6 +31,7 @@ final class GetScheduleInput extends Input
      *   GroupName?: string|null,
      *   Name?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -45,6 +46,7 @@ final class GetScheduleInput extends Input
      *   GroupName?: string|null,
      *   Name?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetScheduleInput $input
      */
     public static function create($input): self

--- a/src/Service/Scheduler/src/Input/ListScheduleGroupsInput.php
+++ b/src/Service/Scheduler/src/Input/ListScheduleGroupsInput.php
@@ -36,6 +36,7 @@ final class ListScheduleGroupsInput extends Input
      *   NamePrefix?: string|null,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -52,6 +53,7 @@ final class ListScheduleGroupsInput extends Input
      *   NamePrefix?: string|null,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListScheduleGroupsInput $input
      */
     public static function create($input): self

--- a/src/Service/Scheduler/src/Input/ListSchedulesInput.php
+++ b/src/Service/Scheduler/src/Input/ListSchedulesInput.php
@@ -54,6 +54,7 @@ final class ListSchedulesInput extends Input
      *   NextToken?: string|null,
      *   State?: ScheduleState::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -74,6 +75,7 @@ final class ListSchedulesInput extends Input
      *   NextToken?: string|null,
      *   State?: ScheduleState::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListSchedulesInput $input
      */
     public static function create($input): self

--- a/src/Service/Scheduler/src/Input/UpdateScheduleInput.php
+++ b/src/Service/Scheduler/src/Input/UpdateScheduleInput.php
@@ -158,6 +158,7 @@ final class UpdateScheduleInput extends Input
      *   State?: ScheduleState::*|null,
      *   Target?: Target|array,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -194,6 +195,7 @@ final class UpdateScheduleInput extends Input
      *   State?: ScheduleState::*|null,
      *   Target?: Target|array,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|UpdateScheduleInput $input
      */
     public static function create($input): self

--- a/src/Service/SecretsManager/composer.json
+++ b/src/Service/SecretsManager/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.9",
+        "async-aws/core": "^1.30",
         "symfony/polyfill-uuid": "^1.13.1"
     },
     "require-dev": {

--- a/src/Service/SecretsManager/src/Input/CreateSecretRequest.php
+++ b/src/Service/SecretsManager/src/Input/CreateSecretRequest.php
@@ -183,6 +183,7 @@ final class CreateSecretRequest extends Input
      *   ForceOverwriteReplicaSecret?: bool|null,
      *   Type?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -213,6 +214,7 @@ final class CreateSecretRequest extends Input
      *   ForceOverwriteReplicaSecret?: bool|null,
      *   Type?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateSecretRequest $input
      */
     public static function create($input): self

--- a/src/Service/SecretsManager/src/Input/DeleteSecretRequest.php
+++ b/src/Service/SecretsManager/src/Input/DeleteSecretRequest.php
@@ -59,6 +59,7 @@ final class DeleteSecretRequest extends Input
      *   RecoveryWindowInDays?: int|null,
      *   ForceDeleteWithoutRecovery?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -75,6 +76,7 @@ final class DeleteSecretRequest extends Input
      *   RecoveryWindowInDays?: int|null,
      *   ForceDeleteWithoutRecovery?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteSecretRequest $input
      */
     public static function create($input): self

--- a/src/Service/SecretsManager/src/Input/GetSecretValueRequest.php
+++ b/src/Service/SecretsManager/src/Input/GetSecretValueRequest.php
@@ -53,6 +53,7 @@ final class GetSecretValueRequest extends Input
      *   VersionId?: string|null,
      *   VersionStage?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -69,6 +70,7 @@ final class GetSecretValueRequest extends Input
      *   VersionId?: string|null,
      *   VersionStage?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetSecretValueRequest $input
      */
     public static function create($input): self

--- a/src/Service/SecretsManager/src/Input/ListSecretsRequest.php
+++ b/src/Service/SecretsManager/src/Input/ListSecretsRequest.php
@@ -68,6 +68,7 @@ final class ListSecretsRequest extends Input
      *   SortOrder?: SortOrderType::*|null,
      *   SortBy?: SortByType::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -90,6 +91,7 @@ final class ListSecretsRequest extends Input
      *   SortOrder?: SortOrderType::*|null,
      *   SortBy?: SortByType::*|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListSecretsRequest $input
      */
     public static function create($input): self

--- a/src/Service/SecretsManager/src/Input/PutSecretValueRequest.php
+++ b/src/Service/SecretsManager/src/Input/PutSecretValueRequest.php
@@ -126,6 +126,7 @@ final class PutSecretValueRequest extends Input
      *   VersionStages?: string[]|null,
      *   RotationToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -148,6 +149,7 @@ final class PutSecretValueRequest extends Input
      *   VersionStages?: string[]|null,
      *   RotationToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutSecretValueRequest $input
      */
     public static function create($input): self

--- a/src/Service/SecretsManager/src/Input/UpdateSecretRequest.php
+++ b/src/Service/SecretsManager/src/Input/UpdateSecretRequest.php
@@ -125,6 +125,7 @@ final class UpdateSecretRequest extends Input
      *   SecretString?: string|null,
      *   Type?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -149,6 +150,7 @@ final class UpdateSecretRequest extends Input
      *   SecretString?: string|null,
      *   Type?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|UpdateSecretRequest $input
      */
     public static function create($input): self

--- a/src/Service/Ses/composer.json
+++ b/src/Service/Ses/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/Ses/src/Input/DeleteSuppressedDestinationRequest.php
+++ b/src/Service/Ses/src/Input/DeleteSuppressedDestinationRequest.php
@@ -25,6 +25,7 @@ final class DeleteSuppressedDestinationRequest extends Input
      * @param array{
      *   EmailAddress?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -37,6 +38,7 @@ final class DeleteSuppressedDestinationRequest extends Input
      * @param array{
      *   EmailAddress?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteSuppressedDestinationRequest $input
      */
     public static function create($input): self

--- a/src/Service/Ses/src/Input/GetSuppressedDestinationRequest.php
+++ b/src/Service/Ses/src/Input/GetSuppressedDestinationRequest.php
@@ -25,6 +25,7 @@ final class GetSuppressedDestinationRequest extends Input
      * @param array{
      *   EmailAddress?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -37,6 +38,7 @@ final class GetSuppressedDestinationRequest extends Input
      * @param array{
      *   EmailAddress?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetSuppressedDestinationRequest $input
      */
     public static function create($input): self

--- a/src/Service/Ses/src/Input/SendEmailRequest.php
+++ b/src/Service/Ses/src/Input/SendEmailRequest.php
@@ -151,6 +151,7 @@ final class SendEmailRequest extends Input
      *   TenantName?: string|null,
      *   ListManagementOptions?: ListManagementOptions|array|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -185,6 +186,7 @@ final class SendEmailRequest extends Input
      *   TenantName?: string|null,
      *   ListManagementOptions?: ListManagementOptions|array|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|SendEmailRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sns/composer.json
+++ b/src/Service/Sns/composer.json
@@ -14,7 +14,7 @@
         "php": "^8.2",
         "ext-filter": "*",
         "ext-simplexml": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/Sns/src/Input/CreatePlatformEndpointInput.php
+++ b/src/Service/Sns/src/Input/CreatePlatformEndpointInput.php
@@ -57,6 +57,7 @@ final class CreatePlatformEndpointInput extends Input
      *   CustomUserData?: string|null,
      *   Attributes?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -75,6 +76,7 @@ final class CreatePlatformEndpointInput extends Input
      *   CustomUserData?: string|null,
      *   Attributes?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreatePlatformEndpointInput $input
      */
     public static function create($input): self

--- a/src/Service/Sns/src/Input/CreateTopicInput.php
+++ b/src/Service/Sns/src/Input/CreateTopicInput.php
@@ -171,6 +171,7 @@ final class CreateTopicInput extends Input
      *   Tags?: array<Tag|array>|null,
      *   DataProtectionPolicy?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -189,6 +190,7 @@ final class CreateTopicInput extends Input
      *   Tags?: array<Tag|array>|null,
      *   DataProtectionPolicy?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateTopicInput $input
      */
     public static function create($input): self

--- a/src/Service/Sns/src/Input/DeleteEndpointInput.php
+++ b/src/Service/Sns/src/Input/DeleteEndpointInput.php
@@ -25,6 +25,7 @@ final class DeleteEndpointInput extends Input
      * @param array{
      *   EndpointArn?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -37,6 +38,7 @@ final class DeleteEndpointInput extends Input
      * @param array{
      *   EndpointArn?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteEndpointInput $input
      */
     public static function create($input): self

--- a/src/Service/Sns/src/Input/DeleteTopicInput.php
+++ b/src/Service/Sns/src/Input/DeleteTopicInput.php
@@ -22,6 +22,7 @@ final class DeleteTopicInput extends Input
      * @param array{
      *   TopicArn?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class DeleteTopicInput extends Input
      * @param array{
      *   TopicArn?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteTopicInput $input
      */
     public static function create($input): self

--- a/src/Service/Sns/src/Input/ListSubscriptionsByTopicInput.php
+++ b/src/Service/Sns/src/Input/ListSubscriptionsByTopicInput.php
@@ -33,6 +33,7 @@ final class ListSubscriptionsByTopicInput extends Input
      *   TopicArn?: string,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -47,6 +48,7 @@ final class ListSubscriptionsByTopicInput extends Input
      *   TopicArn?: string,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListSubscriptionsByTopicInput $input
      */
     public static function create($input): self

--- a/src/Service/Sns/src/Input/ListTopicsInput.php
+++ b/src/Service/Sns/src/Input/ListTopicsInput.php
@@ -19,6 +19,7 @@ final class ListTopicsInput extends Input
      * @param array{
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -31,6 +32,7 @@ final class ListTopicsInput extends Input
      * @param array{
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListTopicsInput $input
      */
     public static function create($input): self

--- a/src/Service/Sns/src/Input/PublishBatchInput.php
+++ b/src/Service/Sns/src/Input/PublishBatchInput.php
@@ -33,6 +33,7 @@ final class PublishBatchInput extends Input
      *   TopicArn?: string,
      *   PublishBatchRequestEntries?: array<PublishBatchRequestEntry|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -47,6 +48,7 @@ final class PublishBatchInput extends Input
      *   TopicArn?: string,
      *   PublishBatchRequestEntries?: array<PublishBatchRequestEntry|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PublishBatchInput $input
      */
     public static function create($input): self

--- a/src/Service/Sns/src/Input/PublishInput.php
+++ b/src/Service/Sns/src/Input/PublishInput.php
@@ -177,6 +177,7 @@ final class PublishInput extends Input
      *   MessageDeduplicationId?: string|null,
      *   MessageGroupId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -211,6 +212,7 @@ final class PublishInput extends Input
      *   MessageDeduplicationId?: string|null,
      *   MessageGroupId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PublishInput $input
      */
     public static function create($input): self

--- a/src/Service/Sns/src/Input/SubscribeInput.php
+++ b/src/Service/Sns/src/Input/SubscribeInput.php
@@ -133,6 +133,7 @@ final class SubscribeInput extends Input
      *   Attributes?: array<string, string>|null,
      *   ReturnSubscriptionArn?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -153,6 +154,7 @@ final class SubscribeInput extends Input
      *   Attributes?: array<string, string>|null,
      *   ReturnSubscriptionArn?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|SubscribeInput $input
      */
     public static function create($input): self

--- a/src/Service/Sns/src/Input/UnsubscribeInput.php
+++ b/src/Service/Sns/src/Input/UnsubscribeInput.php
@@ -25,6 +25,7 @@ final class UnsubscribeInput extends Input
      * @param array{
      *   SubscriptionArn?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -37,6 +38,7 @@ final class UnsubscribeInput extends Input
      * @param array{
      *   SubscriptionArn?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|UnsubscribeInput $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/composer.json
+++ b/src/Service/Sqs/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/Sqs/src/Input/AddPermissionRequest.php
+++ b/src/Service/Sqs/src/Input/AddPermissionRequest.php
@@ -69,6 +69,7 @@ final class AddPermissionRequest extends Input
      *   AWSAccountIds?: string[],
      *   Actions?: string[],
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -87,6 +88,7 @@ final class AddPermissionRequest extends Input
      *   AWSAccountIds?: string[],
      *   Actions?: string[],
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|AddPermissionRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/src/Input/CancelMessageMoveTaskRequest.php
+++ b/src/Service/Sqs/src/Input/CancelMessageMoveTaskRequest.php
@@ -22,6 +22,7 @@ final class CancelMessageMoveTaskRequest extends Input
      * @param array{
      *   TaskHandle?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class CancelMessageMoveTaskRequest extends Input
      * @param array{
      *   TaskHandle?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CancelMessageMoveTaskRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/src/Input/ChangeMessageVisibilityBatchRequest.php
+++ b/src/Service/Sqs/src/Input/ChangeMessageVisibilityBatchRequest.php
@@ -35,6 +35,7 @@ final class ChangeMessageVisibilityBatchRequest extends Input
      *   QueueUrl?: string,
      *   Entries?: array<ChangeMessageVisibilityBatchRequestEntry|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -49,6 +50,7 @@ final class ChangeMessageVisibilityBatchRequest extends Input
      *   QueueUrl?: string,
      *   Entries?: array<ChangeMessageVisibilityBatchRequestEntry|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ChangeMessageVisibilityBatchRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/src/Input/ChangeMessageVisibilityRequest.php
+++ b/src/Service/Sqs/src/Input/ChangeMessageVisibilityRequest.php
@@ -45,6 +45,7 @@ final class ChangeMessageVisibilityRequest extends Input
      *   ReceiptHandle?: string,
      *   VisibilityTimeout?: int,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -61,6 +62,7 @@ final class ChangeMessageVisibilityRequest extends Input
      *   ReceiptHandle?: string,
      *   VisibilityTimeout?: int,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ChangeMessageVisibilityRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/src/Input/CreateQueueRequest.php
+++ b/src/Service/Sqs/src/Input/CreateQueueRequest.php
@@ -194,6 +194,7 @@ final class CreateQueueRequest extends Input
      *   Attributes?: array<QueueAttributeName::*, string>|null,
      *   tags?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -210,6 +211,7 @@ final class CreateQueueRequest extends Input
      *   Attributes?: array<QueueAttributeName::*, string>|null,
      *   tags?: array<string, string>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateQueueRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/src/Input/DeleteMessageBatchRequest.php
+++ b/src/Service/Sqs/src/Input/DeleteMessageBatchRequest.php
@@ -35,6 +35,7 @@ final class DeleteMessageBatchRequest extends Input
      *   QueueUrl?: string,
      *   Entries?: array<DeleteMessageBatchRequestEntry|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -49,6 +50,7 @@ final class DeleteMessageBatchRequest extends Input
      *   QueueUrl?: string,
      *   Entries?: array<DeleteMessageBatchRequestEntry|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteMessageBatchRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/src/Input/DeleteMessageRequest.php
+++ b/src/Service/Sqs/src/Input/DeleteMessageRequest.php
@@ -34,6 +34,7 @@ final class DeleteMessageRequest extends Input
      *   QueueUrl?: string,
      *   ReceiptHandle?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -48,6 +49,7 @@ final class DeleteMessageRequest extends Input
      *   QueueUrl?: string,
      *   ReceiptHandle?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteMessageRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/src/Input/DeleteQueueRequest.php
+++ b/src/Service/Sqs/src/Input/DeleteQueueRequest.php
@@ -24,6 +24,7 @@ final class DeleteQueueRequest extends Input
      * @param array{
      *   QueueUrl?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -36,6 +37,7 @@ final class DeleteQueueRequest extends Input
      * @param array{
      *   QueueUrl?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteQueueRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/src/Input/GetQueueAttributesRequest.php
+++ b/src/Service/Sqs/src/Input/GetQueueAttributesRequest.php
@@ -158,6 +158,7 @@ final class GetQueueAttributesRequest extends Input
      *   QueueUrl?: string,
      *   AttributeNames?: array<QueueAttributeName::*>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -172,6 +173,7 @@ final class GetQueueAttributesRequest extends Input
      *   QueueUrl?: string,
      *   AttributeNames?: array<QueueAttributeName::*>|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetQueueAttributesRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/src/Input/GetQueueUrlRequest.php
+++ b/src/Service/Sqs/src/Input/GetQueueUrlRequest.php
@@ -35,6 +35,7 @@ final class GetQueueUrlRequest extends Input
      *   QueueName?: string,
      *   QueueOwnerAWSAccountId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -49,6 +50,7 @@ final class GetQueueUrlRequest extends Input
      *   QueueName?: string,
      *   QueueOwnerAWSAccountId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetQueueUrlRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/src/Input/ListDeadLetterSourceQueuesRequest.php
+++ b/src/Service/Sqs/src/Input/ListDeadLetterSourceQueuesRequest.php
@@ -41,6 +41,7 @@ final class ListDeadLetterSourceQueuesRequest extends Input
      *   NextToken?: string|null,
      *   MaxResults?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -57,6 +58,7 @@ final class ListDeadLetterSourceQueuesRequest extends Input
      *   NextToken?: string|null,
      *   MaxResults?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListDeadLetterSourceQueuesRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/src/Input/ListMessageMoveTasksRequest.php
+++ b/src/Service/Sqs/src/Input/ListMessageMoveTasksRequest.php
@@ -31,6 +31,7 @@ final class ListMessageMoveTasksRequest extends Input
      *   SourceArn?: string,
      *   MaxResults?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -45,6 +46,7 @@ final class ListMessageMoveTasksRequest extends Input
      *   SourceArn?: string,
      *   MaxResults?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListMessageMoveTasksRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/src/Input/ListQueuesRequest.php
+++ b/src/Service/Sqs/src/Input/ListQueuesRequest.php
@@ -39,6 +39,7 @@ final class ListQueuesRequest extends Input
      *   NextToken?: string|null,
      *   MaxResults?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -55,6 +56,7 @@ final class ListQueuesRequest extends Input
      *   NextToken?: string|null,
      *   MaxResults?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ListQueuesRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/src/Input/PurgeQueueRequest.php
+++ b/src/Service/Sqs/src/Input/PurgeQueueRequest.php
@@ -24,6 +24,7 @@ final class PurgeQueueRequest extends Input
      * @param array{
      *   QueueUrl?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -36,6 +37,7 @@ final class PurgeQueueRequest extends Input
      * @param array{
      *   QueueUrl?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PurgeQueueRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/src/Input/ReceiveMessageRequest.php
+++ b/src/Service/Sqs/src/Input/ReceiveMessageRequest.php
@@ -184,6 +184,7 @@ final class ReceiveMessageRequest extends Input
      *   WaitTimeSeconds?: int|null,
      *   ReceiveRequestAttemptId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -210,6 +211,7 @@ final class ReceiveMessageRequest extends Input
      *   WaitTimeSeconds?: int|null,
      *   ReceiveRequestAttemptId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|ReceiveMessageRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/src/Input/SendMessageBatchRequest.php
+++ b/src/Service/Sqs/src/Input/SendMessageBatchRequest.php
@@ -35,6 +35,7 @@ final class SendMessageBatchRequest extends Input
      *   QueueUrl?: string,
      *   Entries?: array<SendMessageBatchRequestEntry|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -49,6 +50,7 @@ final class SendMessageBatchRequest extends Input
      *   QueueUrl?: string,
      *   Entries?: array<SendMessageBatchRequestEntry|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|SendMessageBatchRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/src/Input/SendMessageRequest.php
+++ b/src/Service/Sqs/src/Input/SendMessageRequest.php
@@ -169,6 +169,7 @@ final class SendMessageRequest extends Input
      *   MessageDeduplicationId?: string|null,
      *   MessageGroupId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -205,6 +206,7 @@ final class SendMessageRequest extends Input
      *   MessageDeduplicationId?: string|null,
      *   MessageGroupId?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|SendMessageRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sqs/src/Input/StartMessageMoveTaskRequest.php
+++ b/src/Service/Sqs/src/Input/StartMessageMoveTaskRequest.php
@@ -45,6 +45,7 @@ final class StartMessageMoveTaskRequest extends Input
      *   DestinationArn?: string|null,
      *   MaxNumberOfMessagesPerSecond?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -61,6 +62,7 @@ final class StartMessageMoveTaskRequest extends Input
      *   DestinationArn?: string|null,
      *   MaxNumberOfMessagesPerSecond?: int|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|StartMessageMoveTaskRequest $input
      */
     public static function create($input): self

--- a/src/Service/Ssm/composer.json
+++ b/src/Service/Ssm/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/Ssm/src/Input/DeleteParameterRequest.php
+++ b/src/Service/Ssm/src/Input/DeleteParameterRequest.php
@@ -24,6 +24,7 @@ final class DeleteParameterRequest extends Input
      * @param array{
      *   Name?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -36,6 +37,7 @@ final class DeleteParameterRequest extends Input
      * @param array{
      *   Name?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteParameterRequest $input
      */
     public static function create($input): self

--- a/src/Service/Ssm/src/Input/DeleteParametersRequest.php
+++ b/src/Service/Ssm/src/Input/DeleteParametersRequest.php
@@ -25,6 +25,7 @@ final class DeleteParametersRequest extends Input
      * @param array{
      *   Names?: string[],
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -37,6 +38,7 @@ final class DeleteParametersRequest extends Input
      * @param array{
      *   Names?: string[],
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DeleteParametersRequest $input
      */
     public static function create($input): self

--- a/src/Service/Ssm/src/Input/GetParameterRequest.php
+++ b/src/Service/Ssm/src/Input/GetParameterRequest.php
@@ -39,6 +39,7 @@ final class GetParameterRequest extends Input
      *   Name?: string,
      *   WithDecryption?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -53,6 +54,7 @@ final class GetParameterRequest extends Input
      *   Name?: string,
      *   WithDecryption?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetParameterRequest $input
      */
     public static function create($input): self

--- a/src/Service/Ssm/src/Input/GetParametersByPathRequest.php
+++ b/src/Service/Ssm/src/Input/GetParametersByPathRequest.php
@@ -77,6 +77,7 @@ final class GetParametersByPathRequest extends Input
      *   MaxResults?: int|null,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -99,6 +100,7 @@ final class GetParametersByPathRequest extends Input
      *   MaxResults?: int|null,
      *   NextToken?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetParametersByPathRequest $input
      */
     public static function create($input): self

--- a/src/Service/Ssm/src/Input/GetParametersRequest.php
+++ b/src/Service/Ssm/src/Input/GetParametersRequest.php
@@ -41,6 +41,7 @@ final class GetParametersRequest extends Input
      *   Names?: string[],
      *   WithDecryption?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -55,6 +56,7 @@ final class GetParametersRequest extends Input
      *   Names?: string[],
      *   WithDecryption?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetParametersRequest $input
      */
     public static function create($input): self

--- a/src/Service/Ssm/src/Input/PutParameterRequest.php
+++ b/src/Service/Ssm/src/Input/PutParameterRequest.php
@@ -261,6 +261,7 @@ final class PutParameterRequest extends Input
      *   Policies?: string|null,
      *   DataType?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -293,6 +294,7 @@ final class PutParameterRequest extends Input
      *   Policies?: string|null,
      *   DataType?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutParameterRequest $input
      */
     public static function create($input): self

--- a/src/Service/Sso/composer.json
+++ b/src/Service/Sso/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/Sso/src/Input/GetRoleCredentialsRequest.php
+++ b/src/Service/Sso/src/Input/GetRoleCredentialsRequest.php
@@ -45,6 +45,7 @@ final class GetRoleCredentialsRequest extends Input
      *   accountId?: string,
      *   accessToken?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -61,6 +62,7 @@ final class GetRoleCredentialsRequest extends Input
      *   accountId?: string,
      *   accessToken?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|GetRoleCredentialsRequest $input
      */
     public static function create($input): self

--- a/src/Service/SsoOidc/composer.json
+++ b/src/Service/SsoOidc/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/SsoOidc/src/Input/CreateTokenRequest.php
+++ b/src/Service/SsoOidc/src/Input/CreateTokenRequest.php
@@ -109,6 +109,7 @@ final class CreateTokenRequest extends Input
      *   redirectUri?: string|null,
      *   codeVerifier?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -137,6 +138,7 @@ final class CreateTokenRequest extends Input
      *   redirectUri?: string|null,
      *   codeVerifier?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CreateTokenRequest $input
      */
     public static function create($input): self

--- a/src/Service/StepFunctions/composer.json
+++ b/src/Service/StepFunctions/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/StepFunctions/src/Input/SendTaskFailureInput.php
+++ b/src/Service/StepFunctions/src/Input/SendTaskFailureInput.php
@@ -41,6 +41,7 @@ final class SendTaskFailureInput extends Input
      *   error?: string|null,
      *   cause?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -57,6 +58,7 @@ final class SendTaskFailureInput extends Input
      *   error?: string|null,
      *   cause?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|SendTaskFailureInput $input
      */
     public static function create($input): self

--- a/src/Service/StepFunctions/src/Input/SendTaskHeartbeatInput.php
+++ b/src/Service/StepFunctions/src/Input/SendTaskHeartbeatInput.php
@@ -25,6 +25,7 @@ final class SendTaskHeartbeatInput extends Input
      * @param array{
      *   taskToken?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -37,6 +38,7 @@ final class SendTaskHeartbeatInput extends Input
      * @param array{
      *   taskToken?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|SendTaskHeartbeatInput $input
      */
     public static function create($input): self

--- a/src/Service/StepFunctions/src/Input/SendTaskSuccessInput.php
+++ b/src/Service/StepFunctions/src/Input/SendTaskSuccessInput.php
@@ -36,6 +36,7 @@ final class SendTaskSuccessInput extends Input
      *   taskToken?: string,
      *   output?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -50,6 +51,7 @@ final class SendTaskSuccessInput extends Input
      *   taskToken?: string,
      *   output?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|SendTaskSuccessInput $input
      */
     public static function create($input): self

--- a/src/Service/StepFunctions/src/Input/StartExecutionInput.php
+++ b/src/Service/StepFunctions/src/Input/StartExecutionInput.php
@@ -100,6 +100,7 @@ final class StartExecutionInput extends Input
      *   input?: string|null,
      *   traceHeader?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -118,6 +119,7 @@ final class StartExecutionInput extends Input
      *   input?: string|null,
      *   traceHeader?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|StartExecutionInput $input
      */
     public static function create($input): self

--- a/src/Service/StepFunctions/src/Input/StopExecutionInput.php
+++ b/src/Service/StepFunctions/src/Input/StopExecutionInput.php
@@ -38,6 +38,7 @@ final class StopExecutionInput extends Input
      *   error?: string|null,
      *   cause?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -54,6 +55,7 @@ final class StopExecutionInput extends Input
      *   error?: string|null,
      *   cause?: string|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|StopExecutionInput $input
      */
     public static function create($input): self

--- a/src/Service/TimestreamQuery/composer.json
+++ b/src/Service/TimestreamQuery/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": "^8.2",
         "ext-filter": "*",
-        "async-aws/core": "^1.16",
+        "async-aws/core": "^1.30",
         "symfony/polyfill-uuid": "^1.13.1"
     },
     "require-dev": {

--- a/src/Service/TimestreamQuery/src/Input/CancelQueryRequest.php
+++ b/src/Service/TimestreamQuery/src/Input/CancelQueryRequest.php
@@ -22,6 +22,7 @@ final class CancelQueryRequest extends Input
      * @param array{
      *   QueryId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class CancelQueryRequest extends Input
      * @param array{
      *   QueryId?: string,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|CancelQueryRequest $input
      */
     public static function create($input): self

--- a/src/Service/TimestreamQuery/src/Input/DescribeEndpointsRequest.php
+++ b/src/Service/TimestreamQuery/src/Input/DescribeEndpointsRequest.php
@@ -11,6 +11,7 @@ final class DescribeEndpointsRequest extends Input
     /**
      * @param array{
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -21,6 +22,7 @@ final class DescribeEndpointsRequest extends Input
     /**
      * @param array{
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DescribeEndpointsRequest $input
      */
     public static function create($input): self

--- a/src/Service/TimestreamQuery/src/Input/PrepareQueryRequest.php
+++ b/src/Service/TimestreamQuery/src/Input/PrepareQueryRequest.php
@@ -32,6 +32,7 @@ final class PrepareQueryRequest extends Input
      *   QueryString?: string,
      *   ValidateOnly?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -46,6 +47,7 @@ final class PrepareQueryRequest extends Input
      *   QueryString?: string,
      *   ValidateOnly?: bool|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PrepareQueryRequest $input
      */
     public static function create($input): self

--- a/src/Service/TimestreamQuery/src/Input/QueryRequest.php
+++ b/src/Service/TimestreamQuery/src/Input/QueryRequest.php
@@ -97,6 +97,7 @@ final class QueryRequest extends Input
      *   MaxRows?: int|null,
      *   QueryInsights?: QueryInsights|array|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -117,6 +118,7 @@ final class QueryRequest extends Input
      *   MaxRows?: int|null,
      *   QueryInsights?: QueryInsights|array|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|QueryRequest $input
      */
     public static function create($input): self

--- a/src/Service/TimestreamWrite/composer.json
+++ b/src/Service/TimestreamWrite/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.16"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/TimestreamWrite/src/Input/DescribeEndpointsRequest.php
+++ b/src/Service/TimestreamWrite/src/Input/DescribeEndpointsRequest.php
@@ -11,6 +11,7 @@ final class DescribeEndpointsRequest extends Input
     /**
      * @param array{
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -21,6 +22,7 @@ final class DescribeEndpointsRequest extends Input
     /**
      * @param array{
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|DescribeEndpointsRequest $input
      */
     public static function create($input): self

--- a/src/Service/TimestreamWrite/src/Input/WriteRecordsRequest.php
+++ b/src/Service/TimestreamWrite/src/Input/WriteRecordsRequest.php
@@ -55,6 +55,7 @@ final class WriteRecordsRequest extends Input
      *   CommonAttributes?: Record|array|null,
      *   Records?: array<Record|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -73,6 +74,7 @@ final class WriteRecordsRequest extends Input
      *   CommonAttributes?: Record|array|null,
      *   Records?: array<Record|array>,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|WriteRecordsRequest $input
      */
     public static function create($input): self

--- a/src/Service/Translate/composer.json
+++ b/src/Service/Translate/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/Translate/src/Input/TranslateTextRequest.php
+++ b/src/Service/Translate/src/Input/TranslateTextRequest.php
@@ -85,6 +85,7 @@ final class TranslateTextRequest extends Input
      *   TargetLanguageCode?: string,
      *   Settings?: TranslationSettings|array|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -105,6 +106,7 @@ final class TranslateTextRequest extends Input
      *   TargetLanguageCode?: string,
      *   Settings?: TranslationSettings|array|null,
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|TranslateTextRequest $input
      */
     public static function create($input): self

--- a/src/Service/XRay/composer.json
+++ b/src/Service/XRay/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "async-aws/core": "^1.9"
+        "async-aws/core": "^1.30"
     },
     "require-dev": {
         "phpunit/phpunit": "^11.5.42",

--- a/src/Service/XRay/src/Input/PutTraceSegmentsRequest.php
+++ b/src/Service/XRay/src/Input/PutTraceSegmentsRequest.php
@@ -22,6 +22,7 @@ final class PutTraceSegmentsRequest extends Input
      * @param array{
      *   TraceSegmentDocuments?: string[],
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * } $input
      */
     public function __construct(array $input = [])
@@ -34,6 +35,7 @@ final class PutTraceSegmentsRequest extends Input
      * @param array{
      *   TraceSegmentDocuments?: string[],
      *   '@region'?: string|null,
+     *   '@responseBuffer'?: bool,
      * }|PutTraceSegmentsRequest $input
      */
     public static function create($input): self


### PR DESCRIPTION
Allow streaming output operations to opt out of response buffering so large downloads can be consumed without temp storage while keeping buffered behavior as the default. My use case is streaming a large CSV file out of S3. Without this change, I have to go around the SDK and create a presigned URL and download it myself using another HTTP client. Without the ability to turn off buffering, the entire file gets written to `/tmp`.