### PR TITLE
Add conditional multipart uploads to SimpleS3

### DIFF
--- a/src/Integration/Aws/SimpleS3/CHANGELOG.md
+++ b/src/Integration/Aws/SimpleS3/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## NOT RELEASED
 
+### Added
+
+- Add `IfMatch` and `IfNoneMatch` support to multipart uploads.
+
 ## 3.0.2
 
 ### Changed

--- a/src/Integration/Aws/SimpleS3/composer.json
+++ b/src/Integration/Aws/SimpleS3/composer.json
@@ -31,7 +31,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0-dev"
+            "dev-master": "3.1-dev"
         }
     }
 }

--- a/src/Integration/Aws/SimpleS3/src/SimpleS3Client.php
+++ b/src/Integration/Aws/SimpleS3/src/SimpleS3Client.php
@@ -98,11 +98,13 @@ class SimpleS3Client extends S3Client
         }
 
         $completeMultipartUploadOptions = [];
-        foreach (['IfMatch', 'IfNoneMatch'] as $option) {
-            if (\array_key_exists($option, $options)) {
-                $completeMultipartUploadOptions[$option] = $options[$option];
-                unset($options[$option]);
-            }
+        if (\array_key_exists('IfMatch', $options)) {
+            $completeMultipartUploadOptions['IfMatch'] = $options['IfMatch'];
+            unset($options['IfMatch']);
+        }
+        if (\array_key_exists('IfNoneMatch', $options)) {
+            $completeMultipartUploadOptions['IfNoneMatch'] = $options['IfNoneMatch'];
+            unset($options['IfNoneMatch']);
         }
 
         $parts = [];

--- a/src/Integration/Aws/SimpleS3/src/SimpleS3Client.php
+++ b/src/Integration/Aws/SimpleS3/src/SimpleS3Client.php
@@ -63,8 +63,8 @@ class SimpleS3Client extends S3Client
      *   CacheControl?: string,
      *   ContentLength?: int,
      *   ContentType?: string,
-     *   IfMatch?: string,
-     *   IfNoneMatch?: string,
+     *   IfMatch?: string|null,
+     *   IfNoneMatch?: string|null,
      *   Metadata?: array<string, string>,
      *   PartSize?: int,
      * } $options
@@ -98,14 +98,13 @@ class SimpleS3Client extends S3Client
         }
 
         $completeMultipartUploadOptions = [];
-        if (\array_key_exists('IfMatch', $options)) {
+        if (isset($options['IfMatch'])) {
             $completeMultipartUploadOptions['IfMatch'] = $options['IfMatch'];
-            unset($options['IfMatch']);
         }
-        if (\array_key_exists('IfNoneMatch', $options)) {
+        if (isset($options['IfNoneMatch'])) {
             $completeMultipartUploadOptions['IfNoneMatch'] = $options['IfNoneMatch'];
-            unset($options['IfNoneMatch']);
         }
+        unset($options['IfMatch'], $options['IfNoneMatch']);
 
         $parts = [];
         $uploadId = '';
@@ -164,26 +163,12 @@ class SimpleS3Client extends S3Client
             return;
         }
 
-        try {
-            $this->completeMultipartUpload(array_merge($completeMultipartUploadOptions, [
-                'Bucket' => $bucket,
-                'Key' => $key,
-                'UploadId' => $uploadId,
-                'MultipartUpload' => new CompletedMultipartUpload(['Parts' => $parts]),
-            ]));
-        } catch (\Throwable $e) {
-            try {
-                $this->abortMultipartUpload([
-                    'Bucket' => $bucket,
-                    'Key' => $key,
-                    'UploadId' => $uploadId,
-                ]);
-            } catch (\Throwable) {
-                // Preserve the completion failure.
-            }
-
-            throw $e;
-        }
+        $this->completeMultipartUpload(array_merge($completeMultipartUploadOptions, [
+            'Bucket' => $bucket,
+            'Key' => $key,
+            'UploadId' => $uploadId,
+            'MultipartUpload' => new CompletedMultipartUpload(['Parts' => $parts]),
+        ]));
     }
 
     /**
@@ -225,8 +210,8 @@ class SimpleS3Client extends S3Client
      *   CacheControl?: string,
      *   ContentLength?: int,
      *   ContentType?: string,
-     *   IfMatch?: string,
-     *   IfNoneMatch?: string,
+     *   IfMatch?: string|null,
+     *   IfNoneMatch?: string|null,
      *   Metadata?: array<string, string>,
      * } $options
      * @param string|resource|(callable(int): string)|iterable<string> $object

--- a/src/Integration/Aws/SimpleS3/src/SimpleS3Client.php
+++ b/src/Integration/Aws/SimpleS3/src/SimpleS3Client.php
@@ -146,7 +146,7 @@ class SimpleS3Client extends S3Client
                  *
                  * Lets use a normal upload.
                  */
