### PR TITLE
Add CompareFaces method support to Rekognition client

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -514,6 +514,7 @@
             "example": "https://raw.githubusercontent.com/aws/aws-sdk-php/${LATEST}/src/data/rekognition/2016-06-27/examples-1.json",
             "api-reference": "https://docs.aws.amazon.com/rekognition/latest/dg",
             "methods": [
+                "CompareFaces",
                 "CreateCollection",
                 "CreateProject",
                 "DeleteCollection",

--- a/src/Service/Rekognition/CHANGELOG.md
+++ b/src/Service/Rekognition/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Added
+
+- Added operation `compareFaces`
+
 ## 1.8.0
 
 ### Added

--- a/src/Service/Rekognition/composer.json
+++ b/src/Service/Rekognition/composer.json
@@ -32,7 +32,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.8-dev"
+            "dev-master": "1.9-dev"
         }
     }
 }

--- a/src/Service/Rekognition/src/Input/CompareFacesRequest.php
+++ b/src/Service/Rekognition/src/Input/CompareFacesRequest.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace AsyncAws\Rekognition\Input;
+
+use AsyncAws\Core\Exception\InvalidArgument;
+use AsyncAws\Core\Input;
+use AsyncAws\Core\Request;
+use AsyncAws\Core\Stream\StreamFactory;
+use AsyncAws\Rekognition\Enum\QualityFilter;
+use AsyncAws\Rekognition\ValueObject\Image;
+
+final class CompareFacesRequest extends Input
+{
+    /**
+     * The input image as base64-encoded bytes or an S3 object. If you use the AWS CLI to call Amazon Rekognition
+     * operations, passing base64-encoded image bytes is not supported.
+     *
+     * If you are using an AWS SDK to call Amazon Rekognition, you might not need to base64-encode image bytes passed using
+     * the `Bytes` field. For more information, see Images in the Amazon Rekognition developer guide.
+     *
+     * @required
+     *
+     * @var Image|null
+     */
+    private $sourceImage;
+
+    /**
+     * The target image as base64-encoded bytes or an S3 object. If you use the AWS CLI to call Amazon Rekognition
+     * operations, passing base64-encoded image bytes is not supported.
+     *
+     * If you are using an AWS SDK to call Amazon Rekognition, you might not need to base64-encode image bytes passed using
+     * the `Bytes` field. For more information, see Images in the Amazon Rekognition developer guide.
+     *
+     * @required
+     *
+     * @var Image|null
+     */
+    private $targetImage;
+
+    /**
+     * The minimum level of confidence in the face matches that a match must meet to be included in the `FaceMatches` array.
+     *
+     * @var float|null
+     */
+    private $similarityThreshold;
+
+    /**
+     * A filter that specifies a quality bar for how much filtering is done to identify faces. Filtered faces aren't
+     * compared. If you specify `AUTO`, Amazon Rekognition chooses the quality bar. If you specify `LOW`, `MEDIUM`, or
+     * `HIGH`, filtering removes all faces that don’t meet the chosen quality bar. The quality bar is based on a variety
+     * of common use cases. Low-quality detections can occur for a number of reasons. Some examples are an object that's
+     * misidentified as a face, a face that's too blurry, or a face with a pose that's too extreme to use. If you specify
+     * `NONE`, no filtering is performed. The default value is `NONE`.
+     *
+     * To use quality filtering, the collection you are using must be associated with version 3 of the face model or higher.
+     *
+     * @var QualityFilter::*|null
+     */
+    private $qualityFilter;
+
+    /**
+     * @param array{
+     *   SourceImage?: Image|array,
+     *   TargetImage?: Image|array,
+     *   SimilarityThreshold?: float|null,
+     *   QualityFilter?: QualityFilter::*|null,
+     *   '@region'?: string|null,
+     * } $input
+     */
+    public function __construct(array $input = [])
+    {
+        $this->sourceImage = isset($input['SourceImage']) ? Image::create($input['SourceImage']) : null;
+        $this->targetImage = isset($input['TargetImage']) ? Image::create($input['TargetImage']) : null;
+        $this->similarityThreshold = $input['SimilarityThreshold'] ?? null;
+        $this->qualityFilter = $input['QualityFilter'] ?? null;
+        parent::__construct($input);
+    }
+
+    /**
+     * @param array{
+     *   SourceImage?: Image|array,
+     *   TargetImage?: Image|array,
+     *   SimilarityThreshold?: float|null,
+     *   QualityFilter?: QualityFilter::*|null,
+     *   '@region'?: string|null,
+     * }|CompareFacesRequest $input
+     */
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    /**
+     * @return QualityFilter::*|null
+     */
+    public function getQualityFilter(): ?string
+    {
+        return $this->qualityFilter;
+    }
+
+    public function getSimilarityThreshold(): ?float
+    {
+        return $this->similarityThreshold;
+    }
+
+    public function getSourceImage(): ?Image
+    {
+        return $this->sourceImage;
+    }
+
+    public function getTargetImage(): ?Image
+    {
+        return $this->targetImage;
+    }
+
+    /**
+     * @internal
+     */
+    public function request(): Request
+    {
+        // Prepare headers
+        $headers = [
+            'Content-Type' => 'application/x-amz-json-1.1',
+            'X-Amz-Target' => 'RekognitionService.CompareFaces',
+            'Accept' => 'application/json',
+        ];
+
+        // Prepare query
+        $query = [];
+
+        // Prepare URI
+        $uriString = '/';
+
+        // Prepare Body
+        $bodyPayload = $this->requestBody();
+        $body = empty($bodyPayload) ? '{}' : json_encode($bodyPayload, 4194304);
+
+        // Return the Request
+        return new Request('POST', $uriString, $query, $headers, StreamFactory::create($body));
+    }
+
+    /**
+     * @param QualityFilter::*|null $value
+     */
+    public function setQualityFilter(?string $value): self
+    {
+        $this->qualityFilter = $value;
+
+        return $this;
+    }
+
+    public function setSimilarityThreshold(?float $value): self
+    {
+        $this->similarityThreshold = $value;
+
+        return $this;
+    }
+
+    public function setSourceImage(?Image $value): self
+    {
+        $this->sourceImage = $value;
+
+        return $this;
+    }
+
+    public function setTargetImage(?Image $value): self
+    {
+        $this->targetImage = $value;
+
+        return $this;
+    }
+
+    private function requestBody(): array
+    {
+        $payload = [];
+        if (null === $v = $this->sourceImage) {
+            throw new InvalidArgument(\sprintf('Missing parameter "SourceImage" for "%s". The value cannot be null.', __CLASS__));
+        }
+        $payload['SourceImage'] = $v->requestBody();
+        if (null === $v = $this->targetImage) {
+            throw new InvalidArgument(\sprintf('Missing parameter "TargetImage" for "%s". The value cannot be null.', __CLASS__));
+        }
+        $payload['TargetImage'] = $v->requestBody();
+        if (null !== $v = $this->similarityThreshold) {
+            $payload['SimilarityThreshold'] = $v;
+        }
+        if (null !== $v = $this->qualityFilter) {
+            if (!QualityFilter::exists($v)) {
+                /** @psalm-suppress NoValue */
+                throw new InvalidArgument(\sprintf('Invalid parameter "QualityFilter" for "%s". The value "%s" is not a valid "QualityFilter".', __CLASS__, $v));
+            }
+            $payload['QualityFilter'] = $v;
+        }
+
+        return $payload;
+    }
+}