-                $this->doSmallFileUpload($options, $bucket, $key, $buffer);
+                $this->doSmallFileUpload(array_merge($options, $completeMultipartUploadOptions), $bucket, $key, $buffer);
 
                 return;
             }
@@ -157,7 +157,7 @@ class SimpleS3Client extends S3Client
 
         if (empty($parts)) {
             // The upload did not contain any data. Let's create an empty file
-            $this->doSmallFileUpload($options, $bucket, $key, '');
+            $this->doSmallFileUpload(array_merge($options, $completeMultipartUploadOptions), $bucket, $key, '');
 
             return;
         }

--- a/src/Integration/Aws/SimpleS3/src/SimpleS3Client.php
+++ b/src/Integration/Aws/SimpleS3/src/SimpleS3Client.php
@@ -63,6 +63,8 @@ class SimpleS3Client extends S3Client
      *   CacheControl?: string,
      *   ContentLength?: int,
      *   ContentType?: string,
+     *   IfMatch?: string,
+     *   IfNoneMatch?: string,
      *   Metadata?: array<string, string>,
      *   PartSize?: int,
      * } $options
@@ -93,6 +95,14 @@ class SimpleS3Client extends S3Client
             $this->doSmallFileUpload($options, $bucket, $key, $object);
 
             return;
+        }
+
+        $completeMultipartUploadOptions = [];
+        foreach (['IfMatch', 'IfNoneMatch'] as $option) {
+            if (\array_key_exists($option, $options)) {
+                $completeMultipartUploadOptions[$option] = $options[$option];
+                unset($options[$option]);
+            }
         }
 
         $parts = [];
@@ -152,12 +162,12 @@ class SimpleS3Client extends S3Client
             return;
         }
 
-        $this->completeMultipartUpload([
+        $this->completeMultipartUpload(array_merge($completeMultipartUploadOptions, [
             'Bucket' => $bucket,
             'Key' => $key,
             'UploadId' => $uploadId,
             'MultipartUpload' => new CompletedMultipartUpload(['Parts' => $parts]),
-        ]);
+        ]));
     }
 
     /**
@@ -199,6 +209,8 @@ class SimpleS3Client extends S3Client
      *   CacheControl?: string,
      *   ContentLength?: int,
      *   ContentType?: string,
+     *   IfMatch?: string,
+     *   IfNoneMatch?: string,
      *   Metadata?: array<string, string>,
      * } $options
      * @param string|resource|(callable(int): string)|iterable<string> $object

--- a/src/Integration/Aws/SimpleS3/src/SimpleS3Client.php
+++ b/src/Integration/Aws/SimpleS3/src/SimpleS3Client.php
@@ -162,12 +162,26 @@ class SimpleS3Client extends S3Client
             return;
         }
 
-        $this->completeMultipartUpload(array_merge($completeMultipartUploadOptions, [
-            'Bucket' => $bucket,
-            'Key' => $key,
-            'UploadId' => $uploadId,
-            'MultipartUpload' => new CompletedMultipartUpload(['Parts' => $parts]),
-        ]));
+        try {
+            $this->completeMultipartUpload(array_merge($completeMultipartUploadOptions, [
+                'Bucket' => $bucket,
+                'Key' => $key,
+                'UploadId' => $uploadId,
+                'MultipartUpload' => new CompletedMultipartUpload(['Parts' => $parts]),
+            ]));
+        } catch (\Throwable $e) {
+            try {
+                $this->abortMultipartUpload([
+                    'Bucket' => $bucket,
+                    'Key' => $key,
+                    'UploadId' => $uploadId,
+                ]);
+            } catch (\Throwable) {
+                // Preserve the completion failure.
+            }
+
+            throw $e;
+        }
     }
 
     /**

--- a/src/Integration/Aws/SimpleS3/tests/Unit/SimpleS3ClientTest.php
+++ b/src/Integration/Aws/SimpleS3/tests/Unit/SimpleS3ClientTest.php
@@ -137,6 +137,53 @@ class SimpleS3ClientTest extends TestCase
         ]);
     }
 
+    public function testMultipartUploadIsAbortedWhenCompletionFails(): void
+    {
+        $object = fopen('php://temp', 'rw+');
+        fwrite($object, str_repeat('a', 2 * 1024 * 1024));
+        $failure = new \RuntimeException('Conditional request failed.');
+
+        $s3 = $this->getMockBuilder(SimpleS3Client::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['createMultipartUpload', 'abortMultipartUpload', 'putObject', 'completeMultipartUpload', 'uploadPart'])
+            ->getMock();
+
+        $s3->expects(self::never())->method('putObject');
+        $s3->expects(self::once())
+            ->method('createMultipartUpload')
+            ->willReturnCallback(static function (): CreateMultipartUploadOutput {
+                $upload = self::createStub(CreateMultipartUploadOutput::class);
+                $upload->method('getUploadId')->willReturn('failed-upload-id');
+
+                return $upload;
+            });
+        $s3->expects(self::exactly(2))
+            ->method('uploadPart')
+            ->willReturnCallback(static function (array $part): UploadPartOutput {
+                $output = self::createStub(UploadPartOutput::class);
+                $output->method('getETag')->willReturn("etag-{$part['PartNumber']}");
+
+                return $output;
+            });
+        $s3->expects(self::once())
+            ->method('completeMultipartUpload')
+            ->willThrowException($failure);
+        $s3->expects(self::once())
+            ->method('abortMultipartUpload')
+            ->with([
+                'Bucket' => 'bucket',
+                'Key' => 'conditional.txt',
+                'UploadId' => 'failed-upload-id',
+            ]);
+
+        $this->expectExceptionObject($failure);
+
+        $s3->upload('bucket', 'conditional.txt', $object, [
+            'PartSize' => 1,
+            'IfNoneMatch' => '*',
+        ]);
+    }
+
     #[DataProvider('providePartSizes')]
     public function testUploadIsSmallerThanPartSize(int $partSize)
     {

--- a/src/Integration/Aws/SimpleS3/tests/Unit/SimpleS3ClientTest.php
+++ b/src/Integration/Aws/SimpleS3/tests/Unit/SimpleS3ClientTest.php
@@ -184,6 +184,50 @@ class SimpleS3ClientTest extends TestCase
         ]);
     }
 
+    #[DataProvider('provideConditionalWriteOptions')]
+    public function testUnknownLengthSmallUploadForwardsConditionalWriteOption(string $option, string $value): void
+    {
+        $resource = fopen('php://temp', 'rw+');
+        fwrite($resource, 'contents');
+        fseek($resource, 0, \SEEK_SET);
+
+        $callback = static function (array $input) use ($option, $value): bool {
+            self::assertSame($value, $input[$option]);
+
+            return true;
+        };
+
+        $this->assertSmallFileUpload(
+            $callback,
+            'bucket',
+            'conditional.txt',
+            static function (int $length) use ($resource): string {
+                return fread($resource, $length);
+            },
+            ['PartSize' => 2, $option => $value]
+        );
+    }
+
+    #[DataProvider('provideConditionalWriteOptions')]
+    public function testUnknownLengthEmptyUploadForwardsConditionalWriteOption(string $option, string $value): void
+    {
+        $callback = static function (array $input) use ($option, $value): bool {
+            self::assertSame($value, $input[$option]);
+
+            return true;
+        };
+
+        $this->assertSmallFileUpload(
+            $callback,
+            'bucket',
+            'conditional.txt',
+            static function (int $length): string {
+                return '';
+            },
+            ['PartSize' => 2, $option => $value]
+        );
+    }
+
     #[DataProvider('providePartSizes')]
     public function testUploadIsSmallerThanPartSize(int $partSize)
     {

--- a/src/Integration/Aws/SimpleS3/tests/Unit/SimpleS3ClientTest.php
+++ b/src/Integration/Aws/SimpleS3/tests/Unit/SimpleS3ClientTest.php
@@ -137,7 +137,7 @@ class SimpleS3ClientTest extends TestCase
         ]);
     }
 
-    public function testMultipartUploadIsAbortedWhenCompletionFails(): void
+    public function testMultipartUploadIsNotAbortedWhenCompletionFails(): void
     {
         $object = fopen('php://temp', 'rw+');
         fwrite($object, str_repeat('a', 2 * 1024 * 1024));
@@ -168,13 +168,7 @@ class SimpleS3ClientTest extends TestCase
         $s3->expects(self::once())
             ->method('completeMultipartUpload')
             ->willThrowException($failure);
-        $s3->expects(self::once())
-            ->method('abortMultipartUpload')
-            ->with([
-                'Bucket' => 'bucket',
-                'Key' => 'conditional.txt',
-                'UploadId' => 'failed-upload-id',
-            ]);
+        $s3->expects(self::never())->method('abortMultipartUpload');
 
         $this->expectExceptionObject($failure);
 
@@ -182,6 +176,59 @@ class SimpleS3ClientTest extends TestCase
             'PartSize' => 1,
             'IfNoneMatch' => '*',
         ]);
+    }
+
+    #[DataProvider('provideConditionalWriteOptionNames')]
+    public function testMultipartUploadIgnoresNullConditionalWriteOption(string $option): void
+    {
+        $object = fopen('php://temp', 'rw+');
+        fwrite($object, str_repeat('a', 2 * 1024 * 1024));
+
+        $s3 = $this->getMockBuilder(SimpleS3Client::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['createMultipartUpload', 'completeMultipartUpload', 'uploadPart'])
+            ->getMock();
+
+        $s3->expects(self::once())
+            ->method('createMultipartUpload')
+            ->with(self::callback(static function (array $input) use ($option): bool {
+                self::assertArrayNotHasKey($option, $input);
+
+                return true;
+            }))
+            ->willReturnCallback(static function (): CreateMultipartUploadOutput {
+                $upload = self::createStub(CreateMultipartUploadOutput::class);
+                $upload->method('getUploadId')->willReturn('null-condition-upload-id');
+
+                return $upload;
+            });
+        $s3->expects(self::exactly(2))
+            ->method('uploadPart')
+            ->willReturnCallback(static function (array $part): UploadPartOutput {
+                $output = self::createStub(UploadPartOutput::class);
+                $output->method('getETag')->willReturn("etag-{$part['PartNumber']}");
+
+                return $output;
+            });
+        $s3->expects(self::once())
+            ->method('completeMultipartUpload')
+            ->with(self::callback(static function (array $input) use ($option): bool {
+                self::assertArrayNotHasKey($option, $input);
+
+                return true;
+            }))
+            ->willReturn(self::createStub(CompleteMultipartUploadOutput::class));
+
+        $s3->upload('bucket', 'conditional.txt', $object, [
+            'PartSize' => 1,
+            $option => null,
+        ]);
+    }
+
+    public static function provideConditionalWriteOptionNames(): iterable
+    {
+        yield 'If-Match' => ['IfMatch'];
+        yield 'If-None-Match' => ['IfNoneMatch'];
     }
 
     #[DataProvider('provideConditionalWriteOptions')]

--- a/src/Integration/Aws/SimpleS3/tests/Unit/SimpleS3ClientTest.php
+++ b/src/Integration/Aws/SimpleS3/tests/Unit/SimpleS3ClientTest.php
@@ -54,6 +54,89 @@ class SimpleS3ClientTest extends TestCase
         $this->assertSmallFileUpload($callback, $bucket, $file, $object);
     }
 
+    #[DataProvider('provideConditionalWriteOptions')]
+    public function testUploadSmallFileForwardsConditionalWriteOption(string $option, string $value): void
+    {
+        $callback = static function (array $input) use ($option, $value): bool {
+            self::assertSame($value, $input[$option]);
+
+            return true;
+        };
+
+        $this->assertSmallFileUpload(
+            $callback,
+            'bucket',
+            'conditional.txt',
+            'contents',
+            [$option => $value]
+        );
+    }
+
+    public static function provideConditionalWriteOptions(): iterable
+    {
+        yield 'If-Match' => ['IfMatch', '"expected-etag"'];
+        yield 'If-None-Match' => ['IfNoneMatch', '*'];
+    }
+
+    #[DataProvider('provideConditionalWriteOptions')]
+    public function testMultipartUploadAppliesConditionalWriteOptionOnlyOnCompletion(string $option, string $value): void
+    {
+        $bucket = 'bucket';
+        $file = 'conditional.txt';
+        $object = fopen('php://temp', 'rw+');
+        fwrite($object, str_repeat('a', 2 * 1024 * 1024));
+
+        $s3 = $this->getMockBuilder(SimpleS3Client::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['createMultipartUpload', 'abortMultipartUpload', 'putObject', 'completeMultipartUpload', 'uploadPart'])
+            ->getMock();
+
+        $s3->expects(self::never())->method('abortMultipartUpload');
+        $s3->expects(self::never())->method('putObject');
+        $s3->expects(self::once())
+            ->method('createMultipartUpload')
+            ->with(self::callback(static function (array $input) use ($bucket, $file, $option): bool {
+                self::assertSame($bucket, $input['Bucket']);
+                self::assertSame($file, $input['Key']);
+                self::assertSame(['purpose' => 'conditional-write'], $input['Metadata']);
+                self::assertArrayNotHasKey($option, $input);
+
+                return true;
+            }))
+            ->willReturnCallback(static function (): CreateMultipartUploadOutput {
+                $upload = self::createStub(CreateMultipartUploadOutput::class);
+                $upload->method('getUploadId')->willReturn('conditional-upload-id');
+
+                return $upload;
+            });
+        $s3->expects(self::exactly(2))
+            ->method('uploadPart')
+            ->willReturnCallback(static function (array $part) use ($option): UploadPartOutput {
+                self::assertArrayNotHasKey($option, $part);
+
+                $output = self::createStub(UploadPartOutput::class);
+                $output->method('getETag')->willReturn("etag-{$part['PartNumber']}");
+
+                return $output;
+            });
+        $s3->expects(self::once())
+            ->method('completeMultipartUpload')
+            ->with(self::callback(static function (array $input) use ($option, $value): bool {
+                self::assertSame($value, $input[$option]);
+                self::assertSame('conditional-upload-id', $input['UploadId']);
+                self::assertCount(2, $input['MultipartUpload']->getParts());
+
+                return true;
+            }))
+            ->willReturn(self::createStub(CompleteMultipartUploadOutput::class));
+
+        $s3->upload($bucket, $file, $object, [
+            'PartSize' => 1,
+            'Metadata' => ['purpose' => 'conditional-write'],
+            $option => $value,
+        ]);
+    }
+
     #[DataProvider('providePartSizes')]
     public function testUploadIsSmallerThanPartSize(int $partSize)
     {


### PR DESCRIPTION
`SimpleS3Client::upload()` already forwards `IfMatch` and `IfNoneMatch` for small objects written with `PutObject`, but these conditions are lost when the upload switches to multipart. This can cause a caller expecting a conditional write to overwrite an object unconditionally.

This change keeps conditional options off multipart initiation and part requests, then applies them to `CompleteMultipartUpload`, where S3 evaluates the write condition. It also preserves conditions when an unknown-length stream falls back to `PutObject` and ignores null-valued conditional options.