--- a/src/Service/Rekognition/src/RekognitionClient.php
+++ b/src/Service/Rekognition/src/RekognitionClient.php
@@ -27,6 +27,7 @@ use AsyncAws\Rekognition\Exception\ResourceNotFoundException;
 use AsyncAws\Rekognition\Exception\ResourceNotReadyException;
 use AsyncAws\Rekognition\Exception\ServiceQuotaExceededException;
 use AsyncAws\Rekognition\Exception\ThrottlingException;
+use AsyncAws\Rekognition\Input\CompareFacesRequest;
 use AsyncAws\Rekognition\Input\CreateCollectionRequest;
 use AsyncAws\Rekognition\Input\CreateProjectRequest;
 use AsyncAws\Rekognition\Input\DeleteCollectionRequest;
@@ -38,6 +39,7 @@ use AsyncAws\Rekognition\Input\IndexFacesRequest;
 use AsyncAws\Rekognition\Input\ListCollectionsRequest;
 use AsyncAws\Rekognition\Input\RecognizeCelebritiesRequest;
 use AsyncAws\Rekognition\Input\SearchFacesByImageRequest;
+use AsyncAws\Rekognition\Result\CompareFacesResponse;
 use AsyncAws\Rekognition\Result\CreateCollectionResponse;
 use AsyncAws\Rekognition\Result\CreateProjectResponse;
 use AsyncAws\Rekognition\Result\DeleteCollectionResponse;
@@ -54,6 +56,87 @@ use AsyncAws\Rekognition\ValueObject\Image;
 
 class RekognitionClient extends AbstractApi
 {
+    /**
+     * Compares a face in the *source* input image with each of the 100 largest faces detected in the *target* input image.
+     *
+     * If the source image contains multiple faces, the service detects the largest face and compares it with each face
+     * detected in the target image.
+     *
+     * > CompareFaces uses machine learning algorithms, which are probabilistic. A false negative is an incorrect prediction
+     * > that a face in the target image has a low similarity confidence score when compared to the face in the source
+     * > image. To reduce the probability of false negatives, we recommend that you compare the target image against
+     * > multiple source images. If you plan to use `CompareFaces` to make a decision that impacts an individual's rights,
+     * > privacy, or access to services, we recommend that you pass the result to a human for review and further validation
+     * > before taking action.
+     *
+     * You pass the input and target images either as base64-encoded image bytes or as references to images in an Amazon S3
+     * bucket. If you use the AWS CLI to call Amazon Rekognition operations, passing image bytes isn't supported. The image
+     * must be formatted as a PNG or JPEG file.
+     *
+     * In response, the operation returns an array of face matches ordered by similarity score in descending order. For each
+     * face match, the response provides a bounding box of the face, facial landmarks, pose details (pitch, roll, and yaw),
+     * quality (brightness and sharpness), and confidence value (indicating the level of confidence that the bounding box
+     * contains a face). The response also provides a similarity score, which indicates how closely the faces match.
+     *
+     * > By default, only faces with a similarity score of greater than or equal to 80% are returned in the response. You
+     * > can change this value by specifying the `SimilarityThreshold` parameter.
+     *
+     * `CompareFaces` also returns an array of faces that don't match the source image. For each face, it returns a bounding
+     * box, confidence value, landmarks, pose details, and quality. The response also returns information about the face in
+     * the source image, including the bounding box of the face and confidence value.
+     *
+     * The `QualityFilter` input parameter allows you to filter out detected faces that don’t meet a required quality bar.
+     * The quality bar is based on a variety of common use cases. Use `QualityFilter` to set the quality bar by specifying
+     * `LOW`, `MEDIUM`, or `HIGH`. If you do not want to filter detected faces, specify `NONE`. The default value is `NONE`.
+     *
+     * If the image doesn't contain Exif metadata, `CompareFaces` returns orientation information for the source and target
+     * images. Use these values to display the images with the correct image orientation.
+     *
+     * If no faces are detected in the source or target images, `CompareFaces` returns an `InvalidParameterException` error.
+     *
+     * > This is a stateless API operation. That is, data returned by this operation doesn't persist.
+     *
+     * For an example, see Comparing Faces in Images in the Amazon Rekognition Developer Guide.
+     *
+     * This operation requires permissions to perform the `rekognition:CompareFaces` action.
+     *
+     * @see https://docs.aws.amazon.com/rekognition/latest/dg/API_CompareFaces.html
+     * @see https://docs.aws.amazon.com/aws-sdk-php/v3/api/api-rekognition-2016-06-27.html#comparefaces
+     *
+     * @param array{
+     *   SourceImage: Image|array,
+     *   TargetImage: Image|array,
+     *   SimilarityThreshold?: float|null,
+     *   QualityFilter?: QualityFilter::*|null,
+     *   '@region'?: string|null,
+     * }|CompareFacesRequest $input
+     *
+     * @throws AccessDeniedException
+     * @throws ImageTooLargeException
+     * @throws InternalServerErrorException
+     * @throws InvalidImageFormatException
+     * @throws InvalidParameterException
+     * @throws InvalidS3ObjectException
+     * @throws ProvisionedThroughputExceededException
+     * @throws ThrottlingException
+     */
+    public function compareFaces($input): CompareFacesResponse
+    {
+        $input = CompareFacesRequest::create($input);
+        $response = $this->getResponse($input->request(), new RequestContext(['operation' => 'CompareFaces', 'region' => $input->getRegion(), 'exceptionMapping' => [
+            'AccessDeniedException' => AccessDeniedException::class,
+            'ImageTooLargeException' => ImageTooLargeException::class,
+            'InternalServerError' => InternalServerErrorException::class,
+            'InvalidImageFormatException' => InvalidImageFormatException::class,
+            'InvalidParameterException' => InvalidParameterException::class,
+            'InvalidS3ObjectException' => InvalidS3ObjectException::class,
+            'ProvisionedThroughputExceededException' => ProvisionedThroughputExceededException::class,
+            'ThrottlingException' => ThrottlingException::class,
+        ]]));
+
+        return new CompareFacesResponse($response);
+    }
+
     /**
      * Creates a collection in an AWS Region. You can add faces to the collection using the IndexFaces operation.
      *

--- a/src/Service/Rekognition/src/Result/CompareFacesResponse.php
+++ b/src/Service/Rekognition/src/Result/CompareFacesResponse.php
@@ -1,0 +1,267 @@
+<?php
+
+namespace AsyncAws\Rekognition\Result;
+
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Result;
+use AsyncAws\Rekognition\Enum\EmotionName;
+use AsyncAws\Rekognition\Enum\LandmarkType;
+use AsyncAws\Rekognition\Enum\OrientationCorrection;
+use AsyncAws\Rekognition\ValueObject\BoundingBox;
+use AsyncAws\Rekognition\ValueObject\ComparedFace;
+use AsyncAws\Rekognition\ValueObject\ComparedSourceImageFace;
+use AsyncAws\Rekognition\ValueObject\CompareFacesMatch;
+use AsyncAws\Rekognition\ValueObject\Emotion;
+use AsyncAws\Rekognition\ValueObject\ImageQuality;
+use AsyncAws\Rekognition\ValueObject\Landmark;
+use AsyncAws\Rekognition\ValueObject\Pose;
+use AsyncAws\Rekognition\ValueObject\Smile;
+
+class CompareFacesResponse extends Result
+{
+    /**
+     * The face in the source image that was used for comparison.
+     *
+     * @var ComparedSourceImageFace|null
+     */
+    private $sourceImageFace;
+
+    /**
+     * An array of faces in the target image that match the source image face. Each `CompareFacesMatch` object provides the
+     * bounding box, the confidence level that the bounding box contains a face, and the similarity score for the face in
+     * the bounding box and the face in the source image.
+     *
+     * @var CompareFacesMatch[]
+     */
+    private $faceMatches;
+
+    /**
+     * An array of faces in the target image that did not match the source image face.
+     *
+     * @var ComparedFace[]
+     */
+    private $unmatchedFaces;
+
+    /**
+     * The value of `SourceImageOrientationCorrection` is always null.
+     *
+     * If the input image is in .jpeg format, it might contain exchangeable image file format (Exif) metadata that includes
+     * the image's orientation. Amazon Rekognition uses this orientation information to perform image correction. The
+     * bounding box coordinates are translated to represent object locations after the orientation information in the Exif
+     * metadata is used to correct the image orientation. Images in .png format don't contain Exif metadata.
+     *
+     * Amazon Rekognition doesn’t perform image correction for images in .png format and .jpeg images without orientation
+     * information in the image Exif metadata. The bounding box coordinates aren't translated and represent the object
+     * locations before the image is rotated.
+     *
+     * @var OrientationCorrection::*|null
+     */
+    private $sourceImageOrientationCorrection;
+
+    /**
+     * The value of `TargetImageOrientationCorrection` is always null.
+     *
+     * If the input image is in .jpeg format, it might contain exchangeable image file format (Exif) metadata that includes
+     * the image's orientation. Amazon Rekognition uses this orientation information to perform image correction. The
+     * bounding box coordinates are translated to represent object locations after the orientation information in the Exif
+     * metadata is used to correct the image orientation. Images in .png format don't contain Exif metadata.
+     *
+     * Amazon Rekognition doesn’t perform image correction for images in .png format and .jpeg images without orientation
+     * information in the image Exif metadata. The bounding box coordinates aren't translated and represent the object
+     * locations before the image is rotated.
+     *
+     * @var OrientationCorrection::*|null
+     */
+    private $targetImageOrientationCorrection;
+
+    /**
+     * @return CompareFacesMatch[]
+     */
+    public function getFaceMatches(): array
+    {
+        $this->initialize();
+
+        return $this->faceMatches;
+    }
+
+    public function getSourceImageFace(): ?ComparedSourceImageFace
+    {
+        $this->initialize();
+
+        return $this->sourceImageFace;
+    }
+
+    /**
+     * @return OrientationCorrection::*|null
+     */
+    public function getSourceImageOrientationCorrection(): ?string
+    {
+        $this->initialize();
+
+        return $this->sourceImageOrientationCorrection;
+    }
+
+    /**
+     * @return OrientationCorrection::*|null
+     */
+    public function getTargetImageOrientationCorrection(): ?string
+    {
+        $this->initialize();
+
+        return $this->targetImageOrientationCorrection;
+    }
+
+    /**
+     * @return ComparedFace[]
+     */
+    public function getUnmatchedFaces(): array
+    {
+        $this->initialize();
+
+        return $this->unmatchedFaces;
+    }
+
+    protected function populateResult(Response $response): void
+    {
+        $data = $response->toArray();
+
+        $this->sourceImageFace = empty($data['SourceImageFace']) ? null : $this->populateResultComparedSourceImageFace($data['SourceImageFace']);
+        $this->faceMatches = empty($data['FaceMatches']) ? [] : $this->populateResultCompareFacesMatchList($data['FaceMatches']);
+        $this->unmatchedFaces = empty($data['UnmatchedFaces']) ? [] : $this->populateResultCompareFacesUnmatchList($data['UnmatchedFaces']);
+        $this->sourceImageOrientationCorrection = isset($data['SourceImageOrientationCorrection']) ? (!OrientationCorrection::exists((string) $data['SourceImageOrientationCorrection']) ? OrientationCorrection::UNKNOWN_TO_SDK : (string) $data['SourceImageOrientationCorrection']) : null;
+        $this->targetImageOrientationCorrection = isset($data['TargetImageOrientationCorrection']) ? (!OrientationCorrection::exists((string) $data['TargetImageOrientationCorrection']) ? OrientationCorrection::UNKNOWN_TO_SDK : (string) $data['TargetImageOrientationCorrection']) : null;
+    }
+
+    private function populateResultBoundingBox(array $json): BoundingBox
+    {
+        return new BoundingBox([
+            'Width' => isset($json['Width']) ? (float) $json['Width'] : null,
+            'Height' => isset($json['Height']) ? (float) $json['Height'] : null,
+            'Left' => isset($json['Left']) ? (float) $json['Left'] : null,
+            'Top' => isset($json['Top']) ? (float) $json['Top'] : null,
+        ]);
+    }
+
+    private function populateResultCompareFacesMatch(array $json): CompareFacesMatch
+    {
+        return new CompareFacesMatch([
+            'Similarity' => isset($json['Similarity']) ? (float) $json['Similarity'] : null,
+            'Face' => empty($json['Face']) ? null : $this->populateResultComparedFace($json['Face']),
+        ]);
+    }
+
+    /**
+     * @return CompareFacesMatch[]
+     */
+    private function populateResultCompareFacesMatchList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = $this->populateResultCompareFacesMatch($item);
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return ComparedFace[]
+     */
+    private function populateResultCompareFacesUnmatchList(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = $this->populateResultComparedFace($item);
+        }
+
+        return $items;
+    }
+
+    private function populateResultComparedFace(array $json): ComparedFace
+    {
+        return new ComparedFace([
+            'BoundingBox' => empty($json['BoundingBox']) ? null : $this->populateResultBoundingBox($json['BoundingBox']),
+            'Confidence' => isset($json['Confidence']) ? (float) $json['Confidence'] : null,
+            'Landmarks' => !isset($json['Landmarks']) ? null : $this->populateResultLandmarks($json['Landmarks']),
+            'Pose' => empty($json['Pose']) ? null : $this->populateResultPose($json['Pose']),
+            'Quality' => empty($json['Quality']) ? null : $this->populateResultImageQuality($json['Quality']),
+            'Emotions' => !isset($json['Emotions']) ? null : $this->populateResultEmotions($json['Emotions']),
+            'Smile' => empty($json['Smile']) ? null : $this->populateResultSmile($json['Smile']),
+        ]);
+    }
+
+    private function populateResultComparedSourceImageFace(array $json): ComparedSourceImageFace
+    {
+        return new ComparedSourceImageFace([
+            'BoundingBox' => empty($json['BoundingBox']) ? null : $this->populateResultBoundingBox($json['BoundingBox']),
+            'Confidence' => isset($json['Confidence']) ? (float) $json['Confidence'] : null,
+        ]);
+    }
+
+    private function populateResultEmotion(array $json): Emotion
+    {
+        return new Emotion([
+            'Type' => isset($json['Type']) ? (!EmotionName::exists((string) $json['Type']) ? EmotionName::UNKNOWN_TO_SDK : (string) $json['Type']) : null,
+            'Confidence' => isset($json['Confidence']) ? (float) $json['Confidence'] : null,
+        ]);
+    }
+
+    /**
+     * @return Emotion[]
+     */
+    private function populateResultEmotions(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = $this->populateResultEmotion($item);
+        }
+
+        return $items;
+    }
+
+    private function populateResultImageQuality(array $json): ImageQuality
+    {
+        return new ImageQuality([
+            'Brightness' => isset($json['Brightness']) ? (float) $json['Brightness'] : null,
+            'Sharpness' => isset($json['Sharpness']) ? (float) $json['Sharpness'] : null,
+        ]);
+    }
+
+    private function populateResultLandmark(array $json): Landmark
+    {
+        return new Landmark([
+            'Type' => isset($json['Type']) ? (!LandmarkType::exists((string) $json['Type']) ? LandmarkType::UNKNOWN_TO_SDK : (string) $json['Type']) : null,
+            'X' => isset($json['X']) ? (float) $json['X'] : null,
+            'Y' => isset($json['Y']) ? (float) $json['Y'] : null,
+        ]);
+    }
+
+    /**
+     * @return Landmark[]
+     */
+    private function populateResultLandmarks(array $json): array
+    {
+        $items = [];
+        foreach ($json as $item) {
+            $items[] = $this->populateResultLandmark($item);
+        }
+
+        return $items;
+    }
+
+    private function populateResultPose(array $json): Pose
+    {
+        return new Pose([
+            'Roll' => isset($json['Roll']) ? (float) $json['Roll'] : null,
+            'Yaw' => isset($json['Yaw']) ? (float) $json['Yaw'] : null,
+            'Pitch' => isset($json['Pitch']) ? (float) $json['Pitch'] : null,
+        ]);
+    }
+
+    private function populateResultSmile(array $json): Smile
+    {
+        return new Smile([
+            'Value' => isset($json['Value']) ? filter_var($json['Value'], \FILTER_VALIDATE_BOOLEAN) : null,
+            'Confidence' => isset($json['Confidence']) ? (float) $json['Confidence'] : null,
+        ]);
+    }
+}

--- a/src/Service/Rekognition/src/ValueObject/CompareFacesMatch.php
+++ b/src/Service/Rekognition/src/ValueObject/CompareFacesMatch.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace AsyncAws\Rekognition\ValueObject;
+
+/**
+ * Provides information about a face in a target image that matches the source image face analyzed by `CompareFaces`.
+ * The `Face` property contains the bounding box of the face in the target image. The `Similarity` property is the
+ * confidence that the source image face matches the face in the bounding box.
+ */
+final class CompareFacesMatch
+{
+    /**
+     * Level of confidence that the faces match.
+     *
+     * @var float|null
+     */
+    private $similarity;
+
+    /**
+     * Provides face metadata (bounding box and confidence that the bounding box actually contains a face).
+     *
+     * @var ComparedFace|null
+     */
+    private $face;
+
+    /**
+     * @param array{
+     *   Similarity?: float|null,
+     *   Face?: ComparedFace|array|null,
+     * } $input
+     */
+    public function __construct(array $input)
+    {
+        $this->similarity = $input['Similarity'] ?? null;
+        $this->face = isset($input['Face']) ? ComparedFace::create($input['Face']) : null;
+    }
+
+    /**
+     * @param array{
+     *   Similarity?: float|null,
+     *   Face?: ComparedFace|array|null,
+     * }|CompareFacesMatch $input
+     */
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getFace(): ?ComparedFace
+    {
+        return $this->face;
+    }
+
+    public function getSimilarity(): ?float
+    {
+        return $this->similarity;
+    }
+}

--- a/src/Service/Rekognition/src/ValueObject/ComparedSourceImageFace.php
+++ b/src/Service/Rekognition/src/ValueObject/ComparedSourceImageFace.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace AsyncAws\Rekognition\ValueObject;
+
+/**
+ * Type that describes the face Amazon Rekognition chose to compare with the faces in the target. This contains a
+ * bounding box for the selected face and confidence level that the bounding box contains a face. Note that Amazon
+ * Rekognition selects the largest face in the source image for this comparison.
+ */
+final class ComparedSourceImageFace
+{
+    /**
+     * Bounding box of the face.
+     *
+     * @var BoundingBox|null
+     */
+    private $boundingBox;
+
+    /**
+     * Confidence level that the selected bounding box contains a face.
+     *
+     * @var float|null
+     */
+    private $confidence;
+
+    /**
+     * @param array{
+     *   BoundingBox?: BoundingBox|array|null,
+     *   Confidence?: float|null,
+     * } $input
+     */
+    public function __construct(array $input)
+    {
+        $this->boundingBox = isset($input['BoundingBox']) ? BoundingBox::create($input['BoundingBox']) : null;
+        $this->confidence = $input['Confidence'] ?? null;
+    }
+
+    /**
+     * @param array{
+     *   BoundingBox?: BoundingBox|array|null,
+     *   Confidence?: float|null,
+     * }|ComparedSourceImageFace $input
+     */
+    public static function create($input): self
+    {
+        return $input instanceof self ? $input : new self($input);
+    }
+
+    public function getBoundingBox(): ?BoundingBox
+    {
+        return $this->boundingBox;
+    }
+
+    public function getConfidence(): ?float
+    {
+        return $this->confidence;
+    }
+}

--- a/src/Service/Rekognition/tests/Integration/RekognitionClientTest.php
+++ b/src/Service/Rekognition/tests/Integration/RekognitionClientTest.php
@@ -4,6 +4,7 @@ namespace AsyncAws\Rekognition\Tests\Integration;
 
 use AsyncAws\Core\Credentials\NullProvider;
 use AsyncAws\Core\Test\TestCase;
+use AsyncAws\Rekognition\Input\CompareFacesRequest;
 use AsyncAws\Rekognition\Input\CreateCollectionRequest;
 use AsyncAws\Rekognition\Input\CreateProjectRequest;
 use AsyncAws\Rekognition\Input\DeleteCollectionRequest;
@@ -23,6 +24,41 @@ use AsyncAws\Rekognition\ValueObject\S3Object;
 
 class RekognitionClientTest extends TestCase
 {
+    public function testCompareFaces(): void
+    {
+        $client = $this->getClient();
+
+        $input = new CompareFacesRequest([
+            'SourceImage' => new Image([
+                'Bytes' => 'change me',
+                'S3Object' => new S3Object([
+                    'Bucket' => 'change me',
+                    'Name' => 'change me',
+                    'Version' => 'change me',
+                ]),
+            ]),
+            'TargetImage' => new Image([
+                'Bytes' => 'change me',
+                'S3Object' => new S3Object([
+                    'Bucket' => 'change me',
+                    'Name' => 'change me',
+                    'Version' => 'change me',
+                ]),
+            ]),
+            'SimilarityThreshold' => 1337,
+            'QualityFilter' => 'change me',
+        ]);
+        $result = $client->compareFaces($input);
+
+        $result->resolve();
+
+        // self::assertTODO(expected, $result->getSourceImageFace());
+        // self::assertTODO(expected, $result->getFaceMatches());
+        // self::assertTODO(expected, $result->getUnmatchedFaces());
+        self::assertSame('changeIt', $result->getSourceImageOrientationCorrection());
+        self::assertSame('changeIt', $result->getTargetImageOrientationCorrection());
+    }
+
     public function testCreateCollection(): void
     {
         $client = $this->getClient();

--- a/src/Service/Rekognition/tests/Unit/Input/CompareFacesRequestTest.php
+++ b/src/Service/Rekognition/tests/Unit/Input/CompareFacesRequestTest.php
@@ -11,50 +11,54 @@ class CompareFacesRequestTest extends TestCase
 {
     public function testRequest(): void
     {
-        self::fail('Not implemented');
-
         $input = new CompareFacesRequest([
             'SourceImage' => new Image([
-                'Bytes' => 'change me',
+                'Bytes' => 'first-image-bytes',
                 'S3Object' => new S3Object([
-                    'Bucket' => 'change me',
-                    'Name' => 'change me',
-                    'Version' => 'change me',
+                    'Bucket' => 'bucket1',
+                    'Name' => 'my-bucket-1',
+                    'Version' => 'stable',
                 ]),
             ]),
             'TargetImage' => new Image([
-                'Bytes' => 'change me',
+                'Bytes' => 'second-image-bytes',
                 'S3Object' => new S3Object([
-                    'Bucket' => 'change me',
-                    'Name' => 'change me',
-                    'Version' => 'change me',
+                    'Bucket' => 'bucket2',
+                    'Name' => 'my-bucket-2',
+                    'Version' => 'stable',
                 ]),
             ]),
-            'SimilarityThreshold' => 1337,
-            'QualityFilter' => 'change me',
+            'SimilarityThreshold' => 90,
+            'QualityFilter' => 'AUTO',
         ]);
 
         // see example-1.json from SDK
         $expected = '
             POST / HTTP/1.0
             Content-Type: application/x-amz-json-1.1
+            X-Amz-Target: RekognitionService.CompareFaces
+            Accept: application/json
 
             {
-            "SimilarityThreshold": 90,
-            "SourceImage": {
-                "S3Object": {
-                    "Bucket": "mybucket",
-                    "Name": "mysourceimage"
+                "QualityFilter": "AUTO",
+                "SimilarityThreshold": 90,
+                "SourceImage": {
+                    "Bytes": "Zmlyc3QtaW1hZ2UtYnl0ZXM=",
+                    "S3Object": {
+                        "Bucket": "bucket1",
+                        "Name": "my-bucket-1",
+                        "Version": "stable"
+                    }
+                },
+                "TargetImage": {
+                    "Bytes": "c2Vjb25kLWltYWdlLWJ5dGVz",
+                    "S3Object": {
+                        "Bucket": "bucket2",
+                        "Name": "my-bucket-2",
+                        "Version": "stable"
+                    }
                 }
-            },
-            "TargetImage": {
-                "S3Object": {
-                    "Bucket": "mybucket",
-                    "Name": "mytargetimage"
-                }
-            }
-        }
-                ';
+            }';
 
         self::assertRequestEqualsHttpRequest($expected, $input->request());
     }

--- a/src/Service/Rekognition/tests/Unit/Input/CompareFacesRequestTest.php
+++ b/src/Service/Rekognition/tests/Unit/Input/CompareFacesRequestTest.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace AsyncAws\Rekognition\Tests\Unit\Input;
+
+use AsyncAws\Core\Test\TestCase;
+use AsyncAws\Rekognition\Input\CompareFacesRequest;
+use AsyncAws\Rekognition\ValueObject\Image;
+use AsyncAws\Rekognition\ValueObject\S3Object;
+
+class CompareFacesRequestTest extends TestCase
+{
+    public function testRequest(): void
+    {
+        self::fail('Not implemented');
+
+        $input = new CompareFacesRequest([
+            'SourceImage' => new Image([
+                'Bytes' => 'change me',
+                'S3Object' => new S3Object([
+                    'Bucket' => 'change me',
+                    'Name' => 'change me',
+                    'Version' => 'change me',
+                ]),
+            ]),
+            'TargetImage' => new Image([
+                'Bytes' => 'change me',
+                'S3Object' => new S3Object([
+                    'Bucket' => 'change me',
+                    'Name' => 'change me',
+                    'Version' => 'change me',
+                ]),
+            ]),
+            'SimilarityThreshold' => 1337,
+            'QualityFilter' => 'change me',
+        ]);
+
+        // see example-1.json from SDK
+        $expected = '
+            POST / HTTP/1.0
+            Content-Type: application/x-amz-json-1.1
+
+            {
+            "SimilarityThreshold": 90,
+            "SourceImage": {
+                "S3Object": {
+                    "Bucket": "mybucket",
+                    "Name": "mysourceimage"
+                }
+            },
+            "TargetImage": {
+                "S3Object": {
+                    "Bucket": "mybucket",
+                    "Name": "mytargetimage"
+                }
+            }
+        }
+                ';
+
+        self::assertRequestEqualsHttpRequest($expected, $input->request());
+    }
+}

--- a/src/Service/Rekognition/tests/Unit/RekognitionClientTest.php
+++ b/src/Service/Rekognition/tests/Unit/RekognitionClientTest.php
@@ -4,6 +4,7 @@ namespace AsyncAws\Rekognition\Tests\Unit;
 
 use AsyncAws\Core\Credentials\NullProvider;
 use AsyncAws\Core\Test\TestCase;
+use AsyncAws\Rekognition\Input\CompareFacesRequest;
 use AsyncAws\Rekognition\Input\CreateCollectionRequest;
 use AsyncAws\Rekognition\Input\CreateProjectRequest;
 use AsyncAws\Rekognition\Input\DeleteCollectionRequest;
@@ -16,6 +17,7 @@ use AsyncAws\Rekognition\Input\ListCollectionsRequest;
 use AsyncAws\Rekognition\Input\RecognizeCelebritiesRequest;
 use AsyncAws\Rekognition\Input\SearchFacesByImageRequest;
 use AsyncAws\Rekognition\RekognitionClient;
+use AsyncAws\Rekognition\Result\CompareFacesResponse;
 use AsyncAws\Rekognition\Result\CreateCollectionResponse;
 use AsyncAws\Rekognition\Result\CreateProjectResponse;
 use AsyncAws\Rekognition\Result\DeleteCollectionResponse;
@@ -32,6 +34,22 @@ use Symfony\Component\HttpClient\MockHttpClient;
 
 class RekognitionClientTest extends TestCase
 {
+    public function testCompareFaces(): void
+    {
+        $client = new RekognitionClient([], new NullProvider(), new MockHttpClient());
+
+        $input = new CompareFacesRequest([
+            'SourceImage' => new Image([
+            ]),
+            'TargetImage' => new Image([
+            ]),
+        ]);
+        $result = $client->compareFaces($input);
+
+        self::assertInstanceOf(CompareFacesResponse::class, $result);
+        self::assertFalse($result->info()['resolved']);
+    }
+
     public function testCreateCollection(): void
     {
         $client = new RekognitionClient([], new NullProvider(), new MockHttpClient());

--- a/src/Service/Rekognition/tests/Unit/Result/CompareFacesResponseTest.php
+++ b/src/Service/Rekognition/tests/Unit/Result/CompareFacesResponseTest.php
@@ -13,8 +13,6 @@ class CompareFacesResponseTest extends TestCase
 {
     public function testCompareFacesResponse(): void
     {
-        self::fail('Not implemented');
-
         // see example-1.json from SDK
         $response = new SimpleMockedResponse('{
             "FaceMatches": [
@@ -45,10 +43,13 @@ class CompareFacesResponseTest extends TestCase
         $client = new MockHttpClient($response);
         $result = new CompareFacesResponse(new Response($client->request('POST', 'http://localhost'), $client, new NullLogger()));
 
-        // self::assertTODO(expected, $result->getSourceImageFace());
-        // self::assertTODO(expected, $result->getFaceMatches());
-        // self::assertTODO(expected, $result->getUnmatchedFaces());
-        self::assertSame('changeIt', $result->getSourceImageOrientationCorrection());
-        self::assertSame('changeIt', $result->getTargetImageOrientationCorrection());
+        self::assertSame(99.9991226196289, $result->getSourceImageFace()->getConfidence());
+        self::assertSame(0.33481481671333313, $result->getSourceImageFace()->getBoundingBox()->getHeight());
+        self::assertCount(1, $result->getFaceMatches());
+        self::assertSame(100.0, $result->getFaceMatches()[0]->getSimilarity());
+        self::assertSame(99.9991226196289, $result->getFaceMatches()[0]->getFace()->getConfidence());
+        self::assertCount(0, $result->getUnmatchedFaces());
+        self::assertNull($result->getSourceImageOrientationCorrection());
+        self::assertNull($result->getTargetImageOrientationCorrection());
     }
 }

--- a/src/Service/Rekognition/tests/Unit/Result/CompareFacesResponseTest.php
+++ b/src/Service/Rekognition/tests/Unit/Result/CompareFacesResponseTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace AsyncAws\Rekognition\Tests\Unit\Result;
+
+use AsyncAws\Core\Response;
+use AsyncAws\Core\Test\Http\SimpleMockedResponse;
+use AsyncAws\Core\Test\TestCase;
+use AsyncAws\Rekognition\Result\CompareFacesResponse;
+use Psr\Log\NullLogger;
+use Symfony\Component\HttpClient\MockHttpClient;
+
+class CompareFacesResponseTest extends TestCase
+{
+    public function testCompareFacesResponse(): void
+    {
+        self::fail('Not implemented');
+
+        // see example-1.json from SDK
+        $response = new SimpleMockedResponse('{
+            "FaceMatches": [
+                {
+                    "Face": {
+                        "BoundingBox": {
+                            "Height": 0.33481481671333313,
+                            "Left": 0.31888890266418457,
+                            "Top": 0.4933333396911621,
+                            "Width": 0.25
+                        },
+                        "Confidence": 99.9991226196289
+                    },
+                    "Similarity": 100
+                }
+            ],
+            "SourceImageFace": {
+                "BoundingBox": {
+                    "Height": 0.33481481671333313,
+                    "Left": 0.31888890266418457,
+                    "Top": 0.4933333396911621,
+                    "Width": 0.25
+                },
+                "Confidence": 99.9991226196289
+            }
+        }');
+
+        $client = new MockHttpClient($response);
+        $result = new CompareFacesResponse(new Response($client->request('POST', 'http://localhost'), $client, new NullLogger()));
+
+        // self::assertTODO(expected, $result->getSourceImageFace());
+        // self::assertTODO(expected, $result->getFaceMatches());
+        // self::assertTODO(expected, $result->getUnmatchedFaces());
+        self::assertSame('changeIt', $result->getSourceImageOrientationCorrection());
+        self::assertSame('changeIt', $result->getTargetImageOrientationCorrection());
+    }
+}


### PR DESCRIPTION
Hi there! I added the `CompareFaces` method to the Rekognition client.

I followed the steps mentioned on [this](https://async-aws.com/contribute/generate.html#creating-a-new-client-operation) page. I only ran the generate command, which was enough for the call to work, and tested the code locally inside an already existing project. Worked like a charm out-of-the-box.

This is the fist time I'm contributing something to a Github repo, so please let me know if I'm missing some things in my PR.

